### PR TITLE
Make self-send check more robust

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/PayloadPublisher.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/PayloadPublisher.java
@@ -1,12 +1,24 @@
-
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.encryption.EncodedPayloadWithRecipients;
+import com.quorum.tessera.encryption.KeyNotFoundException;
 import com.quorum.tessera.encryption.PublicKey;
 
-
+/**
+ * Publishes messages from one node to another
+ */
 public interface PayloadPublisher {
-    
-    void publishPayload(EncodedPayloadWithRecipients encodedPayloadWithRecipients,PublicKey recipientKey);
-    
+
+    /**
+     * Formats, encodes and publishes encrypted messages using the target
+     * public key as the identifier, instead of the URL
+     *
+     * @param encodedPayloadWithRecipients the pre-formatted payload object
+     *                                     (i.e. with all recipients still present)
+     * @param recipientKey                 the target public key to publish the
+     *                                     payload to
+     * @throws KeyNotFoundException if the target public key is not known
+     */
+    void publishPayload(EncodedPayloadWithRecipients encodedPayloadWithRecipients, PublicKey recipientKey);
+
 }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/PayloadPublisherImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/PayloadPublisherImpl.java
@@ -42,7 +42,7 @@ public class PayloadPublisherImpl implements PayloadPublisher {
 
         if(enclave.getPublicKeys().contains(recipientKey)) {
             //we are trying to send something to ourselves - don't do it
-            LOGGER.debug("Trying to send message to ourselves with key {}", recipientKey.encodeToBase64());
+            LOGGER.debug("Trying to send message to ourselves with key {}, not publishing", recipientKey.encodeToBase64());
             return;
         }
 

--- a/tessera-core/src/main/resources/tessera-core-spring.xml
+++ b/tessera-core/src/main/resources/tessera-core-spring.xml
@@ -21,6 +21,7 @@
         <constructor-arg ref="payloadEncoder" />
         <constructor-arg ref="partyInfoService" />
         <constructor-arg ref="p2pClient" />
+        <constructor-arg ref="enclave" />
     </bean>
 
 
@@ -47,13 +48,13 @@
 
 
 
-    
-  
-    
+
+
+
     <bean id="p2pClientFactory" class="com.quorum.tessera.client.P2pClientFactory" factory-method="newFactory">
         <constructor-arg ref="config" />
     </bean>
-    
+
     <bean id="p2pClient" factory-bean="p2pClientFactory" factory-method="create">
         <constructor-arg ref="config"/>
     </bean>
@@ -100,7 +101,7 @@
     <bean id="keyConfig" factory-bean="config" factory-method="getKeys" />
 
 
-    <bean id="environmentVariableProvider" class="com.quorum.tessera.config.util.EnvironmentVariableProvider"></bean>
+    <bean id="environmentVariableProvider" class="com.quorum.tessera.config.util.EnvironmentVariableProvider"/>
 
     <bean name="keyPairConverter" class="com.quorum.tessera.keypairconverter.KeyPairConverter">
         <constructor-arg ref="config"/>

--- a/tessera-core/src/main/resources/tessera-core-spring.xml
+++ b/tessera-core/src/main/resources/tessera-core-spring.xml
@@ -47,10 +47,6 @@
     </bean>
 
 
-
-
-
-
     <bean id="p2pClientFactory" class="com.quorum.tessera.client.P2pClientFactory" factory-method="newFactory">
         <constructor-arg ref="config" />
     </bean>

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/PayloadPublisherTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/PayloadPublisherTest.java
@@ -44,7 +44,7 @@ public class PayloadPublisherTest {
 
     @After
     public void onTearDown() {
-        verifyNoMoreInteractions(payloadEncoder, partyInfoService, p2pClient);
+        verifyNoMoreInteractions(payloadEncoder, partyInfoService, p2pClient, enclave);
     }
 
     @Test
@@ -63,6 +63,8 @@ public class PayloadPublisherTest {
         );
 
         payloadPublisher.publishPayload(encodedPayloadWithRecipients, recipientKey);
+
+        verify(enclave).getPublicKeys();
     }
 
     @Test
@@ -88,6 +90,7 @@ public class PayloadPublisherTest {
         verify(partyInfoService).getURLFromRecipientKey(recipientKey);
         verify(payloadEncoder).encode(any(EncodedPayloadWithRecipients.class));
         verify(p2pClient).push(url, encodedBytes);
+        verify(enclave).getPublicKeys();
     }
 
 }


### PR DESCRIPTION
In certain cases, such as a misconfigured network, it is possible we think we are sending to ourselves but are infact not, based on the URL of the recipient. See issue https://github.com/jpmorganchase/tessera/issues/546 as an example.

Instead, the proper way of checking if we are sending to ourselves would be to check if the public key we are sending to is one of the keys that our own enclave manages.

In the case that the target URL is the same as ours, then the call will still go ahead and print what the target is (to identify misconfigured networks more easily).