### PR TITLE
Allow null instance overrides

### DIFF
--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/OverrideUtil.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/OverrideUtil.java
@@ -143,6 +143,10 @@ public interface OverrideUtil {
      */
     static void setValue(Object root, String path, String... value) {
 
+        if(root == null) {
+            return;
+        }
+
         final ListIterator<String> pathTokens = Arrays.asList(path.split("\\.")).listIterator();
 
         final Class rootType = root.getClass();
@@ -256,6 +260,10 @@ public interface OverrideUtil {
 
     static <T> T createInstance(Class<T> type) {
 
+        if(type.isInterface()) {
+            return null;
+        }
+
         return ReflectCallback.execute(() -> {
             Method factoryMethod = type.getDeclaredMethod("create");
             factoryMethod.setAccessible(true);
@@ -271,6 +279,9 @@ public interface OverrideUtil {
     }
 
     static void initialiseNestedObjects(Object obj) {
+        if (obj == null) {
+            return;
+        }
         ReflectCallback.execute(() -> {
             Class type = obj.getClass();
             Field[] fields = type.getDeclaredFields();

--- a/config-cli/src/test/java/com/quorum/tessera/config/cli/OverrideUtilTest.java
+++ b/config-cli/src/test/java/com/quorum/tessera/config/cli/OverrideUtilTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class OverrideUtilTest {
 
@@ -319,6 +320,12 @@ public class OverrideUtilTest {
     }
 
     @Test
+    public void initialiseNestedObjectsWithNullValueDoesNothing() {
+        final Throwable throwable = catchThrowable(() -> OverrideUtil.initialiseNestedObjects(null));
+        assertThat(throwable).isNull();
+    }
+
+    @Test
     public void createConfigInstance() {
         Config config = OverrideUtil.createInstance(Config.class);
         assertThat(config).isNotNull();
@@ -331,6 +338,12 @@ public class OverrideUtilTest {
         assertThat(config.getPeers()).isEmpty();
         assertThat(config.getAlwaysSendTo()).isEmpty();
 
+    }
+
+    @Test
+    public void createConfigInstanceWithInterfaceReturnsNull() {
+        final OverrideUtil interfaceObject = OverrideUtil.createInstance(OverrideUtil.class);
+        assertThat(interfaceObject).isNull();
     }
 
     @Test
@@ -374,6 +387,12 @@ public class OverrideUtilTest {
         OverrideUtil.setValue(someList, "someList.someValue", "password1", "password2");
         assertThat(someList.someList.get(0).someValue).isEqualTo("password1");
         assertThat(someList.someList.get(1).someValue).isEqualTo("password2");
+    }
+
+    @Test
+    public void setValueOnNullDoesNothing() {
+        final Throwable throwable = catchThrowable(() -> OverrideUtil.setValue(null, "jdbc.username", "someuser"));
+        assertThat(throwable).isNull();
     }
 
     @Test

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/LegacyCliAdapterTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/LegacyCliAdapterTest.java
@@ -113,10 +113,10 @@ public class LegacyCliAdapterTest {
         assertThat(config.getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
         assertThat(config.getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
         assertThat(config.getKeys().getKeyData().size()).isEqualTo(2);
-        assertThat(config.getKeys().getKeyData().get(0).getPublicKeyPath().toString()).isEqualTo("data/foo.pub");
-        assertThat(config.getKeys().getKeyData().get(0).getPrivateKeyPath().toString()).isEqualTo("data/foo.key");
-        assertThat(config.getKeys().getKeyData().get(1).getPublicKeyPath().toString()).isEqualTo("data/foo2.pub");
-        assertThat(config.getKeys().getKeyData().get(1).getPrivateKeyPath().toString()).isEqualTo("data/foo2.key");
+        assertThat(config.getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("data/foo.pub"));
+        assertThat(config.getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("data/foo.key"));
+        assertThat(config.getKeys().getKeyData().get(1)).extracting("publicKeyPath").containsExactly(Paths.get("data/foo2.pub"));
+        assertThat(config.getKeys().getKeyData().get(1)).extracting("privateKeyPath").containsExactly(Paths.get("data/foo2.key"));
         assertThat(config.getAlwaysSendTo().size()).isEqualTo(3);
         assertThat(config.getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
         assertThat(config.getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
@@ -209,8 +209,8 @@ public class LegacyCliAdapterTest {
         assertThat(result.getConfig().get().getPeers().size()).isEqualTo(1);
         assertThat(result.getConfig().get().getPeers().get(0).getUrl()).isEqualTo("http://others");
         assertThat(result.getConfig().get().getKeys().getKeyData().size()).isEqualTo(1);
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0).getPublicKeyPath().toString()).isEqualTo("override/new.pub");
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0).getPrivateKeyPath().toString()).isEqualTo("override/new.key");
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
         assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(2);
         assertThat(result.getConfig().get().getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
         assertThat(result.getConfig().get().getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
@@ -337,8 +337,8 @@ public class LegacyCliAdapterTest {
         assertThat(result.getConfig().get().getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
         assertThat(result.getConfig().get().getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
         assertThat(result.getConfig().get().getKeys().getKeyData().size()).isEqualTo(1);
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0).getPublicKeyPath().toString()).isEqualTo("override/new.pub");
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0).getPrivateKeyPath().toString()).isEqualTo("override/new.key");
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
         assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(4);
         assertThat(result.getConfig().get().getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
         assertThat(result.getConfig().get().getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");


### PR DESCRIPTION
If a null instance if trying to be overridden, return null instead of throwing an exception.

The situation this could arise:

The override utility creates empty objects in order to populate them after. In the case of key-pairs, the introspected type is an interface. Since interfaces cannot be instantiated (and which subclass would we eagerly instantiate anyway?), we return a null object.
Therefore, we also need to safeguard against this null object being passed into the internal override methods by returning immediately.