### PR TITLE
Travis and build changes

### DIFF
--- a/.maven.xml
+++ b/.maven.xml
@@ -7,18 +7,24 @@
             <username>${env.SONATYPE_USERNAME}</username>
             <password>${env.SONATYPE_PASSWORD}</password>
         </server>
+        
+        <server>
+            <id>github</id>
+            <password>${env.CI_USER_TOKEN}</password>
+        </server>
+        
     </servers>
 
     <profiles>
-      <profile>
-        <id>ossrh</id>
-        <activation>
-          <activeByDefault>true</activeByDefault>
-        </activation>
-        <properties>
-          <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
-          <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-        </properties>
-      </profile>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+        </profile>
     </profiles>
 </settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
       name: "Acceptance Tests Java 11"
       jdk:  oraclejdk11
       script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
-      before_install:
-        - rm "${JAVA_HOME}/lib/security/cacerts"
-        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
       install: *build_no_checks
     - if: type = pull_request
       name: "Acceptance Tests Java 8"
@@ -85,13 +82,11 @@ matrix:
         - echo "TODO: The release branch $branch_name must be manually merged back to master."
       jdk:  oraclejdk8
     - if: branch = travis_changes AND type = push
-      name: "Acceptance Tests Java 11"
-      jdk:  oraclejdk11
-      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
+      name: "Deploy site"
+      jdk:  oraclejdk8
+      script: mvn site-deploy -P reduce-logging || travis_terminate 1
       install: *build_no_checks
-      script: *build_with_unittests
 
-        
 sudo: enabled
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ matrix:
       install: *build_no_checks
       script: *build_with_unittests
     #Default
-    #    - if: type = pull_request
-    #      name: "Acceptance Tests Java 11"
-    #      jdk:  oraclejdk11
-    #      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
-    #      before_install:
-    #        - rm "${JAVA_HOME}/lib/security/cacerts"
-    #        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
-    #      install: *build_no_checks
+    - if: type = pull_request
+      name: "Acceptance Tests Java 11"
+      jdk:  oraclejdk11
+      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+      install: *build_no_checks
     - if: type = pull_request
       name: "Acceptance Tests Java 8"
       jdk:  oraclejdk8
@@ -88,9 +88,6 @@ matrix:
       name: "Acceptance Tests Java 11"
       jdk:  oraclejdk11
       script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
-      before_install:
-        - rm "${JAVA_HOME}/lib/security/cacerts"
-        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
       install: *build_no_checks
       script: *build_with_unittests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ matrix:
       install: *build_no_checks
       script: *build_with_unittests
     #Default
-    - if: type = pull_request
-      name: "Acceptance Tests Java 11"
-      jdk:  oraclejdk11
-      before_install:
-        - rm "${JAVA_HOME}/lib/security/cacerts"
-        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
-      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
-      install: *build_no_checks
+#    - if: type = pull_request
+#      name: "Acceptance Tests Java 11"
+#      jdk:  oraclejdk11
+#      before_install:
+#        - rm "${JAVA_HOME}/lib/security/cacerts"
+#        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+#      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
+#      install: *build_no_checks
     - if: type = pull_request
       name: "Acceptance Tests Java 8"
       jdk:  oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,14 @@ matrix:
         - mvn --settings .maven.xml -B -DpushChanges=true release:perform || travis_terminate 1
         - echo "TODO: The release branch $branch_name must be manually merged back to master."
       jdk:  oraclejdk8
-
+    - if: branch = travis_changes AND type = push
+          name: "Acceptance Tests Java 11"
+          jdk:  oraclejdk11
+          script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
+          before_install:
+            - rm "${JAVA_HOME}/lib/security/cacerts"
+            - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+          install: *build_no_checks
 sudo: enabled
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ matrix:
       script: 
           - git checkout -b marktest
           - git push
-      install: *build_no_checks
+      install: echo "install"
 
 sudo: enabled
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,14 +81,14 @@ matrix:
         - mvn --settings .maven.xml -B -DpushChanges=true release:perform || travis_terminate 1
         - echo "TODO: The release branch $branch_name must be manually merged back to master."
       jdk:  oraclejdk8
-    - if: branch = travis_changes AND type = push
-      name: "Deploy site"
-      jdk:  oraclejdk8
-      before_install:
-        - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
-      script: 
-          - mvn site-deploy
-      install: echo "install"
+#    - if: branch = travis_changes AND type = push
+#      name: "Deploy site"
+#      jdk:  oraclejdk8
+#      before_install:
+#        - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
+#      script: 
+#          - mvn site-deploy
+#      install: echo "install"
 
 sudo: enabled
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,7 @@ matrix:
       before_install:
         - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
       script: 
-          - git checkout -b marktest
-          - git push origin marktest
+          - mvn site-deploy
       install: echo "install"
 
 sudo: enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     - if: type = pull_request
       name: "Acceptance Tests Java 11"
       jdk:  oraclejdk11
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
       script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
       install: *build_no_checks
     - if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,11 @@ matrix:
     - if: branch = travis_changes AND type = push
       name: "Deploy site"
       jdk:  oraclejdk8
-      script: mvn site-deploy -P reduce-logging || travis_terminate 1
+      before_install:
+        - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
+      script: 
+          - git checkout -b marktest
+          - git push
       install: *build_no_checks
 
 sudo: enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
         - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
       script: 
           - git checkout -b marktest
-          - git push
+          - git push origin marktest
       install: echo "install"
 
 sudo: enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,13 +85,16 @@ matrix:
         - echo "TODO: The release branch $branch_name must be manually merged back to master."
       jdk:  oraclejdk8
     - if: branch = travis_changes AND type = push
-          name: "Acceptance Tests Java 11"
-          jdk:  oraclejdk11
-          script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
-          before_install:
-            - rm "${JAVA_HOME}/lib/security/cacerts"
-            - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
-          install: *build_no_checks
+      name: "Acceptance Tests Java 11"
+      jdk:  oraclejdk11
+      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+      install: *build_no_checks
+      script: *build_with_unittests
+
+        
 sudo: enabled
 
 notifications:

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/H2DataExporterTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/H2DataExporterTest.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.data.migration;
 
-import org.h2.jdbc.JdbcSQLException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -21,6 +20,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import org.h2.jdbc.JdbcSQLInvalidAuthorizationSpecException;
 
 public class H2DataExporterTest {
 
@@ -133,7 +133,7 @@ public class H2DataExporterTest {
 
         final Throwable throwable = catchThrowable(() -> DriverManager.getConnection(connectionString, null, null));
 
-        assertThat(throwable).isInstanceOf(JdbcSQLException.class);
+        assertThat(throwable).isInstanceOf(JdbcSQLInvalidAuthorizationSpecException.class);
 
     }
 

--- a/key-vault/azure-key-vault/pom.xml
+++ b/key-vault/azure-key-vault/pom.xml
@@ -9,6 +9,23 @@
 
     <artifactId>azure-key-vault</artifactId>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-keyvault</artifactId>
+                <version>1.1.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>adal4j</artifactId>
+                <version>1.6.3</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>

--- a/key-vault/hashicorp-key-vault/pom.xml
+++ b/key-vault/hashicorp-key-vault/pom.xml
@@ -9,6 +9,22 @@
 
     <artifactId>hashicorp-key-vault</artifactId>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.vault</groupId>
+                <artifactId>spring-vault-core</artifactId>
+                <version>2.1.1.RELEASE</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -911,30 +911,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-keyvault</artifactId>
-                <version>1.1.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>adal4j</artifactId>
-                <version>1.6.3</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.vault</groupId>
-                <artifactId>spring-vault-core</artifactId>
-                <version>2.1.1.RELEASE</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>3.12.0</version>
-            </dependency>
-
-            <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
                 <version>3.1.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <scm>
         <url>https://github.com/jpmorganchase/tessera</url>
-        <connection>scm:git:git://github.com/jpmorganchase/tessera.git</connection>
-        <developerConnection>scm:git:git@github.com:jpmorganchase/tessera.git</developerConnection>
+        <connection>scm:git:https://github.com/jpmorganchase/tessera.git</connection>
+        <developerConnection>scm:git:https://github.com/jpmorganchase/tessera.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <scm>
         <url>https://github.com/jpmorganchase/tessera</url>
-        <connection>scm:git:https://github.com/jpmorganchase/tessera.git</connection>
-        <developerConnection>scm:git:https://github.com/jpmorganchase/tessera.git</developerConnection>
+        <connection>scm:https://github.com/jpmorganchase/tessera.git</connection>
+        <developerConnection>scm:https://github.com/jpmorganchase/tessera.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <scm>
         <url>https://github.com/jpmorganchase/tessera</url>
-        <connection>scm:https://github.com/jpmorganchase/tessera.git</connection>
-        <developerConnection>scm:https://github.com/jpmorganchase/tessera.git</developerConnection>
+        <connection>scm:git:https://github.com/jpmorganchase/tessera.git</connection>
+        <developerConnection>scm:git:https://github.com/jpmorganchase/tessera.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,9 @@
         <slf4j.version>1.7.5</slf4j.version>
         <eclipselink.version>2.7.3</eclipselink.version>
         <grpc.version>1.14.0</grpc.version>
-        <h2.version>1.4.197</h2.version>
+        <h2.version>1.4.199</h2.version>
         <owasp.plugin.version>5.0.0-M2</owasp.plugin.version>
+        <logback.version>1.1.10</logback.version>
     </properties>
 
     <build>
@@ -154,18 +155,6 @@
 
 
         <plugins>
-
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -744,14 +733,14 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.0.13</version>
+                <version>${logback.version}</version>
                 <scope>runtime</scope>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.0.13</version>
+                <version>${logback.version}</version>
                 <scope>runtime</scope>
             </dependency>
 
@@ -1109,6 +1098,27 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>3.1.11</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <failOnError>false</failOnError>
+                    <relaxed>false</relaxed>
+                    <includeTests>false</includeTests>
+
+                    <includeFilterFile>${session.executionRootDirectory}/spotbugs-include.xml</includeFilterFile>
+                    <excludeFilterFile>${session.executionRootDirectory}/spotbugs-exclude.xml</excludeFilterFile>
+
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.9.0</version>
+                        </plugin>
+                    </plugins>
+
+
+                </configuration>
+
             </plugin>
 
             <plugin>
@@ -1175,7 +1185,6 @@
                                 <logback.configurationFile>${session.executionRootDirectory}/logback-build.xml
                                 </logback.configurationFile>
                             </systemPropertyVariables>
-                            &gt;
                         </configuration>
                     </plugin>
                     <plugin>
@@ -1186,7 +1195,6 @@
                                 <logback.configurationFile>${session.executionRootDirectory}/logback-build.xml
                                 </logback.configurationFile>
                             </systemPropertyVariables>
-                            &gt;
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1336,16 +1344,6 @@
                 </plugins>
             </build>
 
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
         </profile>
 
         <profile>
@@ -1377,19 +1375,6 @@
 
 
     </distributionManagement>
-
-<!--    <repositories>-->
-<!--        <repository>-->
-<!--            <id>tessera-repo</id>-->
-<!--            <url>https://raw.github.com/jpmorganchase/tessera/releases</url>-->
-<!--            <snapshots>-->
-<!--                <enabled>false</enabled>-->
-<!--            </snapshots>-->
-<!--            <releases>-->
-<!--                <enabled>true</enabled>-->
-<!--            </releases>-->
-<!--        </repository>-->
-<!--    </repositories>-->
 
     <pluginRepositories>
         <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 
                 </plugin>
                 
-                <plugin>
+<!--                <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${owasp.plugin.version}</version>
@@ -160,7 +160,7 @@
                             </goals>
                         </execution>
                     </executions>
-                </plugin>
+                </plugin>-->
 
             </plugins>
 
@@ -169,10 +169,10 @@
 
         <plugins>
 
-            <plugin>
+<!--            <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-            </plugin>
+            </plugin>-->
             
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <grpc.version>1.14.0</grpc.version>
         <h2.version>1.4.199</h2.version>
         <owasp.plugin.version>5.0.0-M2</owasp.plugin.version>
-        <logback.version>1.1.10</logback.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <build>
@@ -945,17 +945,6 @@
 
     <dependencies>
 
-        <!-- Needed for JavaDoc plugin -->
-        <!--        <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>-->
-
         <!-- Testing -->
 
         <dependency>
@@ -1160,6 +1149,11 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${owasp.plugin.version}</version>
+                <configuration>
+                    <name>OWASP Depencency check</name>
+                    <skipTestScope>true</skipTestScope>
+                    <enableExperimental>true</enableExperimental>
+                </configuration>
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <scm>
         <url>https://github.com/jpmorganchase/tessera</url>
-        <connection>scm:git:https://github.com/jpmorganchase/tessera.git</connection>
-        <developerConnection>scm:git:https://github.com/jpmorganchase/tessera.git</developerConnection>
+        <connection>scm:git:git://github.com/jpmorganchase/tessera.git</connection>
+        <developerConnection>scm:git:git@github.com:jpmorganchase/tessera.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
@@ -120,24 +120,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.7.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>com.github.github</groupId>
-                    <artifactId>site-maven-plugin</artifactId>
-                    <version>0.12</version>
-                    <configuration>
-                        <message>Creating site for ${project.version}</message>
-                        <server>github</server>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>site</goal>
-                            </goals>
-                            <phase>site</phase>
-                        </execution>
-                    </executions>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,24 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>com.github.github</groupId>
+                    <artifactId>site-maven-plugin</artifactId>
+                    <version>0.12</version>
+                    <configuration>
+                        <message>Creating site for ${project.version}</message>
+                        <server>github</server>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>site</goal>
+                            </goals>
+                            <phase>site</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>3.1.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,19 @@
                     </configuration>
 
                 </plugin>
+                
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${owasp.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
             </plugins>
 
@@ -156,6 +169,11 @@
 
         <plugins>
 
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
@@ -1119,16 +1137,16 @@
                     </reportSet>
                 </reportSets>
             </plugin>
-
+            
 
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${owasp.plugin.version}</version>
                 <configuration>
-                    <name>OWASP Depencency check</name>
+                    
+                    <name>owasp depencency check</name>
                     <skipTestScope>true</skipTestScope>
-                    <enableExperimental>true</enableExperimental>
                 </configuration>
                 <reportSets>
                     <reportSet>

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -19,6 +19,7 @@
             <artifactId>tessera-app</artifactId>
             <classifier>app</classifier>
             <version>0.10-SNAPSHOT</version>
+             <scope>test</scope>
         </dependency>
         
         <dependency>
@@ -26,6 +27,7 @@
             <artifactId>tessera-simple</artifactId>
             <classifier>app</classifier>
             <version>0.10-SNAPSHOT</version>
+             <scope>test</scope>
         </dependency>
    
         <dependency>
@@ -33,28 +35,32 @@
             <artifactId>tessera-grpc</artifactId>
             <classifier>app</classifier>
             <version>0.10-SNAPSHOT</version>
+             <scope>test</scope>
         </dependency>
    
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>enclave-jaxrs</artifactId>
+             <scope>test</scope>
         </dependency>
    
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>enclave-jaxrs</artifactId>
             <classifier>server</classifier>
+             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>test-util</artifactId>
+             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>config-migration</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
             <classifier>cli</classifier>
             <version>0.10-SNAPSHOT</version>
         </dependency>
@@ -62,17 +68,20 @@
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>ddls</artifactId>
+             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
             <version>4.0.1</version>
+             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java8</artifactId>
             <version>4.0.1</version>
+             <scope>test</scope>
         </dependency>
 
 

--- a/tests/jmeter-test/pom.xml
+++ b/tests/jmeter-test/pom.xml
@@ -18,12 +18,14 @@
             <artifactId>tessera-app</artifactId>
             <classifier>app</classifier>
             <version>0.10-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.5</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
1. Reactivate jdk 11 acceptance tests as issue with travis appears only on .org
2. Change dependencies reported to have security vulnerabilities
3. Move key vault vendor dependencies into approbate modules so security issues can be handled in a more targeted way. 

