### PR TITLE
Add logback configuration for enclave

### DIFF
--- a/enclave/enclave-jaxrs/src/main/resources/logback.xml
+++ b/enclave/enclave-jaxrs/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %replace(%msg){'[\r\n]', ''}%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- silence hibernate messages that were being created from DefaultCliAdapter -->
+  <logger name="org.hibernate.validator.internal.util.Version" level="OFF"/>
+  <logger name="org.hibernate.validator.internal.engine.ConfigurationImpl" level="OFF"/>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/key-vault/pom.xml
+++ b/key-vault/pom.xml
@@ -56,6 +56,12 @@
 
                             </filter>
                         </filters>
+                        <artifactSet>
+                            <excludes>
+                                <exclude>ch.qos.logback:logback-classic</exclude>
+                                <exclude>ch.qos.logback:logback-core</exclude>
+                            </excludes>
+                        </artifactSet>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Set INFO as root log level, silence messages that were being logged from DefaultCliAdapter and exclude logback dep from shaded vault jars to prevent slf4j binding conflicts when running enclave with vault.