### PR TITLE
Retrieve node key pair information using admin API

### DIFF
--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.admin;
 
-import com.quorum.tessera.config.KeyData;
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.config.apps.AdminApp;
 import com.quorum.tessera.core.config.ConfigService;
@@ -104,10 +103,8 @@ public class ConfigResource implements AdminApp {
             throw new NotFoundException("No key pair found with public key " + base64PublicKey);
         }
 
-        //TODO use dedicated transport object instead?
-        KeyData responseData = new KeyData();
+        PublicKeyResponse responseData = new PublicKeyResponse();
         responseData.setPublicKey(base64PublicKey);
-        responseData.setPrivateKey("REDACTED");
 
         return Response.ok(responseData).build();
     }
@@ -117,22 +114,16 @@ public class ConfigResource implements AdminApp {
     public Response getKeyPairs() {
         Set<PublicKey> publicKeys = configService.getPublicKeys();
 
-        if(publicKeys.isEmpty()) {
-            throw new NotFoundException("No key pairs found");
-        }
-
-        //TODO use dedicated transport object instead?
-        List<KeyData> keyPairData = publicKeys.stream()
+        List<PublicKeyResponse> responseData = publicKeys.stream()
             .map(PublicKey::encodeToBase64)
-            .map(publicKey -> {
-                KeyData kd = new KeyData();
-                kd.setPublicKey(publicKey);
-                kd.setPrivateKey("REDACTED");
-                return kd;
+            .map(key -> {
+                PublicKeyResponse pkr = new PublicKeyResponse();
+                pkr.setPublicKey(key);
+                return pkr;
             })
             .collect(Collectors.toList());
 
-        return Response.ok(new GenericEntity<List<KeyData>>(keyPairData){}).build();
+        return Response.ok(new GenericEntity<List<PublicKeyResponse>>(responseData){}).build();
     }
 
 }

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
@@ -103,8 +103,7 @@ public class ConfigResource implements AdminApp {
             throw new NotFoundException("No key pair found with public key " + base64PublicKey);
         }
 
-        PublicKeyResponse responseData = new PublicKeyResponse();
-        responseData.setPublicKey(base64PublicKey);
+        PublicKeyResponse responseData = new PublicKeyResponse(base64PublicKey);
 
         return Response.ok(responseData).build();
     }
@@ -116,11 +115,7 @@ public class ConfigResource implements AdminApp {
 
         List<PublicKeyResponse> responseData = publicKeys.stream()
             .map(PublicKey::encodeToBase64)
-            .map(key -> {
-                PublicKeyResponse pkr = new PublicKeyResponse();
-                pkr.setPublicKey(key);
-                return pkr;
-            })
+            .map(PublicKeyResponse::new)
             .collect(Collectors.toList());
 
         return Response.ok(new GenericEntity<List<PublicKeyResponse>>(responseData){}).build();

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
@@ -104,6 +104,7 @@ public class ConfigResource implements AdminApp {
             throw new NotFoundException("No key pair found with public key " + base64PublicKey);
         }
 
+        //TODO use dedicated transport object instead?
         KeyData responseData = new KeyData();
         responseData.setPublicKey(base64PublicKey);
         responseData.setPrivateKey("REDACTED");
@@ -120,6 +121,7 @@ public class ConfigResource implements AdminApp {
             throw new NotFoundException("No key pairs found");
         }
 
+        //TODO use dedicated transport object instead?
         List<KeyData> keyPairData = publicKeys.stream()
             .map(PublicKey::encodeToBase64)
             .map(publicKey -> {

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/ConfigResource.java
@@ -1,21 +1,26 @@
 package com.quorum.tessera.admin;
 
+import com.quorum.tessera.config.KeyData;
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.config.apps.AdminApp;
 import com.quorum.tessera.core.config.ConfigService;
+import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.node.PartyInfoService;
 import com.quorum.tessera.node.model.Party;
 import com.quorum.tessera.node.model.PartyInfo;
 
 import javax.validation.Valid;
 import javax.ws.rs.*;
+import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
-import javax.ws.rs.core.GenericEntity;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -83,6 +88,49 @@ public class ConfigResource implements AdminApp {
 
         return Response.ok(new GenericEntity<List<Peer>>(peers) {
         }).build();
+    }
+
+    @GET
+    @Path("/keypairs/{publicKey}")
+    public Response getKeyPair(@PathParam("publicKey") String base64PublicKey) {
+
+        Base64.Decoder base64Decoder = Base64.getDecoder();
+
+        PublicKey publicKey = PublicKey.from(base64Decoder.decode(base64PublicKey));
+
+        Set<PublicKey> publicKeys = configService.getPublicKeys();
+
+        if(!publicKeys.contains(publicKey)) {
+            throw new NotFoundException("No key pair found with public key " + base64PublicKey);
+        }
+
+        KeyData responseData = new KeyData();
+        responseData.setPublicKey(base64PublicKey);
+        responseData.setPrivateKey("REDACTED");
+
+        return Response.ok(responseData).build();
+    }
+
+    @GET
+    @Path("/keypairs")
+    public Response getKeyPairs() {
+        Set<PublicKey> publicKeys = configService.getPublicKeys();
+
+        if(publicKeys.isEmpty()) {
+            throw new NotFoundException("No key pairs found");
+        }
+
+        List<KeyData> keyPairData = publicKeys.stream()
+            .map(PublicKey::encodeToBase64)
+            .map(publicKey -> {
+                KeyData kd = new KeyData();
+                kd.setPublicKey(publicKey);
+                kd.setPrivateKey("REDACTED");
+                return kd;
+            })
+            .collect(Collectors.toList());
+
+        return Response.ok(new GenericEntity<List<KeyData>>(keyPairData){}).build();
     }
 
 }

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/PublicKeyResponse.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/PublicKeyResponse.java
@@ -10,11 +10,15 @@ class PublicKeyResponse {
     @XmlElement
     private String publicKey;
 
-    PublicKeyResponse() {
-
+    //No args constructor required for jaxb marshalling
+    private PublicKeyResponse() {
     }
 
-    void setPublicKey(String publicKey) {
+    PublicKeyResponse(String publicKey) {
         this.publicKey = publicKey;
+    }
+
+    String getPublicKey() {
+        return this.publicKey;
     }
 }

--- a/jaxrs-service/src/main/java/com/quorum/tessera/admin/PublicKeyResponse.java
+++ b/jaxrs-service/src/main/java/com/quorum/tessera/admin/PublicKeyResponse.java
@@ -1,0 +1,20 @@
+package com.quorum.tessera.admin;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+class PublicKeyResponse {
+
+    @XmlElement
+    private String publicKey;
+
+    PublicKeyResponse() {
+
+    }
+
+    void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+}

--- a/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
@@ -143,8 +143,7 @@ public class ConfigResourceTest {
         when(publicKeys.contains(publicKey)).thenReturn(true);
         when(configService.getPublicKeys()).thenReturn(publicKeys);
 
-        PublicKeyResponse expected = new PublicKeyResponse();
-        expected.setPublicKey(base64Pub);
+        PublicKeyResponse expected = new PublicKeyResponse(base64Pub);
 
         Response response = configResource.getKeyPair(base64Pub);
 
@@ -186,11 +185,9 @@ public class ConfigResourceTest {
         when(configService.getPublicKeys()).thenReturn(publicKeys);
 
         final List<PublicKeyResponse> expected = new ArrayList<>();
-        PublicKeyResponse pkrA = new PublicKeyResponse();
-        pkrA.setPublicKey(keyA);
+        PublicKeyResponse pkrA = new PublicKeyResponse(keyA);
 
-        PublicKeyResponse pkrB = new PublicKeyResponse();
-        pkrB.setPublicKey(keyB);
+        PublicKeyResponse pkrB = new PublicKeyResponse(keyB);
 
         expected.add(pkrA);
         expected.add(pkrB);

--- a/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
@@ -107,7 +107,7 @@ public class ConfigResourceTest {
 
     @Test
     public void getPeerNotFound() {
-        final Peer peer = new Peer("getPeerNoptFound");
+        final Peer peer = new Peer("getPeerNotFound");
         when(configService.getPeers()).thenReturn(singletonList(peer));
 
         final Throwable throwable = catchThrowable(() -> this.configResource.getPeer(2));

--- a/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/admin/ConfigResourceTest.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.admin;
 
-import com.quorum.tessera.config.KeyData;
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.core.config.ConfigService;
 import com.quorum.tessera.encryption.PublicKey;
@@ -144,9 +143,8 @@ public class ConfigResourceTest {
         when(publicKeys.contains(publicKey)).thenReturn(true);
         when(configService.getPublicKeys()).thenReturn(publicKeys);
 
-        KeyData expected = new KeyData();
+        PublicKeyResponse expected = new PublicKeyResponse();
         expected.setPublicKey(base64Pub);
-        expected.setPrivateKey("REDACTED");
 
         Response response = configResource.getKeyPair(base64Pub);
 
@@ -187,37 +185,32 @@ public class ConfigResourceTest {
 
         when(configService.getPublicKeys()).thenReturn(publicKeys);
 
-        final List<KeyData> expected = new ArrayList<>();
-        KeyData kdA = new KeyData();
-        kdA.setPublicKey(keyA);
-        kdA.setPrivateKey("REDACTED");
+        final List<PublicKeyResponse> expected = new ArrayList<>();
+        PublicKeyResponse pkrA = new PublicKeyResponse();
+        pkrA.setPublicKey(keyA);
 
-        KeyData kdB = new KeyData();
-        kdB.setPublicKey(keyB);
-        kdB.setPrivateKey("REDACTED");
+        PublicKeyResponse pkrB = new PublicKeyResponse();
+        pkrB.setPublicKey(keyB);
 
-        expected.add(kdA);
-        expected.add(kdB);
+        expected.add(pkrA);
+        expected.add(pkrB);
 
         Response response = configResource.getKeyPairs();
 
         verify(configService).getPublicKeys();
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getEntity()).isEqualTo(expected);
+        assertThat(response.getEntity()).isEqualToComparingFieldByFieldRecursively(expected);
     }
 
     @Test
-    public void getKeyPairsThrowsExceptionIfNoKeyPairs() {
-        Set<PublicKey> publicKeys = mock(Set.class);
-        when(publicKeys.isEmpty()).thenReturn(true);
+    public void getKeyPairsReturnsEmptyListIfNoKeyPairs() {
+        when(configService.getPublicKeys()).thenReturn(Collections.emptySet());
 
-        when(configService.getPublicKeys()).thenReturn(publicKeys);
-
-        Throwable ex = catchThrowable(() -> configResource.getKeyPairs());
+        Response response = configResource.getKeyPairs();
 
         verify(configService).getPublicKeys();
-        assertThat(ex).isNotNull();
-        assertThat(ex).isInstanceOf(NotFoundException.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getEntity()).isEqualToComparingFieldByFieldRecursively(Collections.emptyList());
     }
 
 }

--- a/jaxrs-service/src/test/java/com/quorum/tessera/admin/PublicKeyResponseTest.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/admin/PublicKeyResponseTest.java
@@ -1,0 +1,16 @@
+package com.quorum.tessera.admin;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PublicKeyResponseTest {
+
+    @Test
+    public void getter() {
+        String key = "key";
+        PublicKeyResponse pkr = new PublicKeyResponse(key);
+        assertThat(pkr.getPublicKey()).isEqualTo(key);
+    }
+
+}

--- a/tessera-core/src/main/java/com/quorum/tessera/core/config/ConfigService.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/core/config/ConfigService.java
@@ -1,8 +1,11 @@
 package com.quorum.tessera.core.config;
 
 import com.quorum.tessera.config.Peer;
+import com.quorum.tessera.encryption.PublicKey;
+
 import java.net.URI;
 import java.util.List;
+import java.util.Set;
 
 public interface ConfigService {
 
@@ -15,5 +18,6 @@ public interface ConfigService {
     boolean isDisablePeerDiscovery();
     
     URI getServerUri();
-     
+
+    Set<PublicKey> getPublicKeys();
 }

--- a/tessera-core/src/main/java/com/quorum/tessera/core/config/ConfigServiceImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/core/config/ConfigServiceImpl.java
@@ -3,22 +3,27 @@ package com.quorum.tessera.core.config;
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.config.util.ConfigFileStore;
+import com.quorum.tessera.enclave.Enclave;
+import com.quorum.tessera.encryption.PublicKey;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class ConfigServiceImpl implements ConfigService {
-    
+
     private final Config config;
+
+    private final Enclave enclave;
 
     private final ConfigFileStore configFileStore;
     
-    public ConfigServiceImpl(Config initialConfig,ConfigFileStore configFileStore) {
+    public ConfigServiceImpl(Config initialConfig, Enclave enclave, ConfigFileStore configFileStore) {
         this.config = Objects.requireNonNull(initialConfig);
+        this.enclave = Objects.requireNonNull(enclave);
         this.configFileStore = Objects.requireNonNull(configFileStore);
     }
- 
     
     @Override
     public void addPeer(String url) {
@@ -44,6 +49,11 @@ public class ConfigServiceImpl implements ConfigService {
     @Override
     public URI getServerUri() {
         return config.getP2PServerConfig().getServerUri();
+    }
+
+    @Override
+    public Set<PublicKey> getPublicKeys() {
+        return this.enclave.getPublicKeys();
     }
 
 }

--- a/tessera-core/src/main/resources/tessera-core-spring.xml
+++ b/tessera-core/src/main/resources/tessera-core-spring.xml
@@ -96,6 +96,7 @@
 
     <bean id="configService" class="com.quorum.tessera.core.config.ConfigServiceImpl">
         <constructor-arg ref="config" />
+        <constructor-arg ref="enclave"/>
         <constructor-arg>
             <bean class="com.quorum.tessera.config.util.ConfigFileStore" factory-method="get" />
         </constructor-arg>

--- a/tessera-core/src/test/java/com/quorum/tessera/core/config/ConfigServiceTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/core/config/ConfigServiceTest.java
@@ -5,12 +5,15 @@ import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.config.ServerConfig;
 import com.quorum.tessera.config.util.ConfigFileStore;
-import java.net.URI;
-import java.net.URISyntaxException;
-import static org.assertj.core.api.Assertions.assertThat;
+import com.quorum.tessera.enclave.Enclave;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class ConfigServiceTest {
@@ -21,11 +24,14 @@ public class ConfigServiceTest {
 
     private ConfigFileStore configFileStore;
 
+    private Enclave enclave;
+
     @Before
     public void onSetUp() {
         config = mock(Config.class);
         configFileStore = mock(ConfigFileStore.class);
-        configService = new ConfigServiceImpl(config, configFileStore);
+        enclave = mock(Enclave.class);
+        configService = new ConfigServiceImpl(config, enclave, configFileStore);
     }
 
     @After

--- a/tessera-core/src/test/java/com/quorum/tessera/core/config/ConfigServiceTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/core/config/ConfigServiceTest.java
@@ -92,4 +92,10 @@ public class ConfigServiceTest {
         verify(config).getP2PServerConfig();
         verify(serverConfig).getServerUri();
     }
+
+    @Test
+    public void getPublicKeys() {
+        configService.getPublicKeys();
+        verify(enclave).getPublicKeys();
+    }
 }


### PR DESCRIPTION
* Add `adminhost:port/config/keypairs` endpoint to retrieve all key pairs for a particular node.  Example response is:
```json
[
   {
      "publicKey" : "oNspPPgszVUFw0qmGFfWwh1uxVUXgvBxleXORHj07g8="
   },
   {
      "publicKey" : "ABn6zhBth2qpdrJXp98IvjExV212ALl3j4U//nj4FAI="
   }
]
```
*  Add `adminhost:port/config/keypairs/{publickey}` endpoint to check if node is registered with a particular key pair.  Example response is:
```json
  {
      "publicKey" : "oNspPPgszVUFw0qmGFfWwh1uxVUXgvBxleXORHj07g8="
   }
```
if the node is registered with the key pair, and:
```
No key pair found with public key oNspPPgszVUFw0qmGFfWwh1uxVUXgvBxleXORHj07g8=
```
if node is not registered with the key pair