### PR TITLE
Apply "EmptyLineSeparator" to the `server` modules.

### DIFF
--- a/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/ClientFactory.java
+++ b/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/ClientFactory.java
@@ -75,5 +75,4 @@ public class ClientFactory {
         }
     }
 
-
 }

--- a/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/ClientFactoryTest.java
+++ b/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/ClientFactoryTest.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.jaxrs.client;
 
-
 import com.quorum.tessera.config.ServerConfig;
 import com.quorum.tessera.config.SslConfig;
 import com.quorum.tessera.jaxrs.unixsocket.JerseyUnixSocketConnectorProvider;

--- a/server/jaxrs-client-unixsocket/src/main/java/com/quorum/tessera/jaxrs/unixsocket/JerseyUnixSocketConnectorProvider.java
+++ b/server/jaxrs-client-unixsocket/src/main/java/com/quorum/tessera/jaxrs/unixsocket/JerseyUnixSocketConnectorProvider.java
@@ -1,14 +1,14 @@
 package com.quorum.tessera.jaxrs.unixsocket;
 
-import java.net.URI;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Configuration;
 import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Configuration;
+import java.net.URI;
+
 public class JerseyUnixSocketConnectorProvider implements ConnectorProvider {
 
-    
     @Override
     public Connector getConnector(Client client, Configuration runtimeConfig) {
         URI unixfile = (URI) runtimeConfig.getProperty("unixfile");

--- a/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/JerseyServerIT.java
+++ b/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/JerseyServerIT.java
@@ -1,23 +1,22 @@
 package com.quorum.tessera.jaxrs.unixsocket;
 
 import com.quorum.tessera.config.CommunicationType;
-
 import com.quorum.tessera.config.ServerConfig;
 import com.quorum.tessera.server.JerseyServer;
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.net.URI;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.glassfish.jersey.client.ClientConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class JerseyServerIT {
 
@@ -30,9 +29,6 @@ public class JerseyServerIT {
 
         ServerConfig serverConfig = new ServerConfig();
         serverConfig.setCommunicationType(CommunicationType.REST);
-        
-        //InetServerSocket serverSocket = new InetServerSocket("http://localhost", 8080);
-        Path unixPath = Paths.get(unixfile);
 
         serverConfig.setServerAddress(unixfile.toString());
         Application sample = new SampleApplication();
@@ -42,7 +38,7 @@ public class JerseyServerIT {
     }
 
     @After
-    public void onTearDown() throws Exception {
+    public void onTearDown() {
         server.stop();
     }
 
@@ -93,7 +89,7 @@ public class JerseyServerIT {
     }
 
     @Test
-    public void raw() throws Exception {
+    public void raw() {
 
         ClientConfig config = new ClientConfig();
         config.connectorProvider(new JerseyUnixSocketConnectorProvider());
@@ -110,11 +106,10 @@ public class JerseyServerIT {
     }
 
     @Test
-    public void param() throws Exception {
+    public void param() {
         // URL.setURLStreamHandlerFactory(new UnixSocketURLStreamHandlerFactory());
         ClientConfig config = new ClientConfig();
         config.connectorProvider(new JerseyUnixSocketConnectorProvider());
-
 
         Response result = newClient(unixfile)
                 .target(unixfile)
@@ -132,7 +127,6 @@ public class JerseyServerIT {
         ClientConfig config = new ClientConfig();
         config.connectorProvider(new JerseyUnixSocketConnectorProvider());
 
-        return ClientBuilder.newClient(config)
-                .property("unixfile", unixfile);
+        return ClientBuilder.newClient(config).property("unixfile", unixfile);
     }
 }

--- a/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/SamplePayload.java
+++ b/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/SamplePayload.java
@@ -24,6 +24,5 @@ public class SamplePayload {
     public void setId(String id) {
         this.id = id;
     }
-    
-    
+
 }

--- a/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/SampleResource.java
+++ b/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/SampleResource.java
@@ -1,25 +1,18 @@
 package com.quorum.tessera.jaxrs.unixsocket;
 
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
+
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 @Path("/")
 public class SampleResource {
@@ -65,8 +58,6 @@ public class SampleResource {
         return Response.ok(deleted).build();
     }
 
-
-
     @POST
     @Path("sendraw")
     @Consumes(APPLICATION_OCTET_STREAM)
@@ -93,8 +84,7 @@ public class SampleResource {
         System.out.println("headerParam: "+ headerParam);
         System.out.println("QueryParam: "+ qparam);
 
-        return Response.ok()
-                .build();
-    
+        return Response.ok().build();
     }
+
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/InfluxDbClient.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/InfluxDbClient.java
@@ -14,9 +14,13 @@ import java.net.URI;
 import java.util.List;
 
 public class InfluxDbClient {
+
     private final URI uri;
+
     private final int port;
+
     private final String dbName;
+
     private final String hostName;
 
     private final MBeanServer mbs;
@@ -38,12 +42,14 @@ public class InfluxDbClient {
         String formattedMetrics = formatter.format(metrics, uri);
 
         Client client = ClientBuilder.newClient();
-        WebTarget influxTarget = client.target(hostName + ":" + port)
-                                       .path("write")
-                                       .queryParam("db", dbName);
+        WebTarget influxTarget = client
+            .target(hostName + ":" + port)
+            .path("write")
+            .queryParam("db", dbName);
 
-        return influxTarget.request(MediaType.TEXT_PLAIN)
-                            .accept(MediaType.TEXT_PLAIN)
-                            .post(Entity.text(formattedMetrics));
+        return influxTarget
+            .request(MediaType.TEXT_PLAIN)
+            .accept(MediaType.TEXT_PLAIN)
+            .post(Entity.text(formattedMetrics));
     }
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MBeanMetric.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MBeanMetric.java
@@ -1,6 +1,9 @@
 package com.quorum.tessera.server.monitoring;
 
 public interface MBeanMetric {
+
     String getName();
+
     String getValue();
+
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MBeanResourceMetric.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MBeanResourceMetric.java
@@ -1,8 +1,11 @@
 package com.quorum.tessera.server.monitoring;
 
 public class MBeanResourceMetric implements MBeanMetric {
+
     private String resourceMethod;
+
     private String name;
+
     private String value;
 
     public MBeanResourceMetric(String resourceMethod, String name, String value) {

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/PrometheusProtocolFormatter.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/PrometheusProtocolFormatter.java
@@ -4,28 +4,28 @@ import java.util.List;
 
 public class PrometheusProtocolFormatter {
 
-    public String format(List<MBeanMetric> metrics) {
+    public String format(final List<MBeanMetric> metrics) {
         StringBuilder formattedMetrics = new StringBuilder();
 
-        for(MBeanMetric metric : metrics) {
-            MBeanResourceMetric resourceMetric = (MBeanResourceMetric) metric;
+        for (final MBeanMetric metric : metrics) {
+            final MBeanResourceMetric resourceMetric = (MBeanResourceMetric) metric;
 
             formattedMetrics.append("tessera_")
-                            .append(sanitize(resourceMetric.getResourceMethod()))
-                            .append("_")
-                            .append(sanitize(resourceMetric.getName()))
-                            .append(" ")
-                            .append(resourceMetric.getValue())
-                            .append("\n");
+                .append(sanitize(resourceMetric.getResourceMethod()))
+                .append("_")
+                .append(sanitize(resourceMetric.getName()))
+                .append(" ")
+                .append(resourceMetric.getValue())
+                .append("\n");
         }
 
         return formattedMetrics.toString().trim();
     }
 
-    private String sanitize(String input) {
-        return input.replaceAll("(#.*)|(_total)|\\(\\)|\\)|\\[\\]|\\]|;", "")
-                    .replaceAll("->|\\(|\\[", "_");
+    private String sanitize(final String input) {
+        return input
+            .replaceAll("(#.*)|(_total)|\\(\\)|\\)|\\[\\]|\\]|;", "")
+            .replaceAll("->|\\(|\\[", "_");
     }
-
 
 }

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/jaxrs/SamplePayload.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/jaxrs/SamplePayload.java
@@ -24,6 +24,5 @@ public class SamplePayload {
     public void setId(String id) {
         this.id = id;
     }
-    
-    
+
 }

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/jaxrs/SampleResource.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/jaxrs/SampleResource.java
@@ -29,8 +29,7 @@ public class SampleResource {
         System.out.println("PING");
         return "HEllow";
     }
-    
-    
+
     @Produces(MediaType.APPLICATION_JSON)
     @GET
     @Path("find/{id}")

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/InfluxDbProtocolFormatterTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/InfluxDbProtocolFormatterTest.java
@@ -23,7 +23,6 @@ public class InfluxDbProtocolFormatterTest {
         this.mockUri = new URI("http://localhost:8080");
     }
 
-
     @Test
     public void noArgResourceResponseCorrectlyFormatted() {
         mockMetrics.add(new MBeanResourceMetric("GET->upCheck()#a10a4f8d", "AverageTime[ms]_total", "100"));

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/InfluxDbPublisherTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/InfluxDbPublisherTest.java
@@ -2,30 +2,27 @@ package com.quorum.tessera.server.monitoring;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
 
 public class InfluxDbPublisherTest {
 
     private InfluxDbPublisher influxDbPublisher;
 
-    @Mock
-    InfluxDbClient influxDbClient;
+    private InfluxDbClient influxDbClient;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        this.influxDbClient = mock(InfluxDbClient.class);
+
         this.influxDbPublisher = new InfluxDbPublisher(influxDbClient);
     }
 
     @Test
     public void runMethodIsCalled() {
         influxDbPublisher.run();
-        verify(influxDbClient, times(1)).postMetrics();
+        verify(influxDbClient).postMetrics();
     }
 
 }

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/MetricsEnquirerTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/MetricsEnquirerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 public class MetricsEnquirerTest {
+
     @Mock
     private MBeanServer mBeanServer;
 
@@ -116,7 +117,6 @@ public class MetricsEnquirerTest {
             new MBeanAttributeInfo(attributeName2, "type", "desc", true, false, false)
         };
 
-
         MBeanInfo mBeanInfo1 = new MBeanInfo(null, null, mBeanAttributes1, null, null, null);
         MBeanInfo mBeanInfo2 = new MBeanInfo(null, null, mBeanAttributes2, null, null, null);
 
@@ -151,7 +151,6 @@ public class MetricsEnquirerTest {
             new MBeanAttributeInfo(attributeName2, "type", "desc", true, false, false),
             new MBeanAttributeInfo(attributeName3, "type", "desc", true, false, false)
         };
-
 
         MBeanInfo mBeanInfo1 = new MBeanInfo(null, null, mBeanAttributes1, null, null, null);
         MBeanInfo mBeanInfo2 = new MBeanInfo(null, null, mBeanAttributes2, null, null, null);


### PR DESCRIPTION
Continuation of https://github.com/jpmorganchase/tessera/issues/699

Applies the `EmptyLineSeparator` to `jaxrs-client` and `server` modules.