### PR TITLE
Update the maven surefire plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>3.0.0-M1</version>
                     <configuration>
                         <failIfNoTests>true</failIfNoTests>
                     </configuration>


### PR DESCRIPTION
Update the surefire maven plugin due to an issue with a particular JDK version (and specifically one that docker uses for maven builds)