### PR TITLE
Remove unused code from the configuration migration tool

### DIFF
--- a/config-migration/src/main/java/com/quorum/tessera/config/migration/TomlConfigFactory.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/migration/TomlConfigFactory.java
@@ -2,30 +2,22 @@ package com.quorum.tessera.config.migration;
 
 import com.moandjiezana.toml.Toml;
 import com.quorum.tessera.config.ArgonOptions;
-import com.quorum.tessera.config.KeyDataConfig;
 import com.quorum.tessera.config.SslAuthenticationMode;
 import com.quorum.tessera.config.builder.ConfigBuilder;
 import com.quorum.tessera.config.builder.JdbcConfigFactory;
 import com.quorum.tessera.config.builder.KeyDataBuilder;
 import com.quorum.tessera.config.builder.SslTrustModeFactory;
-import com.quorum.tessera.config.util.JaxbUtil;
-import com.quorum.tessera.io.IOCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonReader;
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 public class TomlConfigFactory {
 
@@ -38,9 +30,7 @@ public class TomlConfigFactory {
         }
 
         Toml toml = new Toml().read(configData);
-        toml.toMap().entrySet().stream().forEach(entry -> {
-            LOGGER.debug("Found entry in toml file : {} {}", entry.getKey(), entry.getValue());
-        });
+        toml.toMap().forEach((key, value) -> LOGGER.debug("Found entry in toml file : {} {}", key, value));
 
         final String urlWithoutPort = Optional
             .ofNullable(toml.getString("url"))
@@ -54,48 +44,48 @@ public class TomlConfigFactory {
             .orElse(null);
 
         final Integer port = Optional.ofNullable(toml.getLong("port"))
-                                                    .map(Long::intValue)
-                                                    .orElse(null);
+            .map(Long::intValue)
+            .orElse(null);
 
         final String workdir = toml.getString("workdir", "");
         final String socket = toml.getString("socket");
 
         final String tls = toml.getString("tls", "off").toUpperCase();
 
-        final List<String> othernodes = toml.getList("othernodes", Collections.emptyList());
+        final List<String> othernodes = toml.getList("othernodes", emptyList());
 
-        final List<String> alwaysSendToKeyPaths = toml.getList("alwayssendto", Collections.emptyList());
+        final List<String> alwaysSendToKeyPaths = toml.getList("alwayssendto", emptyList());
 
         final String storage = toml.getString("storage", "memory");
 
-        final List<String> ipwhitelist = toml.getList("ipwhitelist", Collections.EMPTY_LIST);
+        final List<String> ipwhitelist = toml.getList("ipwhitelist", emptyList());
         final boolean useWhiteList = !ipwhitelist.isEmpty();
 
         //Server side
         final String tlsservertrust = toml.getString("tlsservertrust", "tofu");
         final Optional<String> tlsserverkey = Optional.ofNullable(toml.getString("tlsserverkey"));
         final Optional<String> tlsservercert = Optional.ofNullable(toml.getString("tlsservercert"));
-        final Optional<List<String>> tlsserverchainnames = Optional.ofNullable(toml.getList("tlsserverchain", Collections.emptyList()));
+        final Optional<List<String>> tlsserverchainnames = Optional.ofNullable(toml.getList("tlsserverchain", emptyList()));
         final Optional<String> tlsknownclients = Optional.ofNullable(toml.getString("tlsknownclients"));
 
         //Client side
         final String tlsclienttrust = toml.getString("tlsclienttrust", "tofu");
         final Optional<String> tlsclientkey = Optional.ofNullable(toml.getString("tlsclientkey"));
         final Optional<String> tlsclientcert = Optional.ofNullable(toml.getString("tlsclientcert"));
-        final Optional<List<String>> tlsclientchainnames = Optional.ofNullable(toml.getList("tlsclientchain", Collections.emptyList()));
+        final Optional<List<String>> tlsclientchainnames = Optional.ofNullable(toml.getList("tlsclientchain", emptyList()));
         final Optional<String> tlsknownservers = Optional.ofNullable(toml.getString("tlsknownservers"));
 
         ConfigBuilder configBuilder = ConfigBuilder.create()
-                .serverPort(port)
-                .serverHostname(urlWithoutPort)
-                .unixSocketFile(socket)
-                .sslAuthenticationMode(SslAuthenticationMode.valueOf(tls))
-                .sslServerTrustMode(SslTrustModeFactory.resolveByLegacyValue(tlsservertrust))
-                .sslClientTrustMode(SslTrustModeFactory.resolveByLegacyValue(tlsclienttrust))
-                .peers(othernodes)
-                .alwaysSendTo(alwaysSendToKeyPaths)
-                .useWhiteList(useWhiteList)
-                .workdir(workdir);
+            .serverPort(port)
+            .serverHostname(urlWithoutPort)
+            .unixSocketFile(socket)
+            .sslAuthenticationMode(SslAuthenticationMode.valueOf(tls))
+            .sslServerTrustMode(SslTrustModeFactory.resolveByLegacyValue(tlsservertrust))
+            .sslClientTrustMode(SslTrustModeFactory.resolveByLegacyValue(tlsclienttrust))
+            .peers(othernodes)
+            .alwaysSendTo(alwaysSendToKeyPaths)
+            .useWhiteList(useWhiteList)
+            .workdir(workdir);
 
         tlsserverkey.ifPresent(configBuilder::sslServerTlsKeyPath);
         tlsservercert.ifPresent(configBuilder::sslServerTlsCertificatePath);
@@ -107,76 +97,28 @@ public class TomlConfigFactory {
         tlsknownservers.ifPresent(configBuilder::sslKnownServersFile);
 
         Optional.ofNullable(storage)
-                .map(JdbcConfigFactory::fromLegacyStorageString).ifPresent(configBuilder::jdbcConfig);
+            .map(JdbcConfigFactory::fromLegacyStorageString)
+            .ifPresent(configBuilder::jdbcConfig);
 
         return configBuilder;
     }
 
-    public KeyDataBuilder createKeyDataBuilder(InputStream configData) {
-        Toml toml = new Toml().read(configData);
+    KeyDataBuilder createKeyDataBuilder(InputStream configData) {
+        final Toml toml = new Toml().read(configData);
 
-        final List<String> publicKeyList = toml.getList("publickeys", Collections.emptyList());
+        final List<String> publicKeyList = toml.getList("publickeys", emptyList());
 
-        final List<String> privateKeyList = toml.getList("privatekeys", Collections.emptyList());
+        final List<String> privateKeyList = toml.getList("privatekeys", emptyList());
 
         final String pwd = toml.getString("passwords");
 
         final String workdir = toml.getString("workdir");
 
-        KeyDataBuilder keyDataBuilder = KeyDataBuilder.create();
-        if(!publicKeyList.isEmpty() || !privateKeyList.isEmpty()) {
-            keyDataBuilder.withPublicKeys(publicKeyList)
-                          .withPrivateKeys(privateKeyList)
-                          .withPrivateKeyPasswordFile(pwd)
-                          .withWorkingDirectory(workdir);
-        }
-
-        return keyDataBuilder;
-    }
-
-    static List<KeyDataConfig> createPrivateKeyData(List<String> privateKeys, List<String> privateKeyPasswords) {
-
-        //Populate null values assume that they arent private
-        List<String> passwordList = new ArrayList<>(privateKeyPasswords);
-        for (int i = privateKeyPasswords.size() - 1; i < privateKeys.size(); i++) {
-            passwordList.add(null);
-        }
-
-        List<JsonObject> privateKeyJson = privateKeys
-                .stream()
-                .map(Paths::get)
-                .map(path -> IOCallback.execute(() -> Files.newInputStream(path)))
-                .map(Json::createReader)
-                .map(JsonReader::readObject)
-                .collect(Collectors.toList());
-
-        List<KeyDataConfig> privateKeyData = IntStream
-                .range(0, privateKeyJson.size())
-                .mapToObj(i -> {
-
-                    final String password = passwordList.get(i);
-                    final JsonObject keyDatC = Json.createObjectBuilder(privateKeyJson.get(i)).build();
-
-                    final JsonObject dataNode = keyDatC.getJsonObject("data");
-                    final JsonObjectBuilder ammendedDataNode = Json.createObjectBuilder(dataNode);
-
-                    boolean isLocked = Objects.equals(keyDatC.getString("type"), "argon2sbox");
-                    if (isLocked) {
-                        ammendedDataNode.add("password", Objects.requireNonNull(password, "Password is required."));
-                    }
-
-                    return Json.createObjectBuilder(keyDatC)
-                            .remove("data")
-                            .add("data", ammendedDataNode)
-                            .build();
-                })
-                .map(JsonObject::toString)
-                .map(String::getBytes)
-                .map(ByteArrayInputStream::new)
-                .map(inputStream -> JaxbUtil.unmarshal(inputStream, KeyDataConfig.class))
-                .collect(Collectors.toList());
-
-        return Collections.unmodifiableList(privateKeyData);
+        return KeyDataBuilder.create()
+            .withPublicKeys(publicKeyList)
+            .withPrivateKeys(privateKeyList)
+            .withPrivateKeyPasswordFile(pwd)
+            .withWorkingDirectory(workdir);
     }
 
 }

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
@@ -1,12 +1,9 @@
 package com.quorum.tessera.config.migration;
 
 import com.quorum.tessera.config.*;
-import com.quorum.tessera.config.migration.test.FixtureUtil;
 import com.quorum.tessera.test.util.ElUtil;
-import org.junit.Before;
 import org.junit.Test;
 
-import javax.json.JsonObject;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,12 +18,7 @@ import static org.mockito.Mockito.mock;
 
 public class TomlConfigFactoryTest {
 
-    private TomlConfigFactory tomlConfigFactory;
-
-    @Before
-    public void onSetup() {
-        tomlConfigFactory = new TomlConfigFactory();
-    }
+    private TomlConfigFactory tomlConfigFactory = new TomlConfigFactory();
 
     @Test
     public void createConfigFromSampleFile() throws IOException {
@@ -145,66 +137,6 @@ public class TomlConfigFactoryTest {
         InputStream configData = mock(InputStream.class);
 
         tomlConfigFactory.create(configData, null, "testKey");
-    }
-
-    @Test
-    public void createPrivateKeyData() throws Exception {
-
-        JsonObject keyDataConfigJson = FixtureUtil.createLockedPrivateKey();
-
-        Path privateKeyPath = Files.createTempFile("createPrivateKeyData", ".txt");
-        Files.write(privateKeyPath, keyDataConfigJson.toString().getBytes());
-
-        List<KeyDataConfig> result = TomlConfigFactory
-            .createPrivateKeyData(Arrays.asList(privateKeyPath.toString()), Arrays.asList("Secret"));
-
-        assertThat(result).hasSize(1);
-
-        KeyDataConfig keyConfig = result.get(0);
-
-        assertThat(keyConfig.getType()).isEqualTo(PrivateKeyType.LOCKED);
-
-        JsonObject privateKeyData = keyDataConfigJson.getJsonObject("data");
-
-        PrivateKeyData key = keyConfig.getPrivateKeyData();
-
-        assertThat(key.getPassword()).isEqualTo("Secret");
-        assertThat(key.getAsalt()).isEqualTo(privateKeyData.getString("asalt"));
-        assertThat(key.getSbox()).isEqualTo(privateKeyData.getString("sbox"));
-        assertThat(key.getSnonce()).isEqualTo(privateKeyData.getString("snonce"));
-
-        assertThat(key.getArgonOptions()).isNotNull();
-
-        JsonObject argonOptions = privateKeyData.getJsonObject("aopts");
-
-        assertThat(key.getArgonOptions().getIterations()).isEqualTo(argonOptions.getInt("iterations"));
-        assertThat(key.getArgonOptions().getMemory()).isEqualTo(argonOptions.getInt("memory"));
-        assertThat(key.getArgonOptions().getParallelism()).isEqualTo(argonOptions.getInt("parallelism"));
-        assertThat(key.getArgonOptions().getAlgorithm()).isEqualTo(argonOptions.getString("variant"));
-
-        Files.deleteIfExists(privateKeyPath);
-
-    }
-
-    @Test
-    public void createUnlockedPrivateKeyData() throws Exception {
-
-        JsonObject keyDataConfigJson = FixtureUtil.createUnlockedPrivateKey();
-
-        Path privateKeyPath = Files.createTempFile("createUnlockedPrivateKeyData", ".txt");
-        Files.write(privateKeyPath, keyDataConfigJson.toString().getBytes());
-
-        List<KeyDataConfig> result = TomlConfigFactory
-            .createPrivateKeyData(Arrays.asList(privateKeyPath.toString()), Arrays.asList("Secret"));
-
-        assertThat(result).hasSize(1);
-
-        KeyDataConfig keyConfig = result.get(0);
-
-        assertThat(keyConfig.getType()).isEqualTo(PrivateKeyType.UNLOCKED);
-
-        Files.deleteIfExists(privateKeyPath);
-
     }
 
     @Test


### PR DESCRIPTION
This removes code that would convert public/private keys from file to an inline version for the configuration.

The migration tool only sets the paths that are given, so there is no need to read these files and do the translation.