### PR TITLE
Reorder server start order.

### DIFF
--- a/tessera-app/src/main/java/com/quorum/tessera/Launcher.java
+++ b/tessera-app/src/main/java/com/quorum/tessera/Launcher.java
@@ -117,16 +117,14 @@ public class Launcher {
             }
         }));
 
-        restServer.start();
         if (grpcServer.isPresent()) {
             grpcServer.get().start();
         }
         if (unixSocketServer.isPresent()) {
             unixSocketServer.get().start();
         }
+        restServer.start();
 
-       
-        
         countDown.await();
     }
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/CucumberWhitelistIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/CucumberWhitelistIT.java
@@ -1,0 +1,16 @@
+package com.quorum.tessera.test;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = "classpath:features/whitelist.feature",
+    glue = "transaction.rest",
+    tags = "@rest",
+    plugin = {"json:target/cucumber/rest.json"}
+)
+public class CucumberWhitelistIT {
+
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/ProcessManager.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/ProcessManager.java
@@ -46,6 +46,7 @@ public class ProcessManager {
         configs.put("B", getClass().getResource(String.format(pathTemplate, "2")));
         configs.put("C", getClass().getResource(String.format(pathTemplate, "3")));
         configs.put("D", getClass().getResource(String.format(pathTemplate, "4")));
+        configs.put("E", getClass().getResource(String.format(pathTemplate, "-whitelist")));
         this.configFiles = Collections.unmodifiableMap(configs);
     }
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuite.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuite.java
@@ -1,10 +1,7 @@
 package com.quorum.tessera.test.rest;
 
 import com.quorum.tessera.config.CommunicationType;
-import com.quorum.tessera.test.CucumberAdminIT;
-import com.quorum.tessera.test.CucumberRawIT;
-import com.quorum.tessera.test.CucumberRestIT;
-import com.quorum.tessera.test.ProcessManager;
+import com.quorum.tessera.test.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -26,7 +23,8 @@ import org.junit.runners.Suite;
     AdminConfigIT.class,
     CucumberRestIT.class,
     CucumberRawIT.class,
-    CucumberAdminIT.class
+    CucumberAdminIT.class,
+    CucumberWhitelistIT.class
 })
 public class RestSuite {
 

--- a/tests/acceptance-test/src/test/resources/features/whitelist.feature
+++ b/tests/acceptance-test/src/test/resources/features/whitelist.feature
@@ -1,0 +1,7 @@
+Feature: Whitelisting
+
+    @rest
+    Scenario: Node receives request from a host not in the whitelist
+    Given Node at port 7000
+	When a request is made against the node
+	Then the response code is UNAUTHORIZED

--- a/tests/acceptance-test/src/test/resources/grpc/config-whitelist.json
+++ b/tests/acceptance-test/src/test/resources/grpc/config-whitelist.json
@@ -3,7 +3,7 @@
     "jdbc": {
         "username": "sa",
         "password": "",
-        "url": "jdbc:h2:./target/h2/grpcwhitelist;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9093"
+        "url": "jdbc:h2:./target/h2/grpcwhitelist;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9095"
     },
     "server": {
         "port": 7000,

--- a/tests/acceptance-test/src/test/resources/grpc/config-whitelist.json
+++ b/tests/acceptance-test/src/test/resources/grpc/config-whitelist.json
@@ -1,0 +1,30 @@
+{
+    "useWhiteList": true,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:./target/h2/grpcwhitelist;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9093"
+    },
+    "server": {
+        "port": 7000,
+        "grpcPort" : 50000,
+        "hostName": "http://localhost",
+        "communicationType" : "GRPC"
+    },
+    "peer": [
+        {
+            "url": "http://0.0.0.0:50000"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "keyData": [
+            {
+                "privateKey": "YbOOFA4mwSSdGH6aFfGl2M7N1aiPOj5nHpD7GzJKSiA=",
+                "publicKey": "WxsJ4souK0mptNx1UGw6hb1WNNIbPhLPvW9GoaXau3Q="
+            }
+        ]
+    },
+    "alwaysSendTo": [],
+    "unixSocketFile": "${unixSocketPath}"
+}

--- a/tests/acceptance-test/src/test/resources/rest/config-whitelist.json
+++ b/tests/acceptance-test/src/test/resources/rest/config-whitelist.json
@@ -3,7 +3,7 @@
     "jdbc": {
         "username": "sa",
         "password": "",
-        "url": "jdbc:h2:./target/h2/restwhitelist;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9094"
+        "url": "jdbc:h2:./target/h2/restwhitelist;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9095"
     },
     "server": {
         "port": 7000,

--- a/tests/acceptance-test/src/test/resources/rest/config-whitelist.json
+++ b/tests/acceptance-test/src/test/resources/rest/config-whitelist.json
@@ -1,0 +1,28 @@
+{
+    "useWhiteList": true,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:./target/h2/restwhitelist;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9094"
+    },
+    "server": {
+        "port": 7000,
+        "hostName": "http://localhost"
+    },
+    "peer": [
+        {
+            "url": "http://0.0.0.0:8000"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "keyData": [
+            {
+                "privateKey": "YbOOFA4mwSSdGH6aFfGl2M7N1aiPOj5nHpD7GzJKSiA=",
+                "publicKey": "WxsJ4souK0mptNx1UGw6hb1WNNIbPhLPvW9GoaXau3Q="
+            }
+        ]
+    },
+    "alwaysSendTo": [],
+    "unixSocketFile": "${unixSocketPath}"
+}


### PR DESCRIPTION
Start the REST server last, so it doesn't have properties overwritten by the unix server so that servlets don't get overwritten.

A short term solution - should aim to get a unified server (purely Netty).