### PR TITLE
Add checkstyles for token placement

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -54,18 +54,20 @@
         <module name="TypecastParenPad"/>
         <module name="SingleSpaceSeparator"/>
 
+        <!--Cannot have any whitespace before this token-->
         <module name="NoWhitespaceBefore">
             <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, GENERIC_END, ELLIPSIS, METHOD_REF"/>
             <property name="allowLineBreaks" value="false"/>
         </module>
+        <!--Can only have whitespace before this token if it's first token on line-->
         <module name="NoWhitespaceBefore">
             <property name="tokens" value="DOT"/>
             <property name="allowLineBreaks" value="true"/>
         </module>
 
+        <!--No whitespace directly after this token-->
         <module name="NoWhitespaceAfter">
-            <property name="tokens" value="AT, INC, DEC, UNARY_MINUS, UNARY_PLUS"/>
-            <property name="tokens" value="BNOT, LNOT, DOT, ARRAY_DECLARATOR, INDEX_OP, METHOD_REF"/>
+            <property name="tokens" value="AT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT, DOT, ARRAY_DECLARATOR, INDEX_OP, METHOD_REF"/>
         </module>
 
         <!-- Make sure that method calls have no space between method name and left parenthesis -->
@@ -76,21 +78,50 @@
 
         <!-- These separators (. @ ::) cannot appear at end of a line-->
         <module name="SeparatorWrap">
-            <property name="tokens" value="DOT"/>
-            <property name="tokens" value="AT"/>
-            <property name="tokens" value="METHOD_REF"/>
+            <property name="tokens" value="DOT, AT, METHOD_REF"/>
             <property name="option" value="nl"/>
         </module>
-
         <!-- These separators (, ;) cannot appear at start of a line-->
         <module name="SeparatorWrap">
-            <property name="tokens" value="COMMA"/>
-            <property name="tokens" value="SEMI"/>
+            <property name="tokens" value="COMMA, SEMI"/>
             <property name="option" value="EOL"/>
         </module>
 
         <module name="NoLineWrap">
             <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+        </module>
+
+        <!-- Cannot be the first token on the line -->
+        <module name="OperatorWrap">
+            <property name="option" value="eol"/>
+
+            <property name="tokens" value="TYPE_EXTENSION_AND, SR, BSR, SL, BXOR, BOR, BAND"/>
+            <property name="tokens" value="SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN"/>
+
+            <!--<property name="tokens" value="PLUS"/>--> <!-- TODO: uncomment -->
+            <property name="tokens" value="DIV, MINUS, STAR, MOD"/>
+            <property name="tokens" value="PLUS_ASSIGN, DIV_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN"/>
+            <property name="tokens" value="LITERAL_INSTANCEOF, METHOD_REF, QUESTION, COLON"/>
+            <property name="tokens" value="GE, GT, LE, LT"/>
+            <!--<property name="tokens" value="LOR, LAND"/>--> <!-- TODO: uncomment -->
+            <property name="tokens" value="EQUAL, NOT_EQUAL"/>
+        </module>
+        <!-- Cannot be last token on the line-->
+        <module name="OperatorWrap">
+            <property name="option" value="nl"/>
+
+            <!--<property name="tokens" value="ASSIGN"/>--> <!-- TODO: uncomment -->
+
+            <property name="tokens" value="TYPE_EXTENSION_AND, SR, BSR, SL, BXOR, BOR, BAND"/>
+            <property name="tokens" value="SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN"/>
+
+            <!--<property name="tokens" value="PLUS"/>--> <!-- TODO: uncomment -->
+            <property name="tokens" value="DIV, MINUS, STAR, MOD"/>
+            <property name="tokens" value="PLUS_ASSIGN, DIV_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN"/>
+            <property name="tokens" value="LITERAL_INSTANCEOF, METHOD_REF, QUESTION, COLON"/>
+            <property name="tokens" value="GE, GT, LE, LT"/>
+            <!--<property name="tokens" value="LOR, LAND"/>--> <!-- TODO: uncomment -->
+            <property name="tokens" value="EQUAL, NOT_EQUAL"/>
         </module>
 
         <!-- End: Whitespace -->

--- a/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/BaseKey.java
+++ b/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/BaseKey.java
@@ -1,20 +1,15 @@
-
 package com.quorum.tessera.encryption;
 
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.stream.Stream;
 
-
 public abstract class BaseKey implements Key {
-    
+
     private final byte[] keyBytes;
 
-    private final String base64Encoded;
-    
     protected BaseKey(byte[] keyBytes) {
         this.keyBytes = keyBytes;
-        this.base64Encoded = Base64.getEncoder().encodeToString(keyBytes);
     }
 
     @Override
@@ -24,14 +19,12 @@ public abstract class BaseKey implements Key {
 
     @Override
     public String encodeToBase64() {
-        return base64Encoded;
+        return Base64.getEncoder().encodeToString(keyBytes);
     }
 
-    
     @Override
     public final boolean equals(Object arg0) {
-        return getClass().isInstance(arg0)
-                && Arrays.equals(keyBytes, getClass().cast(arg0).getKeyBytes());
+        return getClass().isInstance(arg0) && Arrays.equals(keyBytes, getClass().cast(arg0).getKeyBytes());
     }
 
     @Override
@@ -41,18 +34,15 @@ public abstract class BaseKey implements Key {
 
     @Override
     public final String toString() {
-        
+
         final String typeName = Stream.of(getClass())
-                .map(Class::getInterfaces)
-                .flatMap(Stream::of)
-                .map(Class::getSimpleName)
-                .findFirst()
-                .get();
-        
-        return String.format("%s[%s]",typeName,encodeToBase64());
+            .map(Class::getInterfaces)
+            .flatMap(Stream::of)
+            .map(Class::getSimpleName)
+            .findFirst()
+            .get();
+
+        return String.format("%s[%s]", typeName, encodeToBase64());
     }
 
-    
-    
-    
 }

--- a/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/KeyManagerImpl.java
+++ b/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/KeyManagerImpl.java
@@ -8,81 +8,80 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class KeyManagerImpl implements KeyManager {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyManagerImpl.class);
 
     /**
      * A list of all pub/priv keys that are attached to this node
      */
     private final Set<KeyPair> localKeys;
-    
+
     private final KeyPair defaultKeys;
-    
+
     private final Set<PublicKey> forwardingPublicKeys;
-    
+
     public KeyManagerImpl(final Collection<KeyPair> keys, Collection<PublicKey> forwardKeys) {
-        
-        this.localKeys = keys.stream().collect(Collectors.toSet());
-        
+
+        this.localKeys = new HashSet<>(keys);
+
         this.defaultKeys = localKeys.iterator().next();
-        
-        this.forwardingPublicKeys = forwardKeys.stream().collect(Collectors.toSet());
+
+        this.forwardingPublicKeys = new HashSet<>(forwardKeys);
     }
-    
+
     @Override
     public PublicKey getPublicKeyForPrivateKey(final PrivateKey privateKey) {
         LOGGER.debug("Attempting to find public key for the private key {}", privateKey);
-        
+
         final PublicKey publicKey = localKeys
-                .stream()
-                .filter(keypair -> Objects.equals(keypair.getPrivateKey(), privateKey))
-                .findFirst()
-                .map(KeyPair::getPublicKey)
-                .orElseThrow(() -> new KeyNotFoundException("Private key " + 
-                                privateKey.encodeToBase64()
-                                + " not found when searching for public key")
-                );
-        
+            .stream()
+            .filter(keypair -> Objects.equals(keypair.getPrivateKey(), privateKey))
+            .findFirst()
+            .map(KeyPair::getPublicKey)
+            .orElseThrow(() -> new KeyNotFoundException(
+                "Private key " + privateKey.encodeToBase64() + " not found when searching for public key"
+            ));
+
         LOGGER.debug("Found public key {} for private key {}", publicKey, privateKey);
-        
+
         return publicKey;
     }
-    
-    
+
+
     @Override
     public PrivateKey getPrivateKeyForPublicKey(final PublicKey publicKey) {
         LOGGER.debug("Attempting to find private key for the public key {}", publicKey);
 
         final PrivateKey privateKey = localKeys
-                .stream()
-                .filter(keypair -> Objects.equals(keypair.getPublicKey(), publicKey))
-                .findFirst()
-                .map(KeyPair::getPrivateKey)
-                .orElseThrow(() -> new KeyNotFoundException("Public key " + publicKey.encodeToBase64()
-                                + " not found when searching for private key")
-                );
-        
+            .stream()
+            .filter(keypair -> Objects.equals(keypair.getPublicKey(), publicKey))
+            .findFirst()
+            .map(KeyPair::getPrivateKey)
+            .orElseThrow(() -> new KeyNotFoundException(
+                "Public key " + publicKey.encodeToBase64() + " not found when searching for private key"
+            ));
+
         LOGGER.debug("Found private key {} for public key {}", privateKey, publicKey);
-        
+
         return privateKey;
     }
-    
+
     @Override
     public Set<PublicKey> getPublicKeys() {
         return localKeys
-                .stream()
-                .map(KeyPair::getPublicKey)
-                .collect(Collectors.toSet());
+            .stream()
+            .map(KeyPair::getPublicKey)
+            .collect(Collectors.toSet());
     }
-    
+
     @Override
     public PublicKey defaultPublicKey() {
         return PublicKey.from(defaultKeys.getPublicKey().getKeyBytes());
     }
-    
+
     @Override
     public Set<PublicKey> getForwardingKeys() {
         return this.forwardingPublicKeys;
     }
-    
+
 }

--- a/shared/src/main/java/com/quorum/tessera/reflect/ReflectCallback.java
+++ b/shared/src/main/java/com/quorum/tessera/reflect/ReflectCallback.java
@@ -1,32 +1,22 @@
 package com.quorum.tessera.reflect;
 
-import java.lang.reflect.InvocationTargetException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @FunctionalInterface
 public interface ReflectCallback<T> {
-    
-    Logger LOGGER = LoggerFactory.getLogger(ReflectCallback.class);
-    
-    T doExecute() throws ClassNotFoundException,
-            NoSuchFieldException,
-            IllegalArgumentException,
-            IllegalAccessException,
-            NoSuchMethodException,
-            InvocationTargetException,
-            InstantiationException;
 
+    Logger LOGGER = LoggerFactory.getLogger(ReflectCallback.class);
+
+    T doExecute() throws ReflectiveOperationException;
 
     static <T> T execute(ReflectCallback<T> callback) {
         try {
             return callback.doExecute();
-        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException
-                | IllegalArgumentException | IllegalAccessException | NoSuchFieldException | ClassNotFoundException ex) {
+        } catch (ReflectiveOperationException ex) {
             LOGGER.error(null, ex);
             throw new ReflectException(ex);
-        }        
-        
+        }
     }
-    
+
 }

--- a/shared/src/test/java/com/quorum/tessera/reflect/ReflectCallbackTest.java
+++ b/shared/src/test/java/com/quorum/tessera/reflect/ReflectCallbackTest.java
@@ -1,7 +1,8 @@
 package com.quorum.tessera.reflect;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
@@ -11,23 +12,16 @@ public class ReflectCallbackTest {
     public void executeThrowsClassNotFoundException() throws Exception {
         ReflectCallback callback = mock(ReflectCallback.class);
 
-        doThrow(ClassNotFoundException.class)
-                .when(callback)
-                .doExecute();
+        doThrow(ClassNotFoundException.class).when(callback).doExecute();
 
         ReflectCallback.execute(callback);
-
     }
 
     @Test
-    public void execute() throws Exception {
+    public void execute() {
         ReflectCallback<String> callback = () -> "Expected value";
-
 
         String result = ReflectCallback.execute(callback);
         assertThat(result).isEqualTo("Expected value");
-        
-        
-        
     }
 }


### PR DESCRIPTION
1. Add check style checks for token placement

The following symbols cannot appear at *start* or *end* of a line:
```
&   >>   >>>  <<   ^   | 
>>= >>>= <<= ^= &= |=
/ - * %
+=  /=  -=  *=
instanceof   ::   ?   :
<= < > >=
==  !=
```

The following symbols should be activated at some point, but have too many violations at the moment:
```
||   &&   +
```

2. Fix existing issues and associated test files that create violations (although they were violations of the commented out code before realising there were too many, they are still fixed here)


`&&` being on a newline inside the `equals` method
`+` being on both a newline and end-of-line
`|` being on a newline due to too many exception types in catch statement - contracted all the types into their parent type