### PR TITLE
Add Admin app

### DIFF
--- a/config-cli/src/main/java/com/quorum/tessera/config/cli/AdminCliAdapter.java
+++ b/config-cli/src/main/java/com/quorum/tessera/config/cli/AdminCliAdapter.java
@@ -78,7 +78,7 @@ public class AdminCliAdapter implements CliAdapter {
 
         //TODO revisit - maybe the admin stuff should be reached via unix socket - in order to avoid security concerns
         ServerConfig serverConfig = config.getServerConfigs().stream()
-            .filter(c -> c.getApp() == AppType.P2P)
+            .filter(c -> c.getApp() == AppType.ADMIN)
             .findFirst().orElse(config.getServerConfigs().stream().findAny().get());
 
         Client restClient = clientFactory.buildFrom(serverConfig);

--- a/config-cli/src/test/resources/sample-config.json
+++ b/config-cli/src/test/resources/sample-config.json
@@ -17,6 +17,16 @@
             "communicationType" : "REST"
         },
         {
+            "app":"ADMIN",
+            "enabled": true,
+            "serverSocket":{
+                "type":"INET",
+                "port": 18090,
+                "hostName": "http://localhost"
+            },
+            "communicationType" : "REST"
+        },
+        {
             "app":"Q2T",
             "enabled": true,
             "serverSocket":{

--- a/config/src/main/java/com/quorum/tessera/config/AppType.java
+++ b/config/src/main/java/com/quorum/tessera/config/AppType.java
@@ -1,32 +1,33 @@
 package com.quorum.tessera.config;
 
-import com.quorum.tessera.config.apps.EnclaveApp;
-import com.quorum.tessera.config.apps.P2PApp;
-import com.quorum.tessera.config.apps.Q2TApp;
-import com.quorum.tessera.config.apps.TesseraApp;
-import com.quorum.tessera.config.apps.ThirdPartyApp;
+import com.quorum.tessera.config.apps.*;
 
+import javax.xml.bind.annotation.XmlEnumValue;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import javax.xml.bind.annotation.XmlEnumValue;
+
+import static java.util.Collections.singleton;
 
 public enum AppType {
     P2P(P2PApp.class,
-        new HashSet<>(Arrays.asList(CommunicationType.GRPC,CommunicationType.REST)),
-        new HashSet<>(Arrays.asList(InetServerSocket.class))),
+        new HashSet<>(Arrays.asList(CommunicationType.GRPC, CommunicationType.REST)),
+        singleton(InetServerSocket.class)),
     Q2T(Q2TApp.class,
         // TODO UNIX_SOCKET will be removed when we will have a netty server configurable for both unix/inet sockets
-        new HashSet<>(Arrays.asList(CommunicationType.GRPC,CommunicationType.REST,CommunicationType.UNIX_SOCKET)),
+        new HashSet<>(Arrays.asList(CommunicationType.GRPC, CommunicationType.REST, CommunicationType.UNIX_SOCKET)),
         new HashSet<>(Arrays.asList(InetServerSocket.class, UnixServerSocket.class))),
     @XmlEnumValue("ThirdParty")
     THIRD_PARTY(ThirdPartyApp.class,
-        new HashSet<>(Arrays.asList(CommunicationType.REST)),
-        new HashSet<>(Arrays.asList(InetServerSocket.class))),
+        singleton(CommunicationType.REST),
+        singleton(InetServerSocket.class)),
     ENCLAVE(EnclaveApp.class,
-            Collections.singleton(CommunicationType.REST),
-            Collections.singleton(InetServerSocket.class)
+        singleton(CommunicationType.REST),
+        singleton(InetServerSocket.class)
+    ),
+    ADMIN(AdminApp.class,
+        singleton(CommunicationType.REST),
+        singleton(InetServerSocket.class)
     );
 
     private final Class<? extends TesseraApp> intf;

--- a/config/src/main/java/com/quorum/tessera/config/apps/AdminApp.java
+++ b/config/src/main/java/com/quorum/tessera/config/apps/AdminApp.java
@@ -1,0 +1,4 @@
+package com.quorum.tessera.config.apps;
+
+public interface AdminApp extends TesseraApp {
+}

--- a/jaxrs-service/pom.xml
+++ b/jaxrs-service/pom.xml
@@ -135,8 +135,7 @@
                             </info>
 
                             <locations>
-                                <location>com.quorum.tessera.p2p.ConfigResource</location>
-   
+                                <location>com.quorum.tessera.admin.ConfigResource</location>
                             </locations>
                             <templatePath>${basedir}/src/main/swagger/strapdown.html.hbs</templatePath>
                             <outputPath>${project.build.directory}/generated-resources/swagger/admin.html</outputPath>

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/AdminRestApp.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/AdminRestApp.java
@@ -1,0 +1,21 @@
+package com.quorum.tessera.admin;
+
+import com.quorum.tessera.api.filter.GlobalFilter;
+import com.quorum.tessera.app.RestApp;
+import com.quorum.tessera.config.apps.AdminApp;
+import com.quorum.tessera.service.locator.ServiceLocator;
+
+import javax.ws.rs.ApplicationPath;
+
+/**
+ * An app that allows access to node management resources
+ */
+@GlobalFilter
+@ApplicationPath("/")
+public class AdminRestApp extends RestApp implements AdminApp {
+
+    public AdminRestApp(final ServiceLocator serviceLocator, final String contextName) {
+        super(serviceLocator, contextName);
+    }
+
+}

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
@@ -1,6 +1,7 @@
-package com.quorum.tessera.p2p;
+package com.quorum.tessera.admin;
 
 import com.quorum.tessera.config.Peer;
+import com.quorum.tessera.config.apps.AdminApp;
 import com.quorum.tessera.core.config.ConfigService;
 import com.quorum.tessera.node.PartyInfoService;
 import com.quorum.tessera.node.model.Party;
@@ -22,7 +23,7 @@ import static java.util.Collections.singleton;
 @Path("/config")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class ConfigResource {
+public class ConfigResource implements AdminApp {
 
     private final ConfigService configService;
 

--- a/jaxrs-service/src/main/resources/tessera-jaxrs-spring.xml
+++ b/jaxrs-service/src/main/resources/tessera-jaxrs-spring.xml
@@ -25,6 +25,13 @@
         </constructor-arg>
         <constructor-arg value="tessera-core-spring.xml" />
     </bean>
+
+    <bean id="adminJaxrsApplication" class="com.quorum.tessera.admin.AdminRestApp">
+        <constructor-arg>
+            <bean class="com.quorum.tessera.service.locator.ServiceLocator" factory-method="create" />
+        </constructor-arg>
+        <constructor-arg value="tessera-core-spring.xml" />
+    </bean>
     
     <!-- Resources -->
     <bean class="com.quorum.tessera.api.common.VersionResource"/>
@@ -47,7 +54,7 @@
         <constructor-arg ref="partyInfoParser" />
     </bean>
     
-    <bean class="com.quorum.tessera.p2p.ConfigResource">
+    <bean class="com.quorum.tessera.admin.ConfigResource">
         <constructor-arg ref="configService" />
         <constructor-arg ref="partyInfoService"/>
     </bean>

--- a/jaxrs-service/src/test/java/com/quorum/tessera/admin/AdminRestAppTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/admin/AdminRestAppTest.java
@@ -1,4 +1,4 @@
-package com.quorum.tessera.p2p;
+package com.quorum.tessera.admin;
 
 import com.quorum.tessera.service.locator.ServiceLocator;
 import org.junit.After;
@@ -7,18 +7,19 @@ import org.junit.Test;
 
 import static org.mockito.Mockito.*;
 
-public class P2PRestAppTest {
+public class AdminRestAppTest {
 
     private static final String contextName = "context";
 
     private ServiceLocator serviceLocator;
 
-    private P2PRestApp p2PRestApp;
+    private AdminRestApp adminRestApp;
 
     @Before
     public void setUp() {
-        serviceLocator = mock(ServiceLocator.class);
-        p2PRestApp = new P2PRestApp(serviceLocator, contextName);
+        this.serviceLocator = mock(ServiceLocator.class);
+
+        this.adminRestApp = new AdminRestApp(serviceLocator, contextName);
     }
 
     @After
@@ -28,7 +29,10 @@ public class P2PRestAppTest {
 
     @Test
     public void getSingletons() {
-        p2PRestApp.getSingletons();
+        this.adminRestApp.getSingletons();
+
         verify(serviceLocator).getServices(contextName);
     }
+
 }
+

--- a/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
@@ -1,4 +1,4 @@
-package com.quorum.tessera.p2p;
+package com.quorum.tessera.admin;
 
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.core.config.ConfigService;

--- a/tests/acceptance-test/src/test/java/admin/cmd/CmdSteps.java
+++ b/tests/acceptance-test/src/test/java/admin/cmd/CmdSteps.java
@@ -47,7 +47,7 @@ public class CmdSteps implements En {
         Then("a peer is added to party", () -> {
 
             Response response = Stream.of(subjectNode)
-                .map(Party::getP2PUri)
+                .map(Party::getAdminUri)
                 .map(client::target)
                 .map(t -> t.path("config"))
                 .map(t -> t.path("peers"))

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/Party.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/Party.java
@@ -17,6 +17,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class Party {
 
@@ -24,6 +25,7 @@ public class Party {
 
     private final URI p2pUri;
     private final URI q2tUri;
+    private final URI adminUri;
 
     private final Config config;
 
@@ -51,8 +53,13 @@ public class Party {
             .filter(sc -> sc.getApp() == AppType.Q2T)
             .findFirst()
             .get();
-
         this.q2tUri = q2tServerConfig.getServerUri();
+
+        Optional<ServerConfig> adminServerConfig = config.getServerConfigs()
+            .stream()
+            .filter(sc -> sc.getApp() == AppType.ADMIN)
+            .findFirst();
+        this.adminUri = adminServerConfig.map(ServerConfig::getServerUri).orElse(null);
         
         this.alias = Objects.requireNonNull(alias);
 
@@ -64,6 +71,10 @@ public class Party {
 
     public URI getP2PUri() {
         return p2pUri;
+    }
+
+    public URI getAdminUri() {
+        return adminUri;
     }
 
     public URI getQ2TUri() {

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/AdminConfigIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/AdminConfigIT.java
@@ -29,7 +29,7 @@ public class AdminConfigIT {
 
         Peer peer = new Peer(url);
 
-        Response response = client.target(party.getP2PUri())
+        Response response = client.target(party.getAdminUri())
             .path("config")
             .path("peers")
             .request(MediaType.APPLICATION_JSON)

--- a/tests/acceptance-test/src/test/resources/rest/config1.json
+++ b/tests/acceptance-test/src/test/resources/rest/config1.json
@@ -5,25 +5,38 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/rest1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9090"
     },
-    "serverConfigs" : [ {
-      "app" : "Q2T",
-      "enabled" : true,
-      "serverSocket" : {
-         "type" : "INET",
-         "hostName" : "http://localhost",
-         "port" : 18080
-      },
-      "communicationType" : "REST"
-   }, {
-      "app" : "P2P",
-      "enabled" : true,
-      "serverSocket" : {
-         "type" : "INET",
-         "hostName" : "http://localhost",
-         "port" : 8080
-      },
-      "communicationType" : "REST"
-   } ],
+    "serverConfigs": [
+        {
+            "app": "Q2T",
+            "enabled": true,
+            "serverSocket": {
+                "type": "INET",
+                "hostName": "http://localhost",
+                "port": 18080
+            },
+            "communicationType": "REST"
+        },
+        {
+            "app": "P2P",
+            "enabled": true,
+            "serverSocket": {
+                "type": "INET",
+                "hostName": "http://localhost",
+                "port": 8080
+            },
+            "communicationType": "REST"
+        },
+        {
+            "app": "ADMIN",
+            "enabled": true,
+            "serverSocket": {
+                "type": "INET",
+                "hostName": "http://localhost",
+                "port": 28080
+            },
+            "communicationType": "REST"
+        }
+    ],
     "peer": [
         {
             "url": "http://localhost:8081/"

--- a/tests/acceptance-test/src/test/resources/rest/config2.json
+++ b/tests/acceptance-test/src/test/resources/rest/config2.json
@@ -5,26 +5,36 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/rest2;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9091"
     },
-    "serverConfigs":[
+    "serverConfigs": [
         {
-            "app":"Q2T",
+            "app": "Q2T",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
+            "serverSocket": {
+                "type": "INET",
                 "port": 18081,
                 "hostName": "http://localhost"
             },
-            "communicationType" : "REST"
+            "communicationType": "REST"
         },
         {
-            "app":"P2P",
+            "app": "P2P",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
+            "serverSocket": {
+                "type": "INET",
                 "port": 8081,
                 "hostName": "http://localhost"
             },
-            "communicationType" : "REST"
+            "communicationType": "REST"
+        },
+        {
+            "app": "ADMIN",
+            "enabled": true,
+            "serverSocket": {
+                "type": "INET",
+                "hostName": "http://localhost",
+                "port": 28081
+            },
+            "communicationType": "REST"
         }
     ],
     "peer": [

--- a/tests/acceptance-test/src/test/resources/rest/config3.json
+++ b/tests/acceptance-test/src/test/resources/rest/config3.json
@@ -5,26 +5,36 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/rest3;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9092"
     },
-    "serverConfigs":[
+    "serverConfigs": [
         {
-            "app":"Q2T",
+            "app": "Q2T",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
+            "serverSocket": {
+                "type": "INET",
                 "port": 18082,
                 "hostName": "http://localhost"
             },
-            "communicationType" : "REST"
+            "communicationType": "REST"
         },
         {
-            "app":"P2P",
+            "app": "P2P",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
+            "serverSocket": {
+                "type": "INET",
                 "port": 8082,
                 "hostName": "http://localhost"
             },
-            "communicationType" : "REST"
+            "communicationType": "REST"
+        },
+        {
+            "app": "ADMIN",
+            "enabled": true,
+            "serverSocket": {
+                "type": "INET",
+                "hostName": "http://localhost",
+                "port": 28082
+            },
+            "communicationType": "REST"
         }
     ],
     "peer": [

--- a/tests/acceptance-test/src/test/resources/rest/config4.json
+++ b/tests/acceptance-test/src/test/resources/rest/config4.json
@@ -5,26 +5,36 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/rest4;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9094"
     },
-    "serverConfigs":[
+    "serverConfigs": [
         {
-            "app":"Q2T",
+            "app": "Q2T",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
+            "serverSocket": {
+                "type": "INET",
                 "port": 18083,
                 "hostName": "http://localhost"
             },
-            "communicationType" : "REST"
+            "communicationType": "REST"
         },
         {
-            "app":"P2P",
+            "app": "P2P",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
+            "serverSocket": {
+                "type": "INET",
                 "port": 8083,
                 "hostName": "http://localhost"
             },
-            "communicationType" : "REST"
+            "communicationType": "REST"
+        },
+        {
+            "app": "ADMIN",
+            "enabled": true,
+            "serverSocket": {
+                "type": "INET",
+                "hostName": "http://localhost",
+                "port": 28083
+            },
+            "communicationType": "REST"
         }
     ],
     "peer": [


### PR DESCRIPTION
Adds an "Admin app" that contains API endpoints for node management resources, which may require different access settings (read: TLS) than the 3rd Party app.

Fixes https://github.com/jpmorganchase/tessera/issues/543