### PR TITLE
Remove the delete functionality from the exposed p2p app

### DIFF
--- a/jaxrs-service/src/main/java/com/quorum/tessera/p2p/TransactionResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/p2p/TransactionResource.java
@@ -1,23 +1,28 @@
 package com.quorum.tessera.p2p;
 
 import com.quorum.tessera.api.filter.Logged;
+import com.quorum.tessera.api.model.ResendRequest;
+import com.quorum.tessera.api.model.ResendResponse;
+import com.quorum.tessera.enclave.model.MessageHash;
 import com.quorum.tessera.transaction.TransactionManager;
-import com.quorum.tessera.api.model.*;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.Objects;
 
 import static javax.ws.rs.core.MediaType.*;
-import com.quorum.tessera.enclave.model.MessageHash;
 
 /**
  * Provides endpoints for dealing with transactions, including:
@@ -35,47 +40,6 @@ public class TransactionResource {
 
     public TransactionResource(TransactionManager delegate) {
         this.delegate = Objects.requireNonNull(delegate);
-    }
-
-    @Deprecated
-    @ApiOperation("Deprecated: Replaced by /transaction/{key} DELETE HTTP method")
-    @ApiResponses({
-        @ApiResponse(code = 200, message = "Status message", response = String.class),
-        @ApiResponse(code = 404, message = "If the entity doesn't exist")
-    })
-    @POST
-    @Path("delete")
-    @Consumes(APPLICATION_JSON)
-    @Produces(TEXT_PLAIN)
-    public Response delete(
-            @ApiParam(name = "deleteRequest", required = true, value = "Key data to be deleted")
-            @Valid final DeleteRequest deleteRequest) {
-
-        LOGGER.debug("Received deprecated delete request");
-
-        delegate.delete(deleteRequest);
-
-        return Response.status(Response.Status.OK)
-                .entity("Delete successful")
-                .build();
-    }
-
-    @ApiOperation("Delete single transaction from P2PRestApp node")
-    @ApiResponses({
-        @ApiResponse(code = 204, message = "Successful deletion"),
-        @ApiResponse(code = 404, message = "If the entity doesn't exist")
-    })
-    @DELETE
-    @Path("/transaction/{key}")
-    public Response deleteKey(@ApiParam("Encoded hash") @PathParam("key") final String key) {
-
-        LOGGER.debug("Received delete key request");
-
-        DeleteRequest delete = new DeleteRequest();
-        delete.setKey(key);
-        delegate.delete(delete);
-
-        return Response.noContent().build();
     }
 
     @ApiOperation("Resend transactions for given key or message hash/recipient")

--- a/jaxrs-service/src/test/java/com/quorum/tessera/jaxrs/JaxrsIT.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/jaxrs/JaxrsIT.java
@@ -1,26 +1,23 @@
 package com.quorum.tessera.jaxrs;
 
-import com.quorum.tessera.p2p.PartyInfoResource;
-import com.quorum.tessera.p2p.TransactionResource;
 import com.quorum.tessera.api.common.VersionResource;
-import com.quorum.tessera.api.model.DeleteRequest;
-import com.quorum.tessera.transaction.TransactionManagerImpl;
 import com.quorum.tessera.node.PartyInfoParser;
 import com.quorum.tessera.node.PartyInfoService;
 import com.quorum.tessera.node.model.PartyInfo;
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
-import static org.assertj.core.api.Assertions.assertThat;
+import com.quorum.tessera.p2p.PartyInfoResource;
+import com.quorum.tessera.p2p.TransactionResource;
+import com.quorum.tessera.transaction.TransactionManagerImpl;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = JaxrsITConfig.class)
@@ -75,17 +72,6 @@ public class JaxrsIT {
         verify(partyInfoService).updatePartyInfo(partyInfo);
         verify(partyInfoParser).to(partyInfo);
 
-    }
-
-    @Test
-    public void deleteKey() {
-        String key = "SomeKey";
-        Response response = transactionResource.deleteKey(key);
-        assertThat(response.getStatus()).isEqualTo(204);
-
-        verify(transactionManager).delete(any(DeleteRequest.class));
-
-        verifyNoMoreInteractions(transactionManager);
     }
 
 }

--- a/jaxrs-service/src/test/java/com/quorum/tessera/p2p/TransactionResourceTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/p2p/TransactionResourceTest.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.p2p;
 
-import com.quorum.tessera.api.model.DeleteRequest;
 import com.quorum.tessera.api.model.ResendRequest;
 import com.quorum.tessera.api.model.ResendResponse;
 import com.quorum.tessera.transaction.TransactionManager;
@@ -30,24 +29,6 @@ public class TransactionResourceTest {
     @After
     public void onTearDown() {
         verifyNoMoreInteractions(transactionManager);
-
-    }
-
-    @Test
-    public void deleteKey() {
-        Response result = transactionResource.deleteKey("somneKey");
-        assertThat(result.getStatus()).isEqualTo(204);
-
-        verify(transactionManager).delete(any(DeleteRequest.class));
-    }
-
-    @Test
-    public void delete() {
-        DeleteRequest deleteRequest = new DeleteRequest();
-
-        Response result = transactionResource.delete(deleteRequest);
-        assertThat(result.getStatus()).isEqualTo(200);
-        verify(transactionManager).delete(any(DeleteRequest.class));
 
     }
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/DeleteIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/DeleteIT.java
@@ -16,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeleteIT {
 
+    private static final String COUNT_ALL = "select count(*) from ENCRYPTED_TRANSACTION where hash = ?";
+
     private final PartyHelper partyHelper = new RestPartyHelper();
 
     @Test
@@ -37,8 +39,7 @@ public class DeleteIT {
 
         final String encodedHash = URLEncoder.encode(sendResponse.getKey(), UTF_8.toString());
 
-        try(PreparedStatement statement 
-                = sender.getDatabaseConnection().prepareStatement("select count(*) from ENCRYPTED_TRANSACTION where hash = ?")) {
+        try(PreparedStatement statement = sender.getDatabaseConnection().prepareStatement(COUNT_ALL)) {
             statement.setBytes(1, Base64.getDecoder().decode(sendResponse.getKey()));
             try(ResultSet rs = statement.executeQuery()) {
                 assertThat(rs.next()).isTrue();
@@ -48,7 +49,7 @@ public class DeleteIT {
 
         Client client = RestUtils.buildClient();
         //delete it
-        final Response resp = client.target(sender.getP2PUri())
+        final Response resp = client.target(sender.getQ2TUri())
                 .path("transaction")
                 .path(encodedHash)
                 .request()
@@ -61,7 +62,7 @@ public class DeleteIT {
     }
 
     @Test
-    public void deleteTransactionThatDoesntExist() throws Exception {
+    public void deleteTransactionThatDoesntExist() {
 
         final String madeupHash = Base64.getUrlEncoder().encodeToString("madeup".getBytes());
 
@@ -69,7 +70,7 @@ public class DeleteIT {
 
         Party party = partyHelper.getParties().findAny().get();
 
-        final Response response = client.target(party.getP2PUri())
+        final Response response = client.target(party.getQ2TUri())
                 .path("transaction")
                 .path(madeupHash)
                 .request()


### PR DESCRIPTION
When moving to the separated apps, the delete functionality was put into both P2P and Q2T apps. Allowing peers to delete transactions is dangerous and should not be allowed.