### PR TITLE
Simplify the transaction resend logic

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoService.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoService.java
@@ -1,10 +1,7 @@
 package com.quorum.tessera.node;
 
 import com.quorum.tessera.encryption.PublicKey;
-import com.quorum.tessera.node.model.Party;
 import com.quorum.tessera.node.model.PartyInfo;
-
-import java.util.Set;
 
 public interface PartyInfoService {
 
@@ -17,7 +14,7 @@ public interface PartyInfoService {
 
     /**
      * Update the PartyInfo data store with the provided encoded data.This can happen when endpoint /partyinfo is triggered,
- or by a response from this node hitting another node /partyinfo endpoint
+     * or by a response from this node hitting another node /partyinfo endpoint
      *
      * @param partyInfo
      * @return updated PartyInfo object
@@ -31,14 +28,5 @@ public interface PartyInfoService {
      * @return the url the key's node is located at
      */
     String getURLFromRecipientKey(PublicKey key);
-
-    /**
-     * Searches the provided {@link PartyInfo} for recipients that haven't yet been saved to
-     * the list of all known hosts
-     *
-     * @param partyInfoWithUnsavedRecipients received party info that should be diffed
-     * @return the list of all unknown recipients
-     */
-    Set<Party> findUnsavedParties(PartyInfo partyInfoWithUnsavedRecipients);
 
 }

--- a/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoServiceImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoServiceImpl.java
@@ -11,8 +11,6 @@ import com.quorum.tessera.node.model.Recipient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,11 +35,11 @@ public class PartyInfoServiceImpl implements PartyInfoService {
 
 
         final Set<Party> initialParties = configService
-                .getPeers()
-                .stream()
-                .map(Peer::getUrl)
-                .map(Party::new)
-                .collect(toSet());
+            .getPeers()
+            .stream()
+            .map(Peer::getUrl)
+            .map(Party::new)
+            .collect(toSet());
 
         final Set<Recipient> ourKeys = enclave
             .getPublicKeys()
@@ -49,7 +47,6 @@ public class PartyInfoServiceImpl implements PartyInfoService {
             .map(key -> PublicKey.from(key.getKeyBytes()))
             .map(key -> new Recipient(key, advertisedUrl))
             .collect(toSet());
-
 
         partyInfoStore.store(new PartyInfo(advertisedUrl, ourKeys, initialParties));
 
@@ -96,8 +93,6 @@ public class PartyInfoServiceImpl implements PartyInfoService {
             .filter(recipient -> Objects.equals(recipient.getUrl(), incomingUrl))
             .collect(Collectors.toSet());
 
-        // TODO NL - check if we should add the unsaved parties to the resend party store (in the same way in which we are doing it in PartyInfoPoller)
-
         //TODO: instead of adding the peers every time, if a new peer is added at runtime then this should be added separately
         final Set<Party> parties = peerUrls.stream().map(Party::new).collect(toSet());
 
@@ -110,24 +105,14 @@ public class PartyInfoServiceImpl implements PartyInfoService {
     public String getURLFromRecipientKey(final PublicKey key) {
 
         final Recipient retrievedRecipientFromStore = partyInfoStore
-                .getPartyInfo()
-                .getRecipients()
-                .stream()
-                .filter(recipient -> key.equals(recipient.getKey()))
-                .findAny()
-                .orElseThrow(() -> new KeyNotFoundException("Recipient not found for key: "+ key.encodeToBase64()));
+            .getPartyInfo()
+            .getRecipients()
+            .stream()
+            .filter(recipient -> key.equals(recipient.getKey()))
+            .findAny()
+            .orElseThrow(() -> new KeyNotFoundException("Recipient not found for key: " + key.encodeToBase64()));
 
         return retrievedRecipientFromStore.getUrl();
-    }
-
-    @Override
-    public Set<Party> findUnsavedParties(final PartyInfo partyInfoWithUnsavedRecipients) {
-        final Set<Party> knownHosts = this.getPartyInfo().getParties();
-
-        final Set<Party> incomingRecipients = new HashSet<>(partyInfoWithUnsavedRecipients.getParties());
-        incomingRecipients.removeAll(knownHosts);
-
-        return Collections.unmodifiableSet(incomingRecipients);
     }
 
 }

--- a/tessera-core/src/main/java/com/quorum/tessera/sync/SyncPoller.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/sync/SyncPoller.java
@@ -54,6 +54,8 @@ public class SyncPoller implements Runnable {
     @Override
     public void run() {
 
+        this.resendPartyStore.addUnseenParties(partyInfoService.getPartyInfo().getParties());
+
         Optional<SyncableParty> nextPartyToSend = this.resendPartyStore.getNextParty();
 
         while (nextPartyToSend.isPresent()) {

--- a/tessera-core/src/main/java/com/quorum/tessera/sync/TransactionRequesterImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/sync/TransactionRequesterImpl.java
@@ -5,10 +5,10 @@ import com.quorum.tessera.api.model.ResendRequestType;
 import com.quorum.tessera.client.P2pClient;
 import com.quorum.tessera.encryption.Enclave;
 import com.quorum.tessera.encryption.PublicKey;
-import java.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Base64;
 import java.util.Objects;
 
 public class TransactionRequesterImpl implements TransactionRequester {
@@ -19,8 +19,7 @@ public class TransactionRequesterImpl implements TransactionRequester {
 
     private final P2pClient client;
 
-    public TransactionRequesterImpl(final Enclave enclave,
-            final P2pClient client) {
+    public TransactionRequesterImpl(final Enclave enclave, final P2pClient client) {
         this.enclave = Objects.requireNonNull(enclave);
         this.client = Objects.requireNonNull(client);
     }
@@ -31,10 +30,10 @@ public class TransactionRequesterImpl implements TransactionRequester {
         LOGGER.debug("Requesting transactions get resent for {}", uri);
 
         return this.enclave
-                .getPublicKeys() 
-                .stream()
-                .map(this::createRequestAllEntity)
-                .allMatch(req -> this.makeRequest(uri, req));
+            .getPublicKeys()
+            .stream()
+            .map(this::createRequestAllEntity)
+            .allMatch(req -> this.makeRequest(uri, req));
 
     }
 
@@ -42,7 +41,7 @@ public class TransactionRequesterImpl implements TransactionRequester {
      * Will make the desired request until succeeds or max tries has been
      * reached
      *
-     * @param uri the URI to call
+     * @param uri     the URI to call
      * @param request the request object to send
      */
     private boolean makeRequest(final String uri, final ResendRequest request) {

--- a/tessera-core/src/main/resources/tessera-core-spring.xml
+++ b/tessera-core/src/main/resources/tessera-core-spring.xml
@@ -35,21 +35,6 @@
         <constructor-arg ref="encryptedRawTransactionDAO" />
     </bean>
 
-    <!-- Node synchronization management-->
-    <bean name="resendPartyStore" class="com.quorum.tessera.sync.ResendPartyStoreImpl">
-        <constructor-arg ref="config" />
-    </bean>
-
-    <bean name="transactionRequester" class="com.quorum.tessera.sync.TransactionRequesterImpl">
-        <constructor-arg ref="enclave" />
-        <constructor-arg ref="p2pClient" />
-    </bean>
-
-
-
-    
-  
-    
     <bean id="p2pClientFactory" class="com.quorum.tessera.client.P2pClientFactory" factory-method="newFactory">
         <constructor-arg ref="config" />
     </bean>
@@ -73,7 +58,6 @@
     <bean name="partyInfoPoller" class="com.quorum.tessera.node.PartyInfoPoller">
         <constructor-arg ref="partyInfoService"/>
         <constructor-arg ref="partyInfoParser" />
-        <constructor-arg ref="resendPartyStore" />
         <constructor-arg ref="p2pClient"/>
     </bean>
 
@@ -178,27 +162,33 @@
 
     </bean>
 
-
-
-
+    <!-- Node synchronization management-->
     <beans profile="!disable-sync-poller">
+
+        <bean name="resendPartyStore" class="com.quorum.tessera.sync.ResendPartyStoreImpl"/>
+
+        <bean name="transactionRequester" class="com.quorum.tessera.sync.TransactionRequesterImpl">
+            <constructor-arg ref="enclave" />
+            <constructor-arg ref="p2pClient" />
+        </bean>
+
+        <bean name="syncPoller" class="com.quorum.tessera.sync.SyncPoller">
+            <constructor-arg>
+                <bean class="java.util.concurrent.Executors" factory-method="newCachedThreadPool"/>
+            </constructor-arg>
+            <constructor-arg ref="resendPartyStore" />
+            <constructor-arg ref="transactionRequester" />
+            <constructor-arg ref="partyInfoService"/>
+            <constructor-arg ref="partyInfoParser" />
+            <constructor-arg ref="p2pClient"/>
+        </bean>
+
         <bean class="com.quorum.tessera.threading.TesseraScheduledExecutor">
             <constructor-arg>
                 <bean class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
             </constructor-arg>
-            <constructor-arg>
-                <bean class="com.quorum.tessera.sync.SyncPoller">
-                    <constructor-arg>
-                        <bean class="java.util.concurrent.Executors" factory-method="newCachedThreadPool"/>
-                    </constructor-arg>
-                    <constructor-arg ref="resendPartyStore" />
-                    <constructor-arg ref="transactionRequester" />
-                    <constructor-arg ref="partyInfoService"/>
-                    <constructor-arg ref="partyInfoParser" />
-                    <constructor-arg ref="p2pClient"/>
-                </bean>
-            </constructor-arg>
-            <constructor-arg value="60"/>
+            <constructor-arg ref="syncPoller"/>
+            <constructor-arg value="60000"/>
             <constructor-arg value="5000"/>
         </bean>
     </beans>

--- a/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoServiceTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoServiceTest.java
@@ -127,54 +127,6 @@ public class PartyInfoServiceTest {
     }
 
     @Test
-    public void diffPartyInfoReturnsFullSetOnEmptyStore() {
-        doReturn(new PartyInfo("", emptySet(), emptySet())).when(partyInfoStore).getPartyInfo();
-
-        final PartyInfo incomingInfo = new PartyInfo("", emptySet(), NEW_PARTIES);
-
-        final Set<Party> unsavedParties = this.partyInfoService.findUnsavedParties(incomingInfo);
-
-        assertThat(unsavedParties)
-            .hasSize(2)
-            .containsExactlyInAnyOrder(NEW_PARTIES.toArray(new Party[0]));
-
-        verify(partyInfoStore).getPartyInfo();
-
-    }
-
-    @Test
-    public void diffPartyInfoReturnsEmptySetOnFullStore() {
-        doReturn(new PartyInfo("", emptySet(), NEW_PARTIES)).when(partyInfoStore).getPartyInfo();
-
-        final PartyInfo incomingInfo = new PartyInfo("", emptySet(), NEW_PARTIES);
-
-        final Set<Party> unsavedParties = this.partyInfoService.findUnsavedParties(incomingInfo);
-
-        assertThat(unsavedParties).isEmpty();
-
-        verify(partyInfoStore).getPartyInfo();
-
-    }
-
-    @Test
-    public void diffPartyInfoReturnsNodesNotInStore() {
-        doReturn(new PartyInfo("", emptySet(), singleton(new Party("url1"))))
-            .when(partyInfoStore)
-            .getPartyInfo();
-
-        final PartyInfo incomingInfo = new PartyInfo("", emptySet(), NEW_PARTIES);
-
-        final Set<Party> unsavedParties = this.partyInfoService.findUnsavedParties(incomingInfo);
-
-        assertThat(unsavedParties)
-            .hasSize(1)
-            .containsExactlyInAnyOrder(new Party("url2"));
-
-        verify(partyInfoStore).getPartyInfo();
-
-    }
-
-    @Test
     public void autoDiscoveryEnabledStoresAsIs() {
 
         final PartyInfo incomingPartyInfo = mock(PartyInfo.class);


### PR DESCRIPTION
This PR aims to untangle some of the logic involved with automatically resending transactions.

It was done to be part of issue https://github.com/jpmorganchase/tessera/issues/529, and does accomplish the main task of the issue (to avoid resending infinitely), but will still classes two peers with the same url, save for the "/", to be different and thus call resend twice. A followup PR will address that and resolve the issue entirely.

Instead of having to find new parties when receiving a request to "/resend" and pushing the parties into the resend queue, the poller now maintains its own list of parties it has seen, and pulls parties periodically from the internal party info store.

This way, the PartyInfoPoller/Service do not need to know anything about resending, only the opposite (resending needs to know about PartyInfoPoller/Service, which was already true anyway).