### PR TITLE
Bugfix jmeter maven reactor

### DIFF
--- a/tests/jmeter-test/src/test/java/com/quorum/tessera/jmeter/PlaceHolder.java
+++ b/tests/jmeter-test/src/test/java/com/quorum/tessera/jmeter/PlaceHolder.java
@@ -1,13 +1,8 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.quorum.tessera.jmeter;
 
 /**
  *
- * @author mark
+ *Place holder file so the jmeter module is included in maven reactor. 
  */
 public class PlaceHolder {
     

--- a/tests/jmeter-test/src/test/java/com/quorum/tessera/jmeter/PlaceHolder.java
+++ b/tests/jmeter-test/src/test/java/com/quorum/tessera/jmeter/PlaceHolder.java
@@ -1,0 +1,14 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.quorum.tessera.jmeter;
+
+/**
+ *
+ * @author mark
+ */
+public class PlaceHolder {
+    
+}


### PR DESCRIPTION
Add placeholder java class in jmeter module as a quick solution to the problem with the module not being included in the maven reactor.