### PR TITLE
Upgrade checkstyle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.14</version>
+                        <version>8.18</version>
                     </dependency>
                     
                     <dependency>


### PR DESCRIPTION
Upgrade checkstyle plugin version due to security alert regarding potential DOS attack due to dtd downloading during execution