### PR TITLE
allow grpc sendrequest from field to be optional

### DIFF
--- a/grpc-service/src/main/java/com/quorum/tessera/grpc/api/Convertor.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/grpc/api/Convertor.java
@@ -13,7 +13,9 @@ public class Convertor {
     public static com.quorum.tessera.api.model.SendRequest toModel(com.quorum.tessera.grpc.api.SendRequest grpcObject) {
         com.quorum.tessera.api.model.SendRequest sendRequest = new com.quorum.tessera.api.model.SendRequest();
         sendRequest.setTo(grpcObject.getToList().toArray(new String[0]));
-        sendRequest.setFrom(grpcObject.getFrom());
+        if (!grpcObject.getFrom().isEmpty()) {
+            sendRequest.setFrom(grpcObject.getFrom());
+        }
         sendRequest.setPayload(grpcObject.getPayload().toByteArray());
         return sendRequest;
     }

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/api/ConvertorTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/api/ConvertorTest.java
@@ -94,4 +94,19 @@ public class ConvertorTest {
         assertThat(result.getPayload()).isEqualTo("PAYLOAD".getBytes());
 
     }
+
+    @Test
+    public void toModelSendRequestEmptyFromField() {
+        SendRequest grpcSendRequest = SendRequest.newBuilder()
+            .setPayload(ByteString.copyFromUtf8("PAYLOAD"))
+            .addTo("TO1")
+            .build();
+
+        com.quorum.tessera.api.model.SendRequest result = Convertor.toModel(grpcSendRequest);
+        assertThat(result).isNotNull();
+        assertThat(result.getTo()).containsExactly("TO1");
+        assertThat(result.getFrom()).isNull();
+        assertThat(result.getPayload()).isEqualTo("PAYLOAD".getBytes());
+
+    }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/grpc/SendGrpcIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/grpc/SendGrpcIT.java
@@ -90,6 +90,21 @@ public class SendGrpcIT {
     }
 
     @Test
+    public void sendTransactionWithNoSender() {
+        SendRequest request = SendRequest.newBuilder()
+            .addTo("yGcjkFyZklTTXrn8+WIkYwicA2EGBn9wZFkctAad4X0=")
+            .setPayload(ByteString.copyFromUtf8("Zm9v"))
+            .build();
+
+        SendResponse result = blockingStub1.send(request);
+
+        assertThat(result).isNotNull();
+        result.getAllFields().forEach((k, v) -> System.out.println(k + " " + v));
+        assertThat(result.getKey()).isNotNull().isNotBlank();
+
+    }
+
+    @Test
     public void missingPayloadFails() {
 
         SendRequest request = SendRequest.newBuilder()

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/ReceiveRawIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/ReceiveRawIT.java
@@ -159,7 +159,7 @@ public class ReceiveRawIT {
     }
 
     @Test
-    public void fetchNonexistantTransactionFails() throws Exception {
+    public void fetchNonexistentTransactionFails() {
 
         final Response response = client.target(SERVER_URI)
             .path(RECEIVE_PATH)


### PR DESCRIPTION
Grpc objects generated from protobuf file when create new instance will initialise empty strings.

As the sender key will be populated with default public key only if it is null, this empty string can result in unintended behaviour i.e. throwing private for public key not found