### PR TITLE
Update p2p discovery

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -27,9 +27,7 @@
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
         <module name="RedundantModifier"/>
-        <module name="ModifierOrder">
-            
-        </module>
+        <module name="ModifierOrder"/>
         <module name="ParenPad"/>
         <module name="EqualsHashCode"/>
         <module name="EmptyStatement"/>

--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/AdminCliAdapter.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/AdminCliAdapter.java
@@ -28,7 +28,7 @@ public class AdminCliAdapter implements CliAdapter {
     
     private final ClientFactory clientFactory;
 
-    public AdminCliAdapter(ClientFactory clientFactory) {
+    public AdminCliAdapter(final ClientFactory clientFactory) {
         this.clientFactory = Objects.requireNonNull(clientFactory);
     }
     
@@ -83,10 +83,10 @@ public class AdminCliAdapter implements CliAdapter {
         String peerUrl = line.getOptionValue("addpeer");
     
         final Peer peer = new Peer(peerUrl);
-        
+
         String scheme = Optional.of(config)
                 .map(Config::getServerConfig)
-                .map(ServerConfig::getServerUri)
+                .map(ServerConfig::getBindingUri)
                 .map(URI::getScheme)
                 .orElse("http");
         
@@ -95,12 +95,11 @@ public class AdminCliAdapter implements CliAdapter {
                 .map(ServerConfig::getPort)
                 .orElse(80);
  
-        URI uri = UriBuilder.fromPath("/")
+        URI uri = UriBuilder.fromUri(config.getServerConfig().getBindingUri())
                 .port(port)
-                .host("localhost")
-                .scheme(scheme).build();
-        
-        
+                .scheme(scheme)
+                .build();
+
         Response response = restClient.target(uri)
                 .path("config")
                 .path("peers")

--- a/jaxrs-service/src/main/java/com/quorum/tessera/api/ConfigResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/api/ConfigResource.java
@@ -1,24 +1,17 @@
 package com.quorum.tessera.api;
 
-import com.quorum.tessera.api.filter.PrivateApi;
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.core.config.ConfigService;
-import java.net.URI;
-import java.util.List;
-import java.util.Objects;
+
 import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
 
-@PrivateApi
 @Path("/config")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -26,33 +19,37 @@ public class ConfigResource {
 
     private final ConfigService configService;
 
-    public ConfigResource(ConfigService configService) {
+    public ConfigResource(final ConfigService configService) {
         this.configService = Objects.requireNonNull(configService);
     }
 
     @PUT
     @Path("/peers")
-    public Response addPeer(@Valid Peer peer) {
-        
-        configService.addPeer(peer.getUrl());
-        
-        int index = configService.getPeers().size() - 1;
+    public Response addPeer(@Valid final Peer peer) {
 
-        URI uri = UriBuilder.fromPath("config")
+        this.configService.addPeer(peer.getUrl());
+
+        //TODO: this seems a bit presumptuous, search for the peer instead?
+        final int index = this.configService.getPeers().size() - 1;
+
+        final URI uri = UriBuilder.fromPath("config")
                 .path("peers")
                 .path(String.valueOf(index))
                 .build();
+
         return Response.created(uri).build();
     }
 
     @GET
     @Path("/peers/{index}")
-    public Response getPeer(@PathParam("index") Integer index) {
+    public Response getPeer(@PathParam("index") final Integer index) {
 
-        List<Peer> peers = configService.getPeers();
+        final List<Peer> peers = this.configService.getPeers();
+
         if (peers.size() <= index) {
             throw new NotFoundException("No peer found at index "+ index);
         }
+
         return Response.ok(peers.get(index)).build();
     }
 

--- a/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoStore.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoStore.java
@@ -23,7 +23,8 @@ public class PartyInfoStore {
 
     public PartyInfoStore(final ConfigService configService) {
 
-        this.advertisedUrl = configService.getServerUri().toString();
+        //TODO: remove the extra "/" when we deprecate backwards compatibility
+        this.advertisedUrl = configService.getServerUri().toString() + "/";
 
         this.recipients = new HashSet<>();
         this.parties = new HashSet<>();

--- a/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoStoreTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoStoreTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 public class PartyInfoStoreTest {
 
-    private String annoyingUriAsAString = "FIXME";
+    private String uri = "http://localhost:8080";
 
     private ConfigService configService;
 
@@ -28,8 +28,9 @@ public class PartyInfoStoreTest {
 
     @Before
     public void onSetUp() throws URISyntaxException {
-        configService = mock(ConfigService.class);
-        when(configService.getServerUri()).thenReturn(new URI(annoyingUriAsAString));
+        this.configService = mock(ConfigService.class);
+        when(configService.getServerUri()).thenReturn(new URI(uri));
+
         this.partyInfoStore = new PartyInfoStore(configService);
 
     }
@@ -37,16 +38,12 @@ public class PartyInfoStoreTest {
     @Test
     public void registeringSamePublicKeyTwice() {
 
-        final String ourUrl = annoyingUriAsAString;
+        final PublicKey testKey = PublicKey.from("some-key".getBytes());
 
-        final Set<Recipient> ourKeys = singleton(
-            new Recipient(PublicKey.from("some-key".getBytes()), ourUrl)
-        );
-        final Set<Party> parties = singleton(
-            new Party("http://other-node.com:8080")
-        );
+        final Set<Recipient> ourKeys = singleton(new Recipient(testKey, uri));
+        final Set<Party> parties = singleton(new Party("http://other-node.com:8080"));
 
-        final PartyInfo initialInfo = new PartyInfo(ourUrl, ourKeys, parties);
+        final PartyInfo initialInfo = new PartyInfo(uri, ourKeys, parties);
 
         partyInfoStore.store(initialInfo);
         partyInfoStore.store(initialInfo);
@@ -55,13 +52,13 @@ public class PartyInfoStoreTest {
         final Set<Recipient> retrievedRecipients = partyInfoStore.getPartyInfo().getRecipients();
         final String fetchedUrl = partyInfoStore.getPartyInfo().getUrl();
 
-        assertThat(retrievedParties).hasSize(2).containsExactlyInAnyOrder(new Party("http://other-node.com:8080"),
-            new Party(ourUrl));
-        assertThat(retrievedRecipients).hasSize(1).containsExactly(
-            new Recipient(PublicKey.from("some-key".getBytes()), ourUrl)
-        );
-
-        assertThat(fetchedUrl).isEqualTo(ourUrl);
+        assertThat(fetchedUrl).isEqualTo(uri + "/");
+        assertThat(retrievedParties)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(new Party("http://other-node.com:8080"), new Party(uri + "/"));
+        assertThat(retrievedRecipients)
+            .hasSize(1)
+            .containsExactly(new Recipient(testKey, uri));
     }
 
 }


### PR DESCRIPTION
Remove stipulation that adding a new runtime peer is a private API call. In a non-test network it should be put behind a reverse proxy or other external infrastructure.

Changed auto discover behaviour in the case that it is disabled.
When a request is received, it first checks the sender is one of our known and accepted peers (else throw an error), and then only updates keys related to that peer.
It will not update the peer list at all, and will not add any keys relating to nodes who are not the sender.