### PR TITLE
Include base64 public key in exception message. Log key not found at

### DIFF
--- a/jaxrs-service/src/main/java/com/quorum/tessera/api/exception/KeyNotFoundExceptionMapper.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/api/exception/KeyNotFoundExceptionMapper.java
@@ -16,7 +16,8 @@ public class KeyNotFoundExceptionMapper implements ExceptionMapper<KeyNotFoundEx
 
     @Override
     public Response toResponse(final KeyNotFoundException e) {
-        LOGGER.error("", e);
+        LOGGER.debug("", e);
+        LOGGER.warn(e.getMessage());
 
         //TODO: change to 404
         return Response.status(Response.Status.BAD_REQUEST)

--- a/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoServiceImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoServiceImpl.java
@@ -105,7 +105,7 @@ public class PartyInfoServiceImpl implements PartyInfoService {
                 .stream()
                 .filter(recipient -> key.equals(recipient.getKey()))
                 .findAny()
-                .orElseThrow(() -> new KeyNotFoundException("Recipient not found"));
+                .orElseThrow(() -> new KeyNotFoundException("Recipient not found for key: "+ key.encodeToBase64()));
 
         return retrievedRecipientFromStore.getUrl();
     }

--- a/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoServiceTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoServiceTest.java
@@ -120,7 +120,7 @@ public class PartyInfoServiceTest {
 
         final PublicKey failingKey = PublicKey.from("otherKey".getBytes());
         final Throwable throwable = catchThrowable(() -> partyInfoService.getURLFromRecipientKey(failingKey));
-        assertThat(throwable).isInstanceOf(KeyNotFoundException.class).hasMessage("Recipient not found");
+        assertThat(throwable).isInstanceOf(KeyNotFoundException.class).hasMessage("Recipient not found for key: "+ failingKey.encodeToBase64());
 
         verify(partyInfoStore).getPartyInfo();
     }


### PR DESCRIPTION
debug level the message and status is returned to the client.