### PR TITLE
upgrade bouncycastle library to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -646,7 +646,7 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
-                <version>1.59</version>
+                <version>1.61</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
update bouncycastle library to latest version which contains a fix for vulnerability CVE-2018-1000613.
More details at https://nvd.nist.gov/vuln/detail/CVE-2018-1000613