### PR TITLE
Allow private key password change

### DIFF
--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/CliAdapter.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/CliAdapter.java
@@ -1,12 +1,11 @@
-
 package com.quorum.tessera.config.cli;
 
 public interface CliAdapter {
 
     CliResult execute(String... args) throws Exception;
 
-     static CliAdapter create() {
-         return new DefaultCliAdapter();
-     }
-     
+    static CliAdapter create() {
+        return new DefaultCliAdapter();
+    }
+
 }

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/CliDelegate.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/CliDelegate.java
@@ -2,7 +2,6 @@ package com.quorum.tessera.config.cli;
 
 import com.quorum.tessera.config.Config;
 
-
 public enum CliDelegate {
 
     INSTANCE;
@@ -18,13 +17,13 @@ public enum CliDelegate {
     }
 
     public CliResult execute(String... args) throws Exception {
-        
-        CliAdapter cliAdapter = CliAdapter.create();
 
-        CliResult result = cliAdapter.execute(args);
+        final CliAdapter cliAdapter = CliAdapter.create();
+
+        final CliResult result = cliAdapter.execute(args);
+
         this.config = result.getConfig().orElse(null);
         return result;
     }
-
 
 }

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/CliException.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/CliException.java
@@ -1,4 +1,3 @@
-
 package com.quorum.tessera.config.cli;
 
 public class CliException extends RuntimeException {

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/CliResult.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/CliResult.java
@@ -1,10 +1,9 @@
-
 package com.quorum.tessera.config.cli;
 
 import com.quorum.tessera.config.Config;
+
 import java.util.Objects;
 import java.util.Optional;
-
 
 public class CliResult {
     

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/ConfigurationParser.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/ConfigurationParser.java
@@ -1,0 +1,72 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ConfigFactory;
+import com.quorum.tessera.config.KeyData;
+import com.quorum.tessera.config.util.JaxbUtil;
+import org.apache.commons.cli.CommandLine;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+
+public class ConfigurationParser implements Parser<Config> {
+
+    private List<KeyData> newlyGeneratedKeys = Collections.emptyList();
+
+    public ConfigurationParser withNewKeys(final List<KeyData> newKeys) {
+        this.newlyGeneratedKeys = Objects.requireNonNull(newKeys);
+        return this;
+    }
+
+    @Override
+    public Config parse(final CommandLine commandLine) throws IOException {
+
+        final ConfigFactory configFactory = ConfigFactory.create();
+
+        Config config = null;
+
+        if (commandLine.hasOption("configfile")) {
+            final Path path = Paths.get(commandLine.getOptionValue("configfile"));
+
+            if (!Files.exists(path)) {
+                throw new FileNotFoundException(String.format("%s not found.", path));
+            }
+
+            try (InputStream in = Files.newInputStream(path)) {
+                config = configFactory.create(in, newlyGeneratedKeys);
+            }
+
+            if (!newlyGeneratedKeys.isEmpty()) {
+                //we have generated new keys, so we need to output the new configuration
+                output(commandLine, config);
+            }
+
+        }
+
+        return config;
+    }
+
+    private static void output(CommandLine commandLine, Config config) throws IOException {
+
+        if (commandLine.hasOption("output")) {
+            final Path outputConfigFile = Paths.get(commandLine.getOptionValue("output"));
+
+            try (OutputStream out = Files.newOutputStream(outputConfigFile, CREATE_NEW)) {
+                JaxbUtil.marshal(config, out);
+            }
+        } else {
+            JaxbUtil.marshal(config, System.out);
+        }
+
+    }
+}

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/KeyGenerationParser.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/KeyGenerationParser.java
@@ -1,0 +1,69 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import com.quorum.tessera.config.ArgonOptions;
+import com.quorum.tessera.config.KeyData;
+import com.quorum.tessera.config.keys.KeyGenerator;
+import com.quorum.tessera.config.keys.KeyGeneratorFactory;
+import com.quorum.tessera.config.util.JaxbUtil;
+import org.apache.commons.cli.CommandLine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+
+public class KeyGenerationParser implements Parser<List<KeyData>> {
+
+    private final KeyGenerator generator = KeyGeneratorFactory.newFactory().create();
+
+    public List<KeyData> parse(final CommandLine commandLine) throws IOException {
+
+        final ArgonOptions options = this.argonOptions(commandLine).orElse(null);
+
+        if (commandLine.hasOption("keygen")) {
+            return this.filenames(commandLine)
+                .stream()
+                .map(name -> generator.generate(name, options))
+                .collect(Collectors.toList());
+        }
+
+        return new ArrayList<>();
+
+    }
+
+    private Optional<ArgonOptions> argonOptions(final CommandLine commandLine) throws IOException {
+
+        if (commandLine.hasOption("keygenconfig")) {
+            final String pathName = commandLine.getOptionValue("keygenconfig");
+            final InputStream configStream = Files.newInputStream(Paths.get(pathName));
+
+            final ArgonOptions argonOptions = JaxbUtil.unmarshal(configStream, ArgonOptions.class);
+            return Optional.of(argonOptions);
+        }
+
+        return Optional.empty();
+    }
+
+    private List<String> filenames(final CommandLine commandLine) {
+
+        if (commandLine.hasOption("filename")) {
+
+            final String keyNames = commandLine.getOptionValue("filename");
+            if (keyNames != null) {
+                return Stream.of(keyNames.split(",")).collect(Collectors.toList());
+            }
+
+        }
+
+        return singletonList("");
+
+    }
+
+}

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/KeyUpdateParser.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/KeyUpdateParser.java
@@ -1,0 +1,132 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import com.quorum.tessera.config.ArgonOptions;
+import com.quorum.tessera.config.KeyDataConfig;
+import com.quorum.tessera.config.PrivateKeyData;
+import com.quorum.tessera.config.PrivateKeyType;
+import com.quorum.tessera.config.keys.KeyEncryptor;
+import com.quorum.tessera.config.keys.KeysConverter;
+import com.quorum.tessera.config.util.JaxbUtil;
+import com.quorum.tessera.config.util.PasswordReader;
+import com.quorum.tessera.nacl.Key;
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class KeyUpdateParser implements Parser<Optional> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeyUpdateParser.class);
+
+    private final KeyEncryptor keyEncryptor;
+
+    private final PasswordReader passwordReader;
+
+    public KeyUpdateParser(final KeyEncryptor keyEncryptor, final PasswordReader passwordReader) {
+        this.keyEncryptor = Objects.requireNonNull(keyEncryptor);
+        this.passwordReader = Objects.requireNonNull(passwordReader);
+    }
+
+    @Override
+    public Optional parse(final CommandLine commandLine) throws IOException {
+        if (commandLine.hasOption("updatepassword")) {
+            final ArgonOptions argonOptions = argonOptions(commandLine);
+            final List<String> passwords = passwords(commandLine);
+            final Path keypath = privateKeyPath(commandLine);
+
+            final KeyDataConfig keyDataConfig = JaxbUtil.unmarshal(Files.newInputStream(keypath), KeyDataConfig.class);
+            final Key privateKey = this.getExistingKey(keyDataConfig, passwords);
+
+            final String newPassword = passwordReader.requestUserPassword();
+
+            final KeyDataConfig updatedKey;
+            if(newPassword.isEmpty()) {
+                final PrivateKeyData privateKeyData = new PrivateKeyData(privateKey.toString(), null, null, null, null, null);
+                updatedKey = new KeyDataConfig(privateKeyData, PrivateKeyType.UNLOCKED);
+            } else {
+                final PrivateKeyData privateKeyData = keyEncryptor.encryptPrivateKey(privateKey, newPassword, argonOptions);
+                updatedKey = new KeyDataConfig(privateKeyData, PrivateKeyType.LOCKED);
+            }
+
+            //write the key to file
+            Files.write(keypath, JaxbUtil.marshalToString(updatedKey).getBytes(UTF_8));
+            System.out.println("Private key at " + keypath.toString() + " updated.");
+        }
+
+        return Optional.empty();
+    }
+
+    Key getExistingKey(final KeyDataConfig kdc, final List<String> passwords) {
+
+        if (kdc.getType() == PrivateKeyType.UNLOCKED) {
+            return KeysConverter.convert(singletonList(kdc.getValue())).get(0);
+        } else {
+
+            for (final String pass : passwords) {
+                try {
+                    return keyEncryptor.decryptPrivateKey(
+                        new PrivateKeyData(
+                            null, kdc.getSnonce(), kdc.getAsalt(), kdc.getSbox(), kdc.getArgonOptions(), pass
+                        )
+                    );
+                } catch (final Exception e) {
+                    LOGGER.debug("Password failed to decrypt. Trying next if available.");
+                }
+            }
+
+            throw new IllegalArgumentException("Locked key but no valid password given");
+        }
+    }
+
+    static Path privateKeyPath(final CommandLine commandLine) {
+        final String privateKeyPath = commandLine.getOptionValue("keys.keyData.privateKeyPath");
+
+        if (privateKeyPath == null) {
+            throw new IllegalArgumentException("Private key path cannot be null when updating key password");
+        }
+
+        final Path keypath = Paths.get(privateKeyPath);
+        if (Files.notExists(keypath)) {
+            throw new IllegalArgumentException("Private key path must exist when updating key password");
+        }
+
+        return keypath;
+    }
+
+    static List<String> passwords(final CommandLine commandLine) throws IOException {
+        final String password = commandLine.getOptionValue("keys.passwords");
+        final String passwordFile = commandLine.getOptionValue("keys.passwordFile");
+
+        if (password != null) {
+            return singletonList(password);
+        } else if (passwordFile != null) {
+            return Files.readAllLines(Paths.get(passwordFile));
+        } else {
+            return emptyList();
+        }
+
+    }
+
+    static ArgonOptions argonOptions(final CommandLine commandLine) {
+        final String algorithm = commandLine.getOptionValue("keys.keyData.config.data.aopts.algorithm", "i");
+        final String iterations = commandLine.getOptionValue("keys.keyData.config.data.aopts.iterations", "10");
+        final String memory = commandLine.getOptionValue("keys.keyData.config.data.aopts.memory", "1048576");
+        final String parallelism = commandLine.getOptionValue("keys.keyData.config.data.aopts.parallelism", "4");
+
+        return new ArgonOptions(
+            algorithm, Integer.valueOf(iterations), Integer.valueOf(memory), Integer.valueOf(parallelism)
+        );
+    }
+
+}

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/Parser.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/Parser.java
@@ -1,0 +1,25 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import org.apache.commons.cli.CommandLine;
+
+/**
+ * A parser that checks for CLI options and takes actions based upon them
+ * <p>
+ * The actions may have side-effects, and may choose to return a value
+ *
+ * @param <T> The return type from parsing the CLI options
+ */
+public interface Parser<T> {
+
+    /**
+     * Parses the CLI arguments and performs actions based upon whether the
+     * arguments relevant to it are present or not
+     *
+     * @param commandLine the command line object that has parsed the configuration
+     * @return the output of the parser, if any
+     * @throws Exception if there is a problem with the supplied configuration,
+     *                   any exception could be thrown
+     */
+    T parse(CommandLine commandLine) throws Exception;
+
+}

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/PidFileParser.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/parsers/PidFileParser.java
@@ -1,0 +1,48 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
+public class PidFileParser implements Parser<Optional> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PidFileParser.class);
+
+    @Override
+    public Optional parse(final CommandLine commandLine) throws IOException {
+
+        if (commandLine.hasOption("pidfile")) {
+
+            final Path pidFilePath = Paths.get(commandLine.getOptionValue("pidfile"));
+
+            if (Files.exists(pidFilePath)) {
+                LOGGER.info("File already exists {}", pidFilePath);
+            } else {
+                Files.createFile(pidFilePath);
+                LOGGER.info("Created pid file {}", pidFilePath);
+            }
+
+            final String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+
+            try (final OutputStream stream = Files.newOutputStream(pidFilePath, CREATE, TRUNCATE_EXISTING)) {
+                stream.write(pid.getBytes(UTF_8));
+            }
+
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/config-cli/src/test/java/com/quorum/tessera/config/cli/parsers/KeyGenerationParserTest.java
+++ b/config-cli/src/test/java/com/quorum/tessera/config/cli/parsers/KeyGenerationParserTest.java
@@ -1,0 +1,111 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import com.quorum.tessera.config.ArgonOptions;
+import com.quorum.tessera.config.KeyData;
+import com.quorum.tessera.config.keys.KeyGenerator;
+import com.quorum.tessera.config.keys.MockKeyGeneratorFactory;
+import org.apache.commons.cli.CommandLine;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class KeyGenerationParserTest {
+
+    private KeyGenerationParser parser = new KeyGenerationParser();
+
+    @Test
+    public void notProvidingArgonOptionsGivesNull() throws Exception {
+        final Path keyLocation = Files.createTempFile(UUID.randomUUID().toString(), "");
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("keygen")).thenReturn(true);
+        when(commandLine.hasOption("filename")).thenReturn(true);
+        when(commandLine.getOptionValue("filename")).thenReturn(keyLocation.toString());
+        when(commandLine.hasOption("keygenconfig")).thenReturn(false);
+
+        final List<KeyData> result = parser.parse(commandLine);
+
+        assertThat(result).isNotNull().hasSize(1);
+
+        final KeyGenerator keyGenerator = MockKeyGeneratorFactory.getMockKeyGenerator();
+
+        final ArgumentCaptor<ArgonOptions> captor = ArgumentCaptor.forClass(ArgonOptions.class);
+        verify(keyGenerator).generate(eq(keyLocation.toString()), captor.capture());
+
+        assertThat(captor.getAllValues()).hasSize(1);
+        assertThat(captor.getValue()).isNull();
+    }
+
+    @Test
+    public void providingArgonOptionsGetSentCorrectly() throws Exception {
+        final String options = "{\"variant\": \"id\",\"memory\": 100,\"iterations\": 7,\"parallelism\": 22}";
+        final Path argonOptions = Files.createTempFile(UUID.randomUUID().toString(), "");
+        Files.write(argonOptions, options.getBytes());
+
+        final Path keyLocation = Files.createTempFile(UUID.randomUUID().toString(), "");
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("keygen")).thenReturn(true);
+        when(commandLine.hasOption("filename")).thenReturn(true);
+        when(commandLine.getOptionValue("filename")).thenReturn(keyLocation.toString());
+        when(commandLine.hasOption("keygenconfig")).thenReturn(true);
+        when(commandLine.getOptionValue("keygenconfig")).thenReturn(argonOptions.toString());
+
+        final List<KeyData> result = parser.parse(commandLine);
+
+        assertThat(result).isNotNull().hasSize(1);
+
+        final KeyGenerator keyGenerator = MockKeyGeneratorFactory.getMockKeyGenerator();
+
+        final ArgumentCaptor<ArgonOptions> captor = ArgumentCaptor.forClass(ArgonOptions.class);
+        verify(keyGenerator).generate(eq(keyLocation.toString()), captor.capture());
+
+        assertThat(captor.getAllValues()).hasSize(1);
+        assertThat(captor.getValue().getAlgorithm()).isEqualTo("id");
+        assertThat(captor.getValue().getIterations()).isEqualTo(7);
+        assertThat(captor.getValue().getMemory()).isEqualTo(100);
+        assertThat(captor.getValue().getParallelism()).isEqualTo(22);
+    }
+
+    @Test
+    public void keygenWithNoName() throws Exception {
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("keygen")).thenReturn(true);
+        when(commandLine.hasOption("filename")).thenReturn(false);
+        when(commandLine.hasOption("keygenconfig")).thenReturn(false);
+
+        final List<KeyData> result = this.parser.parse(commandLine);
+
+        assertThat(result).isNotNull().hasSize(1);
+
+        final KeyGenerator keyGenerator = MockKeyGeneratorFactory.getMockKeyGenerator();
+        verify(keyGenerator).generate("", null);
+    }
+
+    @Test
+    public void keygenNotGivenReturnsEmptyList() throws IOException {
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("keygen")).thenReturn(false);
+        when(commandLine.hasOption("filename")).thenReturn(false);
+        when(commandLine.hasOption("keygenconfig")).thenReturn(false);
+
+        final List<KeyData> result = this.parser.parse(commandLine);
+
+        assertThat(result).isNotNull().hasSize(0);
+
+        final KeyGenerator keyGenerator = MockKeyGeneratorFactory.getMockKeyGenerator();
+        verifyZeroInteractions(keyGenerator);
+    }
+
+}

--- a/config-cli/src/test/java/com/quorum/tessera/config/cli/parsers/KeyUpdateParserTest.java
+++ b/config-cli/src/test/java/com/quorum/tessera/config/cli/parsers/KeyUpdateParserTest.java
@@ -1,0 +1,303 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import com.quorum.tessera.config.*;
+import com.quorum.tessera.config.keys.KeyEncryptorFactory;
+import com.quorum.tessera.config.util.JaxbUtil;
+import com.quorum.tessera.config.util.PasswordReader;
+import com.quorum.tessera.nacl.Key;
+import org.apache.commons.cli.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.xml.bind.UnmarshalException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.*;
+
+public class KeyUpdateParserTest {
+
+    private PasswordReader passwordReader;
+
+    private KeyUpdateParser parser;
+
+    private Options options;
+
+    @Before
+    public void init() {
+        this.passwordReader = mock(PasswordReader.class);
+        when(passwordReader.requestUserPassword()).thenReturn("newPassword");
+        this.parser = new KeyUpdateParser(KeyEncryptorFactory.create(), passwordReader);
+
+        this.options = new Options();
+        this.options.addOption(Option.builder("updatepassword").hasArg(false).build());
+
+        this.options.addOption(Option.builder().longOpt("keys.keyData.config.data.aopts.algorithm").hasArg().build());
+        this.options.addOption(Option.builder().longOpt("keys.keyData.config.data.aopts.iterations").hasArg().build());
+        this.options.addOption(Option.builder().longOpt("keys.keyData.config.data.aopts.memory").hasArg().build());
+        this.options.addOption(Option.builder().longOpt("keys.keyData.config.data.aopts.parallelism").hasArg().build());
+
+        this.options.addOption(Option.builder().longOpt("keys.passwords").hasArg().build());
+        this.options.addOption(Option.builder().longOpt("keys.passwordFile").hasArg().build());
+
+        this.options.addOption(Option.builder().longOpt("keys.keyData.privateKeyPath").hasArg().build());
+    }
+
+    @Test
+    public void updateOptionNotPresentDoesntRequestOtherOptions() throws IOException {
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("updatepassword")).thenReturn(false);
+
+        this.parser.parse(commandLine);
+
+        verify(commandLine).hasOption("updatepassword");
+        verifyNoMoreInteractions(commandLine);
+
+    }
+
+    //Argon Option tests
+
+    @Test
+    public void noArgonOptionsGivenHasDefaults() throws ParseException {
+
+        final CommandLine commandLine = new DefaultParser().parse(options, new String[]{});
+
+        final ArgonOptions argonOptions = KeyUpdateParser.argonOptions(commandLine);
+
+        assertThat(argonOptions.getAlgorithm()).isEqualTo("i");
+        assertThat(argonOptions.getParallelism()).isEqualTo(4);
+        assertThat(argonOptions.getMemory()).isEqualTo(1048576);
+        assertThat(argonOptions.getIterations()).isEqualTo(10);
+
+    }
+
+    @Test
+    public void argonOptionsGivenHasOverrides() throws ParseException {
+
+        final String[] args = new String[]{
+            "--keys.keyData.config.data.aopts.algorithm", "d",
+            "--keys.keyData.config.data.aopts.memory", "100",
+            "--keys.keyData.config.data.aopts.iterations", "100",
+            "--keys.keyData.config.data.aopts.parallelism", "100"
+        };
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final ArgonOptions argonOptions = KeyUpdateParser.argonOptions(commandLine);
+
+        assertThat(argonOptions.getAlgorithm()).isEqualTo("d");
+        assertThat(argonOptions.getParallelism()).isEqualTo(100);
+        assertThat(argonOptions.getMemory()).isEqualTo(100);
+        assertThat(argonOptions.getIterations()).isEqualTo(100);
+
+    }
+
+    //Password reading tests
+    @Test
+    public void inlinePasswordParsed() throws ParseException, IOException {
+        final String[] args = new String[]{"--keys.passwords", "pass"};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final List<String> passwords = KeyUpdateParser.passwords(commandLine);
+
+        assertThat(passwords).isNotNull().hasSize(1).containsExactly("pass");
+    }
+
+    @Test
+    public void passwordFileParsedAndRead() throws ParseException, IOException {
+        final Path passwordFile = Files.createTempFile("passwords", ".txt");
+        Files.write(passwordFile, "passwordInsideFile\nsecondPassword".getBytes());
+
+        final String[] args = new String[]{"--keys.passwordFile", passwordFile.toAbsolutePath().toString()};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final List<String> passwords = KeyUpdateParser.passwords(commandLine);
+
+        assertThat(passwords).isNotNull().hasSize(2).containsExactlyInAnyOrder("passwordInsideFile", "secondPassword");
+    }
+
+    @Test
+    public void passwordFileThrowsErrorIfCantBeRead() throws ParseException {
+        final String[] args = new String[]{"--keys.passwordFile", "/tmp/passwords.txt"};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final Throwable throwable = catchThrowable(() -> KeyUpdateParser.passwords(commandLine));
+
+        assertThat(throwable).isNotNull().isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void emptyListGivenForNoPasswords() throws ParseException, IOException {
+        final String[] args = new String[]{};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final List<String> passwords = KeyUpdateParser.passwords(commandLine);
+
+        assertThat(passwords).isNotNull().isEmpty();
+    }
+
+    //key file tests
+    @Test
+    public void noPrivateKeyGivenThrowsError() throws ParseException {
+        final String[] args = new String[]{};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final Throwable throwable = catchThrowable(() -> KeyUpdateParser.privateKeyPath(commandLine));
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Private key path cannot be null when updating key password");
+    }
+
+    @Test
+    public void cantReadPrivateKeyThrowsError() throws ParseException {
+        final String[] args = new String[]{"--keys.keyData.privateKeyPath", "/tmp/nonexisting.txt"};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final Throwable throwable = catchThrowable(() -> KeyUpdateParser.privateKeyPath(commandLine));
+
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void privateKeyExistsReturnsPath() throws ParseException, IOException {
+        final Path key = Files.createTempFile("key", ".key");
+
+        final String[] args = new String[]{"--keys.keyData.privateKeyPath", key.toString()};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final Path path = KeyUpdateParser.privateKeyPath(commandLine);
+
+        assertThat(path).isEqualTo(key);
+    }
+
+    //key fetching tests
+    @Test
+    public void unlockedKeyReturnedProperly() {
+
+        final KeyDataConfig kdc = new KeyDataConfig(
+            new PrivateKeyData("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=", null, null, null, null, null),
+            PrivateKeyType.UNLOCKED
+        );
+
+        final Key key = this.parser.getExistingKey(kdc, emptyList());
+
+        assertThat(key).isNotNull();
+        assertThat(key.toString()).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+
+    }
+
+    @Test
+    public void lockedKeyFailsWithNoPasswordsMatching() {
+
+        final KeyDataConfig kdc = new KeyDataConfig(
+            new PrivateKeyData(
+                null,
+                "x3HUNXH6LQldKtEv3q0h0hR4S12Ur9pC",
+                "7Sem2tc6fjEfW3yYUDN/kSslKEW0e1zqKnBCWbZu2Zw=",
+                "d0CmRus0rP0bdc7P7d/wnOyEW14pwFJmcLbdu2W3HmDNRWVJtoNpHrauA/Sr5Vxc",
+                new ArgonOptions("id", 10, 1048576, 4),
+                null
+            ),
+            PrivateKeyType.LOCKED
+        );
+
+        final Throwable throwable = catchThrowable(() -> this.parser.getExistingKey(kdc, singletonList("wrong")));
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Locked key but no valid password given");
+    }
+
+    @Test
+    public void lockedKeySucceedsWithPasswordsMatching() {
+
+        final KeyDataConfig kdc = new KeyDataConfig(
+            new PrivateKeyData(
+                null,
+                "x3HUNXH6LQldKtEv3q0h0hR4S12Ur9pC",
+                "7Sem2tc6fjEfW3yYUDN/kSslKEW0e1zqKnBCWbZu2Zw=",
+                "d0CmRus0rP0bdc7P7d/wnOyEW14pwFJmcLbdu2W3HmDNRWVJtoNpHrauA/Sr5Vxc",
+                new ArgonOptions("id", 10, 1048576, 4),
+                null
+            ),
+            PrivateKeyType.LOCKED
+        );
+
+        final Key key = this.parser.getExistingKey(kdc, singletonList("q"));
+
+        assertThat(key).isNotNull();
+        assertThat(key.toString()).isEqualTo("6ccai0+GXRRVbNckE+JubN+UQ9+8pMCx86dZI683X7w=");
+
+    }
+
+    @Test
+    public void lockedKeySucceedsWithAtleastOnePasswordsMatching() {
+
+        final KeyDataConfig kdc = new KeyDataConfig(
+            new PrivateKeyData(
+                null,
+                "x3HUNXH6LQldKtEv3q0h0hR4S12Ur9pC",
+                "7Sem2tc6fjEfW3yYUDN/kSslKEW0e1zqKnBCWbZu2Zw=",
+                "d0CmRus0rP0bdc7P7d/wnOyEW14pwFJmcLbdu2W3HmDNRWVJtoNpHrauA/Sr5Vxc",
+                new ArgonOptions("id", 10, 1048576, 4),
+                null
+            ),
+            PrivateKeyType.LOCKED
+        );
+
+        final Key key = this.parser.getExistingKey(kdc, Arrays.asList("wrong", "q"));
+
+        assertThat(key).isNotNull();
+        assertThat(key.toString()).isEqualTo("6ccai0+GXRRVbNckE+JubN+UQ9+8pMCx86dZI683X7w=");
+
+    }
+
+    @Test
+    public void loadingMalformedKeyfileThrowsError() throws IOException, ParseException {
+
+        final Path key = Files.createTempFile("key", ".key");
+        Files.write(key, "BAD JSON DATA".getBytes());
+
+        final String[] args = new String[]{"-updatepassword", "--keys.keyData.privateKeyPath", key.toString()};
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        final Throwable throwable = catchThrowable(() -> this.parser.parse(commandLine));
+
+        assertThat(throwable).isInstanceOf(ConfigException.class).hasCauseExactlyInstanceOf(UnmarshalException.class);
+
+    }
+
+    @Test
+    public void keyGetsUpdated() throws IOException, ParseException {
+        final KeyDataConfig startingKey = JaxbUtil.unmarshal(
+            getClass().getResourceAsStream("/lockedprivatekey.json"), KeyDataConfig.class
+        );
+
+        final Path key = Files.createTempFile("key", ".key");
+        Files.write(key, JaxbUtil.marshalToString(startingKey).getBytes());
+
+        final String[] args = new String[]{
+            "-updatepassword",
+            "--keys.keyData.privateKeyPath", key.toString(),
+            "--keys.passwords", "q"
+        };
+        final CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        this.parser.parse(commandLine);
+
+        final KeyDataConfig endingKey = JaxbUtil.unmarshal(Files.newInputStream(key), KeyDataConfig.class);
+
+        assertThat(endingKey.getSbox()).isNotEqualTo(startingKey.getSbox());
+        assertThat(endingKey.getSnonce()).isNotEqualTo(startingKey.getSnonce());
+        assertThat(endingKey.getAsalt()).isNotEqualTo(startingKey.getAsalt());
+    }
+
+}

--- a/config-cli/src/test/java/com/quorum/tessera/config/cli/parsers/PidFileParserTest.java
+++ b/config-cli/src/test/java/com/quorum/tessera/config/cli/parsers/PidFileParserTest.java
@@ -1,0 +1,65 @@
+package com.quorum.tessera.config.cli.parsers;
+
+import org.apache.commons.cli.CommandLine;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PidFileParserTest {
+
+    private PidFileParser pidFileParser = new PidFileParser();
+
+    private Path pidFile;
+
+    @Before
+    public void init() throws IOException {
+        this.pidFile = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
+    }
+
+    @Test
+    public void fileOverwrittenIfAlreadyExists() throws IOException {
+
+        final String message = "THIS ISNT A PID";
+
+        Files.write(this.pidFile, message.getBytes());
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("pidfile")).thenReturn(true);
+        when(commandLine.getOptionValue("pidfile")).thenReturn(this.pidFile.toAbsolutePath().toString());
+
+        assertThat(this.pidFile).exists();
+
+        this.pidFileParser.parse(commandLine);
+
+        final byte[] filesBytes = Files.readAllBytes(this.pidFile);
+
+        assertThat(filesBytes).isNotEqualTo(message.getBytes());
+
+    }
+
+    @Test
+    public void fileCreatedIfNotAlreadyExists() throws IOException {
+
+        Files.deleteIfExists(this.pidFile);
+
+        final CommandLine commandLine = mock(CommandLine.class);
+        when(commandLine.hasOption("pidfile")).thenReturn(true);
+        when(commandLine.getOptionValue("pidfile")).thenReturn(this.pidFile.toAbsolutePath().toString());
+
+        assertThat(this.pidFile).doesNotExist();
+
+        this.pidFileParser.parse(commandLine);
+
+        assertThat(this.pidFile).exists();
+
+    }
+
+}

--- a/config-cli/src/test/java/com/quorum/tessera/config/keys/MockKeyGeneratorFactory.java
+++ b/config-cli/src/test/java/com/quorum/tessera/config/keys/MockKeyGeneratorFactory.java
@@ -7,7 +7,7 @@ public class MockKeyGeneratorFactory implements KeyGeneratorFactory {
     public enum KeyGeneratorHolder {
         INSTANCE;
 
-        final KeyGenerator keyGenerator = mock(KeyGenerator.class);
+        KeyGenerator keyGenerator = mock(KeyGenerator.class);
 
     }
 
@@ -18,6 +18,10 @@ public class MockKeyGeneratorFactory implements KeyGeneratorFactory {
 
     public static KeyGenerator getMockKeyGenerator() {
         return KeyGeneratorHolder.INSTANCE.keyGenerator;
+    }
+
+    public static void reset() {
+        KeyGeneratorHolder.INSTANCE.keyGenerator =  mock(KeyGenerator.class);
     }
 
 }

--- a/config-migration/tessera-config.json
+++ b/config-migration/tessera-config.json
@@ -6,6 +6,7 @@
    },
    "server" : {
       "port" : 9001,
+      "grpcPort" : 50521,
       "communicationType" : "REST",
       "sslConfig" : {
          "tls" : "OFF",

--- a/config-migration/tessera-config.json
+++ b/config-migration/tessera-config.json
@@ -6,7 +6,6 @@
    },
    "server" : {
       "port" : 9001,
-      "grpcPort" : 50521,
       "communicationType" : "REST",
       "sslConfig" : {
          "tls" : "OFF",


### PR DESCRIPTION
https://github.com/jpmorganchase/tessera/issues/447

Create parsers for each type of CLI option. Each parser is responsible
for it's own options and actions. This way, not everything is put into
one super CLI class.

Add ability to change, add or remove a password on a private key. This
option is only for file based private keys, and will stop other CLI
parsing from taking place, including but not limited to:
- new key generation
- configuration file loading and validating
- application startup

The rules and CLI options can be found in the attached issue.