### PR TITLE
Docker update path to tessera app jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN cd /tessera && mvn clean -Dmaven.repo.local=/tessera/.m2/repository -DskipTe
 # Create docker image with only distribution jar
 FROM openjdk:8-jre-alpine
 
-COPY --from=builder /tessera/tessera-app/target/*-app.jar /tessera/tessera-app.jar
+COPY --from=builder /tessera/tessera-dist/tessera-app/target/*-app.jar /tessera/tessera-app.jar
 
 ENTRYPOINT ["java", "-jar", "/tessera/tessera-app.jar"]

--- a/enclave/enclave-jaxrs/pom.xml
+++ b/enclave/enclave-jaxrs/pom.xml
@@ -108,7 +108,7 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.59</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
             <type>jar</type>
         </dependency>
         

--- a/logback-build.xml
+++ b/logback-build.xml
@@ -9,7 +9,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
During separation of the application into multiple artefacts, the Docker image that builds Tessera was not updated to the new location. This PR fixes that path.