### PR TITLE
Change `"I'm up!"` to `"TM_READY"` for easy discovery

### DIFF
--- a/jaxrs-service/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
@@ -31,7 +31,7 @@ public class UpCheckResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @ApiResponses({@ApiResponse(code = 200, message = UPCHECK_RESPONSE)})
-    @ApiOperation(value = "Check if local P2PRestApp Node is up", produces = "I'm up")
+    @ApiOperation(value = "Check if local P2PRestApp Node is up", produces = "TM_READY")
     public String upCheck() {
 
         LOGGER.info("GET upcheck");

--- a/jaxrs-service/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
@@ -20,7 +20,7 @@ public class UpCheckResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpCheckResource.class);
 
-    private static final String UPCHECK_RESPONSE = "I'm up!";
+    private static final String UPCHECK_RESPONSE = "TM_READY";
 
     /**
      * Called to check if the application is running and responsive


### PR DESCRIPTION
Change `"I'm up!"` to `"TM_READY"` for easy discovery & safe search. Return codes should use limited char set (alpha numeric, upper case and underscore). Having `'`, mixed casing and punctuation complicates return codes.

Related to https://github.com/jpmorganchase/quorum-examples/issues/146