### PR TITLE
Apply "EmptyLineSeparator" to the `config` module

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/AppType.java
+++ b/config/src/main/java/com/quorum/tessera/config/AppType.java
@@ -10,26 +10,23 @@ import java.util.Set;
 import static java.util.Collections.singleton;
 
 public enum AppType {
-    P2P(P2PApp.class,
-        new HashSet<>(Arrays.asList(CommunicationType.GRPC, CommunicationType.REST))),
-    Q2T(Q2TApp.class,
-        new HashSet<>(Arrays.asList(CommunicationType.GRPC, CommunicationType.REST))
-        ),
+
+    P2P(P2PApp.class, new HashSet<>(Arrays.asList(CommunicationType.GRPC, CommunicationType.REST))),
+
+    Q2T(Q2TApp.class, new HashSet<>(Arrays.asList(CommunicationType.GRPC, CommunicationType.REST))),
+
     @XmlEnumValue("ThirdParty")
-    THIRD_PARTY(ThirdPartyApp.class,
-        singleton(CommunicationType.REST)),
-    ENCLAVE(EnclaveApp.class,
-        singleton(CommunicationType.REST)
-    ),
-    ADMIN(AdminApp.class,
-        singleton(CommunicationType.REST)
-    );
+    THIRD_PARTY(ThirdPartyApp.class, singleton(CommunicationType.REST)),
+
+    ENCLAVE(EnclaveApp.class, singleton(CommunicationType.REST)),
+
+    ADMIN(AdminApp.class, singleton(CommunicationType.REST));
 
     private final Class<? extends TesseraApp> intf;
+
     private final Set<CommunicationType> allowedCommunicationTypes;
 
-    AppType(Class<? extends TesseraApp> intf,
-            Set<CommunicationType> allowedCommunicationTypes) {
+    AppType(final Class<? extends TesseraApp> intf, final Set<CommunicationType> allowedCommunicationTypes) {
         this.intf = intf;
         this.allowedCommunicationTypes = allowedCommunicationTypes;
     }
@@ -41,6 +38,5 @@ public enum AppType {
     public Set<CommunicationType> getAllowedCommunicationTypes() {
         return allowedCommunicationTypes;
     }
-
 
 }

--- a/config/src/main/java/com/quorum/tessera/config/ArgonOptions.java
+++ b/config/src/main/java/com/quorum/tessera/config/ArgonOptions.java
@@ -26,8 +26,6 @@ public class ArgonOptions extends ConfigItem {
     @XmlAttribute
     private Integer parallelism;
 
-
-
     public ArgonOptions(String algorithm, Integer iterations, Integer memory, Integer parallelism) {
         this.algorithm = Optional.ofNullable(algorithm).orElse("id");
         this.iterations = iterations;
@@ -36,6 +34,7 @@ public class ArgonOptions extends ConfigItem {
     }
 
     public ArgonOptions() {
+
     }
 
     public String getAlgorithm() {

--- a/config/src/main/java/com/quorum/tessera/config/Config.java
+++ b/config/src/main/java/com/quorum/tessera/config/Config.java
@@ -185,8 +185,5 @@ public class Config extends ConfigItem {
     public void setDisablePeerDiscovery(boolean disablePeerDiscovery) {
         this.disablePeerDiscovery = disablePeerDiscovery;
     }
-    
-    
-    
-    
+
 }

--- a/config/src/main/java/com/quorum/tessera/config/ConfigException.java
+++ b/config/src/main/java/com/quorum/tessera/config/ConfigException.java
@@ -1,10 +1,8 @@
-
 package com.quorum.tessera.config;
-
 
 public class ConfigException extends RuntimeException {
 
-    public ConfigException(Throwable cause) {
+    public ConfigException(final Throwable cause) {
         super(cause);
     }
     

--- a/config/src/main/java/com/quorum/tessera/config/InfluxConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/InfluxConfig.java
@@ -32,10 +32,8 @@ public class InfluxConfig extends ConfigItem {
     }
 
     public InfluxConfig() {
-        this(null,null,null,null);
+        this(null, null, null, null);
     }
-
-
 
     public String getHostName() {
         return hostName;
@@ -68,6 +66,5 @@ public class InfluxConfig extends ConfigItem {
     public void setDbName(String dbName) {
         this.dbName = dbName;
     }
-    
-    
+
 }

--- a/config/src/main/java/com/quorum/tessera/config/KeyData.java
+++ b/config/src/main/java/com/quorum/tessera/config/KeyData.java
@@ -76,8 +76,8 @@ public class KeyData extends ConfigItem {
     }
 
     public KeyData() {
-    }
 
+    }
 
     public String getPrivateKey() {
         return privateKey;
@@ -190,4 +190,5 @@ public class KeyData extends ConfigItem {
     public void setHashicorpVaultSecretVersion(String hashicorpVaultSecretVersion) {
         this.hashicorpVaultSecretVersion = hashicorpVaultSecretVersion;
     }
+
 }

--- a/config/src/main/java/com/quorum/tessera/config/Peer.java
+++ b/config/src/main/java/com/quorum/tessera/config/Peer.java
@@ -27,7 +27,5 @@ public class Peer extends ConfigItem {
     public void setUrl(String url) {
         this.url = url;
     }
-    
-    
 
 }

--- a/config/src/main/java/com/quorum/tessera/config/ServerConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/ServerConfig.java
@@ -36,9 +36,9 @@ public class ServerConfig extends ConfigItem {
     private InfluxConfig influxConfig;
 
     @ValidServerAddress(
-            message = "Binding Address is invalid",
-            isBindingAddress = true,
-            supportedSchemes = {"http","https"}
+        message = "Binding Address is invalid",
+        isBindingAddress = true,
+        supportedSchemes = {"http", "https"}
     )
     @XmlElement
     private String bindingAddress;
@@ -47,7 +47,7 @@ public class ServerConfig extends ConfigItem {
     @NotNull
     @XmlElement
     private String serverAddress;
-    
+
     public ServerConfig(final AppType app,
                         final boolean enabled,
                         final String serverAddress,
@@ -64,16 +64,18 @@ public class ServerConfig extends ConfigItem {
         this.bindingAddress = bindingAddress;
     }
 
-    public ServerConfig(){}
+    public ServerConfig() {
+
+    }
 
     public String getBindingAddress() {
-        return this.bindingAddress == null ? this.serverAddress: this.bindingAddress;
+        return this.bindingAddress == null ? this.serverAddress : this.bindingAddress;
     }
 
     public URI getServerUri() {
         try {
-        return URI.create(serverAddress);
-        } catch(java.lang.IllegalArgumentException ex) {
+            return URI.create(serverAddress);
+        } catch (IllegalArgumentException ex) {
             throw new ConfigException(ex);
         }
     }
@@ -141,10 +143,9 @@ public class ServerConfig extends ConfigItem {
     public void setServerAddress(String serverAddress) {
         this.serverAddress = serverAddress;
     }
-    
+
     public boolean isUnixSocket() {
         return Objects.equals(getServerUri().getScheme(), "unix");
     }
-    
-    
+
 }

--- a/config/src/main/java/com/quorum/tessera/config/SslAuthenticationMode.java
+++ b/config/src/main/java/com/quorum/tessera/config/SslAuthenticationMode.java
@@ -1,7 +1,5 @@
-
 package com.quorum.tessera.config;
 
-
-public enum SslAuthenticationMode { 
-    OFF,STRICT
+public enum SslAuthenticationMode {
+    OFF, STRICT
 }

--- a/config/src/main/java/com/quorum/tessera/config/SslConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/SslConfig.java
@@ -140,8 +140,8 @@ public class SslConfig {
     }
 
     public SslConfig() {
-    }
 
+    }
 
     public SslAuthenticationMode getTls() {
         return tls;

--- a/config/src/main/java/com/quorum/tessera/config/apps/EnclaveApp.java
+++ b/config/src/main/java/com/quorum/tessera/config/apps/EnclaveApp.java
@@ -1,6 +1,4 @@
-
 package com.quorum.tessera.config.apps;
-
 
 public interface EnclaveApp extends TesseraApp {
     

--- a/config/src/main/java/com/quorum/tessera/config/constraints/ServerAddressValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ServerAddressValidator.java
@@ -1,15 +1,15 @@
 package com.quorum.tessera.config.constraints;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 public class ServerAddressValidator implements ConstraintValidator<ValidServerAddress, String> {
 

--- a/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
@@ -26,9 +26,7 @@ public class ServerConfigValidator implements ConstraintValidator<ValidServerCon
                 serverConfig.getCommunicationType() + "' specified for serverConfig with app " + serverConfig.getApp())
                 .addConstraintViolation();
             return false;
-
         }
-        
 
         return true;
     }

--- a/config/src/main/java/com/quorum/tessera/config/keypairs/DirectKeyPair.java
+++ b/config/src/main/java/com/quorum/tessera/config/keypairs/DirectKeyPair.java
@@ -14,7 +14,6 @@ public class DirectKeyPair implements ConfigKeyPair {
     @XmlElement
     private final String publicKey;
 
-    
     @Size(min = 1)
     @NotNull
     @ValidBase64(message = "Invalid Base64 key provided")

--- a/config/src/main/java/com/quorum/tessera/config/util/ConfigFileStore.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/ConfigFileStore.java
@@ -2,6 +2,7 @@ package com.quorum.tessera.config.util;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.io.IOCallback;
+
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,15 +19,15 @@ public interface ConfigFileStore {
 
         @Override
         public void save(Config config) {
-            
+
             IOCallback.execute(() -> {
                 Path temp = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
-                try(OutputStream fout = Files.newOutputStream(temp)){
+                try (OutputStream fout = Files.newOutputStream(temp)) {
                     JaxbUtil.marshalWithNoValidation(config, fout);
                 }
-                Files.copy(temp, path,StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(temp, path, StandardCopyOption.REPLACE_EXISTING);
                 return null;
-            });  
+            });
         }
     }
 
@@ -34,14 +35,11 @@ public interface ConfigFileStore {
         Store.INSTANCE.path = path;
         return Store.INSTANCE;
     }
-    
-    
+
     static ConfigFileStore get() {
         return Store.INSTANCE;
     }
-    
-    void save(Config config);
-    
 
+    void save(Config config);
 
 }

--- a/config/src/main/java/com/quorum/tessera/config/util/EnvironmentVariables.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/EnvironmentVariables.java
@@ -3,15 +3,25 @@ package com.quorum.tessera.config.util;
 public final class EnvironmentVariables {
 
     public static final String SERVER_KEYSTORE_PWD = "TESSERA_SERVER_KEYSTORE_PWD";
+
     public static final String SERVER_TRUSTSTORE_PWD = "TESSERA_SERVER_TRUSTSTORE_PWD";
+
     public static final String CLIENT_KEYSTORE_PWD = "TESSERA_CLIENT_KEYSTORE_PWD";
+
     public static final String CLIENT_TRUSTSTORE_PWD = "TESSERA_CLIENT_TRUSTSTORE_PWD";
+
     public static final String AZURE_CLIENT_ID = "AZURE_CLIENT_ID";
+
     public static final String AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET";
+
     public static final String HASHICORP_ROLE_ID = "HASHICORP_ROLE_ID";
+
     public static final String HASHICORP_SECRET_ID = "HASHICORP_SECRET_ID";
+
     public static final String HASHICORP_TOKEN = "HASHICORP_TOKEN";
+
     public static final String HASHICORP_CLIENT_KEYSTORE_PWD = "HASHICORP_CLIENT_KEYSTORE_PWD";
+
     public static final String HASHICORP_CLIENT_TRUSTSTORE_PWD = "HASHICORP_CLIENT_TRUSTSTORE_PWD";
 
     private EnvironmentVariables() {

--- a/config/src/main/java/com/quorum/tessera/config/util/XmlProcessingCallback.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/XmlProcessingCallback.java
@@ -1,23 +1,27 @@
-
 package com.quorum.tessera.config.util;
 
 import com.quorum.tessera.config.ConfigException;
-import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
+import java.io.IOException;
 
 @FunctionalInterface
 public interface XmlProcessingCallback<T> {
-    
+
+    Logger LOGGER = LoggerFactory.getLogger(XmlProcessingCallback.class);
+
     T doExecute() throws IOException, JAXBException, TransformerException;
-    
+
     static <T> T execute(XmlProcessingCallback<T> callback) {
         try {
             return callback.doExecute();
         } catch (IOException | JAXBException | TransformerException ex) {
-           throw new ConfigException(ex);
+            LOGGER.error(null, ex);
+            throw new ConfigException(ex);
         }
     }
-    
-    
+
 }

--- a/config/src/main/java/com/quorum/tessera/config/vault/data/HashicorpGetSecretData.java
+++ b/config/src/main/java/com/quorum/tessera/config/vault/data/HashicorpGetSecretData.java
@@ -3,9 +3,13 @@ package com.quorum.tessera.config.vault.data;
 import com.quorum.tessera.config.KeyVaultType;
 
 public class HashicorpGetSecretData implements GetSecretData {
+
     private final String secretEngineName;
+
     private final String secretName;
+
     private final String valueId;
+
     private final int secretVersion;
 
     public HashicorpGetSecretData(String secretEngineName, String secretName, String valueId, int secretVersion) {
@@ -35,4 +39,5 @@ public class HashicorpGetSecretData implements GetSecretData {
     public KeyVaultType getType() {
         return KeyVaultType.HASHICORP;
     }
+
 }

--- a/config/src/main/java/com/quorum/tessera/config/vault/data/HashicorpSetSecretData.java
+++ b/config/src/main/java/com/quorum/tessera/config/vault/data/HashicorpSetSecretData.java
@@ -5,8 +5,11 @@ import com.quorum.tessera.config.KeyVaultType;
 import java.util.Map;
 
 public class HashicorpSetSecretData implements SetSecretData {
+
     private final String secretEngineName;
+
     private final String secretName;
+
     private final Map<String, Object> nameValuePairs;
 
     public HashicorpSetSecretData(String secretEngineName, String secretName, Map<String, Object> nameValuePairs) {
@@ -31,4 +34,5 @@ public class HashicorpSetSecretData implements SetSecretData {
     public KeyVaultType getType() {
         return KeyVaultType.HASHICORP;
     }
+
 }

--- a/config/src/test/java/com/quorum/tessera/config/ConfigExceptionTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ConfigExceptionTest.java
@@ -1,11 +1,9 @@
-
 package com.quorum.tessera.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 public class ConfigExceptionTest {
-    
 
     @Test
     public void constructWithCause() {

--- a/config/src/test/java/com/quorum/tessera/config/DeprecatedServerConfigTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/DeprecatedServerConfigTest.java
@@ -37,7 +37,6 @@ public class DeprecatedServerConfigTest {
         assertThat(p2p.getApp()).isEqualTo(AppType.P2P);
     }
 
-
     @Test
     public void createConfigsFromDeprecatedServerConfigWithCommTypeGRPC() {
 

--- a/config/src/test/java/com/quorum/tessera/config/JaxbCreateFactoryTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/JaxbCreateFactoryTest.java
@@ -53,5 +53,4 @@ public class JaxbCreateFactoryTest {
 
     }
 
-
 }

--- a/config/src/test/java/com/quorum/tessera/config/KeyReadingTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/KeyReadingTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class KeyReadingTest {
 
     @Test
@@ -87,7 +86,6 @@ public class KeyReadingTest {
 
     }
 
-
     @Test
     public void wrongPasswordsProvided() throws IOException {
 
@@ -99,7 +97,5 @@ public class KeyReadingTest {
         assertThat(config.getKeys().getKeyData()).hasSize(1);
         assertThat(config.getKeys().getKeyData().get(0).getPrivateKey()).startsWith("NACL_FAILURE");
     }
-
-
 
 }

--- a/config/src/test/java/com/quorum/tessera/config/ObjectFactoryTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ObjectFactoryTest.java
@@ -1,39 +1,29 @@
 package com.quorum.tessera.config;
 
-import javax.xml.bind.JAXBElement;
-import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.xml.bind.JAXBElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class ObjectFactoryTest {
 
     private ObjectFactory objectFactory;
 
-    public ObjectFactoryTest() {
-    }
-
     @Before
     public void setUp() {
-        objectFactory = new ObjectFactory();
-    }
-
-    @After
-    public void tearDown() {
+        this.objectFactory = new ObjectFactory();
     }
 
     @Test
     public void createConfiguration() {
-        Config configuration = mock(Config.class);
-        JAXBElement<Config> element
-                = objectFactory.createConfiguration(configuration);
+        final Config configuration = mock(Config.class);
+        final JAXBElement<Config> element = objectFactory.createConfiguration(configuration);
 
         assertThat(element).isNotNull();
         assertThat(element.getValue()).isSameAs(configuration);
-
     }
-
-   
 
 }

--- a/config/src/test/java/com/quorum/tessera/config/PrivateKeyTypeTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/PrivateKeyTypeTest.java
@@ -1,9 +1,8 @@
-
 package com.quorum.tessera.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PrivateKeyTypeTest {
     

--- a/config/src/test/java/com/quorum/tessera/config/ServerConfigTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ServerConfigTest.java
@@ -14,7 +14,7 @@ public class ServerConfigTest {
     @Test
     public void serverUri() throws URISyntaxException {
         String serverAddress = "somedomain:8989";
-        ServerConfig config = new ServerConfig(AppType.P2P, true,serverAddress, CommunicationType.REST, null, null, null);
+        ServerConfig config = new ServerConfig(AppType.P2P, true, serverAddress, CommunicationType.REST, null, null, null);
 
         assertThat(config.getServerUri()).isEqualTo(new URI("somedomain:8989"));
         assertThat(config.isSsl()).isFalse();
@@ -23,15 +23,14 @@ public class ServerConfigTest {
     @Test
     public void bindingUri() throws URISyntaxException {
         String serverAddress = "somedomain:99";
-        ServerConfig config = new ServerConfig(AppType.P2P, true,serverAddress, CommunicationType.REST, null, null, "http://somedomain:9000");
+        ServerConfig config = new ServerConfig(AppType.P2P, true, serverAddress, CommunicationType.REST, null, null, "http://somedomain:9000");
         assertThat(config.getBindingUri()).isEqualTo(new URI("http://somedomain:9000"));
         assertThat(config.isSsl()).isFalse();
     }
 
-
     @Test(expected = ConfigException.class)
     public void serverUriInvalidUri() {
-        new ServerConfig(AppType.P2P, true,"&@€~:*&2:-1", CommunicationType.REST, null, null, null).getServerUri();
+        new ServerConfig(AppType.P2P, true, "&@€~:*&2:-1", CommunicationType.REST, null, null, null).getServerUri();
     }
 
     @Test(expected = ConfigException.class)
@@ -44,7 +43,7 @@ public class ServerConfigTest {
         final SslConfig sslConfig = mock(SslConfig.class);
         when(sslConfig.getTls()).thenReturn(SslAuthenticationMode.OFF);
 
-        ServerConfig serverConfig = new ServerConfig(AppType.P2P, true,"somedomain:8989", CommunicationType.REST, sslConfig, null, null);
+        ServerConfig serverConfig = new ServerConfig(AppType.P2P, true, "somedomain:8989", CommunicationType.REST, sslConfig, null, null);
         assertThat(serverConfig.isSsl()).isFalse();
     }
 
@@ -65,14 +64,14 @@ public class ServerConfigTest {
 
     @Test
     public void nullAdvertisedUrlIsSameAsBindAddress() {
-        final ServerConfig serverConfig = new ServerConfig(AppType.P2P, true,"somedomain:8989", CommunicationType.REST, null, null, null);
+        final ServerConfig serverConfig = new ServerConfig(AppType.P2P, true, "somedomain:8989", CommunicationType.REST, null, null, null);
         assertThat(serverConfig.getBindingAddress()).isEqualTo("somedomain:8989");
         assertThat(serverConfig.isUnixSocket()).isFalse();
     }
-    
+
     @Test
     public void unixSocketConfig() {
-        final ServerConfig serverConfig = new ServerConfig(AppType.P2P, true,"unix:/bogis.ipc", CommunicationType.REST, null, null, null);
+        final ServerConfig serverConfig = new ServerConfig(AppType.P2P, true, "unix:/bogis.ipc", CommunicationType.REST, null, null, null);
         assertThat(serverConfig.getBindingAddress()).isEqualTo("unix:/bogis.ipc");
         assertThat(serverConfig.isUnixSocket()).isTrue();
     }

--- a/config/src/test/java/com/quorum/tessera/config/SslAuthenticationModeTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/SslAuthenticationModeTest.java
@@ -1,13 +1,11 @@
-
 package com.quorum.tessera.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SslAuthenticationModeTest {
-    
-    
+
     @Test
     public void testValues() {
         for(SslAuthenticationMode t : SslAuthenticationMode.values()) {

--- a/config/src/test/java/com/quorum/tessera/config/SslTrustModeTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/SslTrustModeTest.java
@@ -1,13 +1,10 @@
-
 package com.quorum.tessera.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SslTrustModeTest {
-    
 
     @Test
     public void testValues() {

--- a/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
@@ -419,8 +419,6 @@ public class ValidationTest {
             assertThat(validresult).hasSize(1);
         }
 
-        
-
         String[] validSamples = {"unix:/foo/bar.ipc","http://localhost:8080","https://somestrangedomain.com:8080"};
         for (String sample : validSamples) {
             config.setServerAddress(sample);

--- a/config/src/test/java/com/quorum/tessera/config/constraints/KeyVaultConfigurationValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/KeyVaultConfigurationValidatorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 public class KeyVaultConfigurationValidatorTest {
 
     private ConstraintValidatorContext context;
+
     private KeyVaultConfigurationValidator validator;
 
     @Before

--- a/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
@@ -1,23 +1,19 @@
 package com.quorum.tessera.config.constraints;
 
 import com.quorum.tessera.io.FilesDelegate;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import org.junit.Test;
 
 import javax.validation.ConstraintValidatorContext;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class PathValidatorTest {
 
@@ -76,7 +72,7 @@ public class PathValidatorTest {
     }
 
     @Test
-    public void nullPathReturnsTrue() throws IOException {
+    public void nullPathReturnsTrue() {
 
         ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
 
@@ -113,13 +109,13 @@ public class PathValidatorTest {
     }
 
     @Test
-    public void checkCannotCreateFile() throws IOException {
+    public void checkCannotCreateFile() {
 
         ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
-        
+
         when(context.buildConstraintViolationWithTemplate(anyString()))
-                .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
-                
+            .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
         ValidPath validPath = mock(ValidPath.class);
         when(validPath.checkCanCreate()).thenReturn(true);
         when(validPath.checkExists()).thenReturn(Boolean.FALSE);
@@ -129,31 +125,29 @@ public class PathValidatorTest {
         Path path = mock(Path.class);
 
         FilesDelegate filesDelegate = mock(FilesDelegate.class);
-        
+
         when(filesDelegate.notExists(path)).thenReturn(Boolean.TRUE);
         when(filesDelegate.createFile(path)).thenThrow(UncheckedIOException.class);
         when(filesDelegate.deleteIfExists(path)).thenThrow(UncheckedIOException.class);//final block coverage
-        
+
         pathValidator.setFilesDelegate(filesDelegate);
-        
+
         assertThat(pathValidator.isValid(path, context)).isFalse();
 
         verify(context).disableDefaultConstraintViolation();
         verify(context).buildConstraintViolationWithTemplate(anyString());
-        
-        verifyNoMoreInteractions(context);
-       
 
+        verifyNoMoreInteractions(context);
     }
-    
+
     @Test
-    public void checkCannotCreateFileExistingFile() throws IOException {
+    public void checkCannotCreateFileExistingFile() {
 
         ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
-        
+
         when(context.buildConstraintViolationWithTemplate(anyString()))
-                .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
-                
+            .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
         ValidPath validPath = mock(ValidPath.class);
         when(validPath.checkCanCreate()).thenReturn(true);
         when(validPath.checkExists()).thenReturn(Boolean.FALSE);
@@ -163,26 +157,24 @@ public class PathValidatorTest {
         Path path = mock(Path.class);
 
         FilesDelegate filesDelegate = mock(FilesDelegate.class);
-        
+
         when(filesDelegate.notExists(path)).thenReturn(Boolean.FALSE);
-        
+
         pathValidator.setFilesDelegate(filesDelegate);
-        
+
         assertThat(pathValidator.isValid(path, context)).isTrue();
 
         verifyNoMoreInteractions(context);
-       
-
     }
-    
-        @Test
-    public void checkCannotCreateFileDontCheck() throws IOException {
+
+    @Test
+    public void checkCannotCreateFileDontCheck() {
 
         ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
-        
+
         when(context.buildConstraintViolationWithTemplate(anyString()))
-                .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
-                
+            .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
         ValidPath validPath = mock(ValidPath.class);
         when(validPath.checkCanCreate()).thenReturn(false);
         when(validPath.checkExists()).thenReturn(false);
@@ -192,15 +184,13 @@ public class PathValidatorTest {
         Path path = mock(Path.class);
 
         FilesDelegate filesDelegate = mock(FilesDelegate.class);
-        
+
         when(filesDelegate.notExists(path)).thenReturn(Boolean.TRUE);
-        
+
         pathValidator.setFilesDelegate(filesDelegate);
-        
+
         assertThat(pathValidator.isValid(path, context)).isTrue();
 
         verifyNoMoreInteractions(context);
-       
-
     }
 }

--- a/config/src/test/java/com/quorum/tessera/config/constraints/ServerConfigValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/ServerConfigValidatorTest.java
@@ -70,6 +70,4 @@ public class ServerConfigValidatorTest {
         verify(cvc).buildConstraintViolationWithTemplate(anyString());
     }
 
-
-
 }

--- a/config/src/test/java/com/quorum/tessera/config/constraints/ServerConfigsValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/ServerConfigsValidatorTest.java
@@ -21,7 +21,9 @@ public class ServerConfigsValidatorTest {
     private List<ServerConfig> serverConfigs;
 
     private ServerConfig p2pServerConfig;
+
     private ServerConfig q2tServerConfig;
+
     private ServerConfig thirdPartyServerConfig;
 
     private ConstraintValidatorContext cvc;

--- a/config/src/test/java/com/quorum/tessera/config/constraints/SslConfigValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/SslConfigValidatorTest.java
@@ -72,7 +72,7 @@ public class SslConfigValidatorTest {
     @Test
     public void testTlsAllowKeyStoreGeneration() {
         SslConfig sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, true, null, null, null, null, SslTrustMode.NONE, null, null, null, null, SslTrustMode.NONE, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, true, null, null, null, null, SslTrustMode.NONE, null, null, null, null, SslTrustMode.NONE, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isTrue();
     }
@@ -80,62 +80,62 @@ public class SslConfigValidatorTest {
     @Test
     public void testKeyStoreConfigInvalid() {
         SslConfig sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, null, null, null, null, null, null, null, null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, Paths.get("somefile"), "somepassword", null, null, null, Paths.get("somefile"), null, null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, Paths.get("somefile"), "somepassword", null, null, null, Paths.get("somefile"), null, null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, Paths.get("somefile"), null, null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, Paths.get("somefile"), null, null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, null, null, null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, Paths.get("somefile"), "password", null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, Paths.get("somefile"), "password", null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, tmpFile, null, null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, tmpFile, null, null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null,Paths.get("someFile"),null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, Paths.get("someFile"), null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null,Paths.get("someFile"),Paths.get("someFile"),null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, Paths.get("someFile"), Paths.get("someFile"), null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile,Paths.get("someFile"),null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, Paths.get("someFile"), null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, tmpFile, Paths.get("someFile"),null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, tmpFile, Paths.get("someFile"), null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, tmpFile, Paths.get("someFile"),Paths.get("someFile"),null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, tmpFile, Paths.get("someFile"), Paths.get("someFile"), null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, tmpFile, tmpFile, Paths.get("someFile"),null
+            SslAuthenticationMode.STRICT, false, tmpFile, null, null, null, null, tmpFile, null, null, null, null, null, null, null, null, tmpFile, tmpFile, tmpFile, Paths.get("someFile"), null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
@@ -333,7 +333,6 @@ public class SslConfigValidatorTest {
         verify(context).buildConstraintViolationWithTemplate(anyString());
         assertThat(result).isFalse();
     }
-
 
     @Test
     public void noClientKeyStorePasswordInConfigOrEnvVarsThenInvalid() {
@@ -551,12 +550,12 @@ public class SslConfigValidatorTest {
     @Test
     public void testTrustModeNull() {
         SslConfig sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, tmpFile, "password", null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, null, tmpFile, "password", null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.CA, tmpFile, "password", null, null, null, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.CA, tmpFile, "password", null, null, null, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
     }
@@ -564,22 +563,22 @@ public class SslConfigValidatorTest {
     @Test
     public void testTrustModeWhiteListButKnownHostsFileNotExisted() {
         SslConfig sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, Paths.get("somefile"), null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, Paths.get("somefile"), null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, Paths.get("some"),null,null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, "password", null, null, SslTrustMode.WHITELIST, tmpFile, Paths.get("some"), null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
     }
@@ -587,32 +586,32 @@ public class SslConfigValidatorTest {
     @Test
     public void testTrustModeCAButTrustStoreConfigInvalid() {
         SslConfig sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.NONE, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", null, null, SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.NONE, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", tmpFile, null, SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.NONE, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", tmpFile, null, SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.NONE, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", Paths.get("somefile"), "password", SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.NONE, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", Paths.get("somefile"), "password", SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.NONE, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", tmpFile, "p", SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.CA, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", tmpFile, "p", SslTrustMode.CA, tmpFile, "password", null, null, SslTrustMode.CA, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", tmpFile, null, SslTrustMode.CA, tmpFile, "password", tmpFile, null, SslTrustMode.CA, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", tmpFile, null, SslTrustMode.CA, tmpFile, "password", tmpFile, null, SslTrustMode.CA, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
 
         sslConfig = new SslConfig(
-                SslAuthenticationMode.STRICT, false, tmpFile, "password", Paths.get("somefile"), "password", SslTrustMode.CA, tmpFile, "password", Paths.get("somefile"), "p", SslTrustMode.CA, null, null, null, null,null,null,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "password", Paths.get("somefile"), "password", SslTrustMode.CA, tmpFile, "password", Paths.get("somefile"), "p", SslTrustMode.CA, null, null, null, null, null, null, null, null, null
         );
         assertThat(validator.isValid(sslConfig, context)).isFalse();
     }
@@ -1008,7 +1007,7 @@ public class SslConfigValidatorTest {
     @Test
     public void testNoKeyStoreFilesButPemFilesProvided() {
         SslConfig sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, null, null, null, null, SslTrustMode.CA, null, null, null, null, SslTrustMode.CA, null, null, Arrays.asList(tmpFile), Arrays.asList(tmpFile), tmpFile,tmpFile,tmpFile,tmpFile,null
+            SslAuthenticationMode.STRICT, false, null, null, null, null, SslTrustMode.CA, null, null, null, null, SslTrustMode.CA, null, null, Arrays.asList(tmpFile), Arrays.asList(tmpFile), tmpFile, tmpFile, tmpFile, tmpFile, null
         );
         assertThat(validator.isValid(sslConfig, context)).isTrue();
     }
@@ -1016,7 +1015,7 @@ public class SslConfigValidatorTest {
     @Test
     public void testValidSsl() {
         SslConfig sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, tmpFile, Arrays.asList(tmpFile), Arrays.asList(tmpFile), tmpFile,tmpFile,tmpFile,tmpFile,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, tmpFile, Arrays.asList(tmpFile), Arrays.asList(tmpFile), tmpFile, tmpFile, tmpFile, tmpFile, null
         );
         assertThat(validator.isValid(sslConfig, context)).isTrue();
     }
@@ -1024,13 +1023,13 @@ public class SslConfigValidatorTest {
     @Test
     public void testValidSslServerOnly() {
         SslConfig sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, null, null, null, null, tmpFile, null, Arrays.asList(tmpFile), null, tmpFile,tmpFile,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, null, null, null, null, tmpFile, null, Arrays.asList(tmpFile), null, tmpFile, tmpFile, null, null, null
         );
         sslConfig.setSslConfigType(SslConfigType.SERVER_ONLY);
         assertThat(validator.isValid(sslConfig, context)).isTrue();
 
         SslConfig secondSslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, null, null, null, null, null, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, null, tmpFile, null, Arrays.asList(tmpFile), null,null,tmpFile,tmpFile,null
+            SslAuthenticationMode.STRICT, false, null, null, null, null, null, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, null, tmpFile, null, Arrays.asList(tmpFile), null, null, tmpFile, tmpFile, null
         );
         secondSslConfig.setSslConfigType(SslConfigType.SERVER_ONLY);
         assertThat(validator.isValid(secondSslConfig, context)).isFalse();
@@ -1039,13 +1038,13 @@ public class SslConfigValidatorTest {
     @Test
     public void testValidSslClientOnly() {
         SslConfig sslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, null, null, null, null, null, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, null, tmpFile, null, Arrays.asList(tmpFile), null,null,tmpFile,tmpFile,null
+            SslAuthenticationMode.STRICT, false, null, null, null, null, null, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, null, tmpFile, null, Arrays.asList(tmpFile), null, null, tmpFile, tmpFile, null
         );
         sslConfig.setSslConfigType(SslConfigType.CLIENT_ONLY);
         assertThat(validator.isValid(sslConfig, context)).isTrue();
 
         SslConfig secondSslConfig = new SslConfig(
-            SslAuthenticationMode.STRICT, false, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, null, null, null, null, tmpFile, null, Arrays.asList(tmpFile), null, tmpFile,tmpFile,null,null,null
+            SslAuthenticationMode.STRICT, false, tmpFile, "pw", tmpFile, "pw", SslTrustMode.CA, tmpFile, null, null, null, null, tmpFile, null, Arrays.asList(tmpFile), null, tmpFile, tmpFile, null, null, null
         );
         secondSslConfig.setSslConfigType(SslConfigType.CLIENT_ONLY);
         assertThat(validator.isValid(secondSslConfig, context)).isFalse();

--- a/config/src/test/java/com/quorum/tessera/config/constraints/ValidContentValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/ValidContentValidatorTest.java
@@ -136,6 +136,5 @@ public class ValidContentValidatorTest {
         assertThat(validator.isValid(path, context)).isFalse();
 
     }
-    
 
 }

--- a/config/src/test/java/com/quorum/tessera/config/util/ConfigFileStoreTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/util/ConfigFileStoreTest.java
@@ -2,15 +2,17 @@ package com.quorum.tessera.config.util;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.JdbcConfig;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Before;
-import org.junit.Test;
 
 public class ConfigFileStoreTest {
 
@@ -35,7 +37,6 @@ public class ConfigFileStoreTest {
     @Test
     public void getReturnsSameInstance() {
         assertThat(ConfigFileStore.get()).isSameAs(configFileStore);
-
     }
     
     @Test
@@ -45,8 +46,7 @@ public class ConfigFileStoreTest {
         config.setJdbcConfig(new JdbcConfig());
         config.getJdbcConfig().setUsername("JUNIT");
         configFileStore.save(config);
-        
-        
+
         Config result = JaxbUtil.unmarshal(Files.newInputStream(path), Config.class);
         
         assertThat(result.getJdbcConfig().getUsername()).isEqualTo("JUNIT");

--- a/config/src/test/java/com/quorum/tessera/config/util/EnvironmentVariableProviderTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/util/EnvironmentVariableProviderTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class EnvironmentVariableProviderTest {
 
     private EnvironmentVariableProvider provider;
@@ -32,4 +31,5 @@ public class EnvironmentVariableProviderTest {
         //returns false as env variables not set in test environment
         assertThat(provider.hasEnv("env")).isFalse();
     }
+
 }

--- a/config/src/test/java/com/quorum/tessera/config/util/JaxbUtilTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/util/JaxbUtilTest.java
@@ -5,6 +5,7 @@ import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyDataConfig;
 import com.quorum.tessera.config.PrivateKeyData;
 import com.quorum.tessera.config.PrivateKeyType;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class JaxbUtilTest {
     public void unmarshalLocked() {
 
         final KeyDataConfig result = JaxbUtil.unmarshal(
-                getClass().getResourceAsStream("/lockedprivatekey.json"), KeyDataConfig.class
+            getClass().getResourceAsStream("/lockedprivatekey.json"), KeyDataConfig.class
         );
 
         assertThat(result).isNotNull();
@@ -52,10 +53,9 @@ public class JaxbUtilTest {
     @Test
     public void marshallingOutputStream() throws Exception {
         final KeyDataConfig input = new KeyDataConfig(
-                new PrivateKeyData("VAL", null, null, null, null),
-                PrivateKeyType.UNLOCKED
+            new PrivateKeyData("VAL", null, null, null, null),
+            PrivateKeyType.UNLOCKED
         );
-        
 
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
             JaxbUtil.marshal(input, bout);
@@ -81,8 +81,8 @@ public class JaxbUtilTest {
         final Throwable throwable = catchThrowable(() -> JaxbUtil.marshal(ex, out));
 
         assertThat(throwable)
-                .isInstanceOf(ConfigException.class)
-                .hasCauseExactlyInstanceOf(MarshalException.class);
+            .isInstanceOf(ConfigException.class)
+            .hasCauseExactlyInstanceOf(MarshalException.class);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class JaxbUtilTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException ex) {
             assertThat(ex)
-                    .isInstanceOf(ConstraintViolationException.class);
+                .isInstanceOf(ConstraintViolationException.class);
         }
     }
 
@@ -118,8 +118,8 @@ public class JaxbUtilTest {
     public void marshalToString() {
 
         final KeyDataConfig input = new KeyDataConfig(
-                new PrivateKeyData("VAL", null, null, null, null),
-                PrivateKeyType.UNLOCKED
+            new PrivateKeyData("VAL", null, null, null, null),
+            PrivateKeyType.UNLOCKED
         );
 
         String resultData = JaxbUtil.marshalToString(input);
@@ -139,8 +139,8 @@ public class JaxbUtilTest {
     public void marshalDOntValidateString() {
 
         final KeyDataConfig input = new KeyDataConfig(
-                null,
-                null
+            null,
+            null
         );
 
         String resultData = JaxbUtil.marshalToStringNoValidation(input);
@@ -159,20 +159,20 @@ public class JaxbUtilTest {
         final Throwable throwable = catchThrowable(() -> JaxbUtil.marshalWithNoValidation(ex, out));
 
         assertThat(throwable)
-                .isInstanceOf(ConfigException.class)
-                .hasCauseExactlyInstanceOf(MarshalException.class);
+            .isInstanceOf(ConfigException.class)
+            .hasCauseExactlyInstanceOf(MarshalException.class);
     }
 
     @Test
     public void unwrapConstraintViolationException() {
 
         ConstraintViolationException validationException
-                = new ConstraintViolationException(Collections.emptySet());
+            = new ConstraintViolationException(Collections.emptySet());
 
         Throwable exception = new Exception(validationException);
 
         Optional<ConstraintViolationException> result
-                = JaxbUtil.unwrapConstraintViolationException(exception);
+            = JaxbUtil.unwrapConstraintViolationException(exception);
 
         assertThat(result).isPresent();
         assertThat(result.get()).isSameAs(validationException);
@@ -182,8 +182,8 @@ public class JaxbUtilTest {
     @Test
     public void marshallingProducesNonJaxbException() {
         final KeyDataConfig input = new KeyDataConfig(
-                new PrivateKeyData("VAL", null, null, null, null),
-                PrivateKeyType.UNLOCKED
+            new PrivateKeyData("VAL", null, null, null, null),
+            PrivateKeyType.UNLOCKED
         );
 
         IOException exception = new IOException("What you talking about willis?");
@@ -194,8 +194,8 @@ public class JaxbUtilTest {
         final Throwable throwable = catchThrowable(() -> JaxbUtil.marshal(input, out));
 
         assertThat(throwable)
-                .isInstanceOf(ConfigException.class)
-                .hasCauseExactlyInstanceOf(javax.xml.bind.MarshalException.class);
+            .isInstanceOf(ConfigException.class)
+            .hasCauseExactlyInstanceOf(javax.xml.bind.MarshalException.class);
 
     }
 
@@ -214,11 +214,9 @@ public class JaxbUtilTest {
 
                     assertThat(result.getJsonObject("jdbc").getString("password")).isEqualTo(expectedMaskValue);
 
-
-
                     assertThat(result.getJsonObject("keys").getJsonArray("keyData")
-                            .getJsonObject(0).getString("privateKey"))
-                            .isEqualTo(expectedMaskValue);
+                        .getJsonObject(0).getString("privateKey"))
+                        .isEqualTo(expectedMaskValue);
 
                 }
 
@@ -227,7 +225,6 @@ public class JaxbUtilTest {
 
     }
 
-    
     @Test
     public void marshalMaskedConfigDontDisplayPrivateKeyIfFileIsPresent() throws Exception {
 
@@ -247,7 +244,7 @@ public class JaxbUtilTest {
         }
 
     }
-    
+
     @Test(expected = ConfigException.class)
     public void marshalMaskedConfigThrowsJAXBException() throws Exception {
         Config config = mock(Config.class);


### PR DESCRIPTION
Continuation of https://github.com/jpmorganchase/tessera/issues/699

Applies the `EmptyLineSeparator` check to the `config` module.
Only a single module done here as a lot of violations occurred, so don't want to make the diff any bigger.
