### PR TITLE
Move password reading

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/ObjectFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/ObjectFactory.java
@@ -10,10 +10,6 @@ public class ObjectFactory {
 
     private static final QName QNAME = new QName("http://tessera.github.com/config", "configuration");
 
-    public ObjectFactory() {
-    }
-
-
     @XmlElementDecl(namespace = "http://tessera.github.com/config", name = "configuration")
     public JAXBElement<Config> createConfiguration(Config value) {
         return new JAXBElement<>(QNAME, Config.class, null, value);

--- a/config/src/main/java/com/quorum/tessera/config/keys/KeyGeneratorImpl.java
+++ b/config/src/main/java/com/quorum/tessera/config/keys/KeyGeneratorImpl.java
@@ -1,15 +1,14 @@
 package com.quorum.tessera.config.keys;
 
 import com.quorum.tessera.config.*;
-import com.quorum.tessera.io.IOCallback;
 import com.quorum.tessera.config.util.JaxbUtil;
 import com.quorum.tessera.config.util.PasswordReader;
+import com.quorum.tessera.io.IOCallback;
 import com.quorum.tessera.nacl.KeyPair;
 import com.quorum.tessera.nacl.NaclFacade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -42,7 +41,7 @@ public class KeyGeneratorImpl implements KeyGenerator {
     @Override
     public KeyData generate(final String filename, final ArgonOptions encryptionOptions) {
 
-        final String password = this.getPassword();
+        final String password = this.passwordReader.requestUserPassword();
 
         final KeyPair generated = this.nacl.generateNewKeys();
 
@@ -122,8 +121,6 @@ public class KeyGeneratorImpl implements KeyGenerator {
 
     private String privateKeyToJson(final KeyData keyData) {
 
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
         final KeyDataConfig privateKey;
 
         if (LOCKED.equals(keyData.getConfig().getType())) {
@@ -144,29 +141,7 @@ public class KeyGeneratorImpl implements KeyGenerator {
             privateKey = keyData.getConfig();
         }
 
-        JaxbUtil.marshal(privateKey, outputStream);
-
-        return new String(outputStream.toByteArray());
-
-    }
-
-    private String getPassword() {
-
-        for(;;) {
-
-            System.out.println("Enter a password if you want to lock the private key or leave blank");
-            final String password = this.passwordReader.readPassword();
-
-            System.out.println("Please re-enter the password (or lack of) to confirm");
-            final String passwordCheck = this.passwordReader.readPassword();
-
-            if(Objects.equals(password, passwordCheck)) {
-                return password;
-            } else {
-                System.out.println("Passwords did not match, try again...");
-            }
-
-        }
+        return JaxbUtil.marshalToString(privateKey);
 
     }
 

--- a/config/src/main/java/com/quorum/tessera/config/util/PasswordReader.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/PasswordReader.java
@@ -2,6 +2,7 @@ package com.quorum.tessera.config.util;
 
 import java.io.Console;
 import java.io.InputStream;
+import java.util.Objects;
 import java.util.Scanner;
 
 /**
@@ -23,13 +24,38 @@ public class PasswordReader {
      * Read a password from either system console or the given stream
      * @return the read password, which may be empty if no password is given
      */
-    public String readPassword() {
+    public String readPasswordFromConsole() {
         if(this.console == null) {
             return this.systemIn.nextLine();
         }
 
         final char[] consolePassword = this.console.readPassword();
         return new String(consolePassword);
+    }
+
+    /**
+     * Requests user input for a password until two matching consecutive entries are made
+     *
+     * @return The password that the user has input
+     */
+    public String requestUserPassword() {
+
+        for(;;) {
+
+            System.out.println("Enter a password if you want to lock the private key or leave blank");
+            final String password = this.readPasswordFromConsole();
+
+            System.out.println("Please re-enter the password (or lack of) to confirm");
+            final String passwordCheck = this.readPasswordFromConsole();
+
+            if(Objects.equals(password, passwordCheck)) {
+                return password;
+            } else {
+                System.out.println("Passwords did not match, try again...");
+            }
+
+        }
+
     }
 
 }

--- a/config/src/test/java/com/quorum/tessera/config/util/PasswordReaderTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/util/PasswordReaderTest.java
@@ -13,9 +13,29 @@ public class PasswordReaderTest {
 
         final PasswordReader passwordReader = new PasswordReader(null, new ByteArrayInputStream("TEST".getBytes()));
 
-        final String readValue = passwordReader.readPassword();
+        final String readValue = passwordReader.readPasswordFromConsole();
 
         assertThat(readValue).isEqualTo("TEST");
+
+    }
+
+    @Test
+    public void passwordsNotMatchingCausesRetry() {
+
+        final byte[] systemInBytes = (
+            "TRY1" + System.lineSeparator() +
+            "TRY2" + System.lineSeparator() +
+            "TRY3" + System.lineSeparator() +
+            "TRY3" + System.lineSeparator()
+        ).getBytes();
+
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(systemInBytes);
+
+        final PasswordReader passwordReader = new PasswordReader(null, byteArrayInputStream);
+
+        final String password = passwordReader.requestUserPassword();
+
+        assertThat(password).isEqualTo("TRY3");
 
     }
 


### PR DESCRIPTION
Part of refactoring in preparation for https://github.com/jpmorganchase/tessera/issues/447

Move the user request for a password to the same class that the password is read from. 
This decouples the password reading from the key generation process.