### PR TITLE
rest enclave still requires bouncycastle - if ssl enabled

### DIFF
--- a/enclave/enclave-jaxrs/pom.xml
+++ b/enclave/enclave-jaxrs/pom.xml
@@ -108,7 +108,7 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.59</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
             <type>jar</type>
         </dependency>
         


### PR DESCRIPTION
as remote enclave module enclave-jaxrs utilises the security module for ssl settings - which will require bouncycastle library - having this scope being test will override that library scope and cause the enclave fail to start in ssl mode