### PR TITLE
Dont deploy snapshots on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ jdk:
 
 matrix:
   include:
+    - jdk: oraclejdk11
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
     #Default
     - name: "Acceptance Tests Java 11"
       env:

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,8 +58,8 @@ if [ "$TRAVIS_EVENT_TYPE" == "api" ] && [ "$TRAVIS_JOB_NAME" == "release" ]; the
     echo "TODO: The release branch must be manually merged back to master. (This could be automated in the future.)"
 
 elif [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-    echo "Deploying snapshot release to central"
-    mvn deploy --settings .maven.xml -P release 
+    #echo "Deploying snapshot release to central"
+    #mvn deploy --settings .maven.xml -P release
 fi
 
 exit 0

--- a/deploy.sh
+++ b/deploy.sh
@@ -60,6 +60,7 @@ if [ "$TRAVIS_EVENT_TYPE" == "api" ] && [ "$TRAVIS_JOB_NAME" == "release" ]; the
 elif [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     #echo "Deploying snapshot release to central"
     #mvn deploy --settings .maven.xml -P release
+    exit 0
 fi
 
 exit 0


### PR DESCRIPTION
Running jobs in parallel means that deploy to called at the end of successful jobs. This
results in deploy being called multiple times when merging to master. 

Commented out deploy snapshot until we find a way or aggregating test results between jobs or even executing mvn deploy in insolation when merge to master. 