### PR TITLE
Fix #705 out of memory error thrown by Files.readAllBytes

### DIFF
--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
@@ -1,24 +1,47 @@
 package com.quorum.tessera.data.migration;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 public class DirectoryStoreFileTest {
-    
+
     @Test
     public void load() throws Exception {
-    
+
         Path directory = Paths.get(getClass().getResource("/dir/").toURI());
-        
+
         DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
-        
-        Map<byte[],byte[]> results = directoryStoreFile.load(directory);
-        
+
+        Map<byte[], byte[]> results = directoryStoreFile.load(directory);
+
         assertThat(results).hasSize(22);
-        
+
     }
-    
+
+    @Test
+    public void loadLarge() throws Exception {
+
+        Path baseDir = Paths.get(getClass().getResource("/").toURI());
+
+        Path directory = baseDir.resolve(UUID.randomUUID().toString());
+
+        Files.createDirectories(directory);
+
+        Path largeFile = Paths.get(directory.toAbsolutePath().toString(), "loadLarge");
+
+        Files.copy(getClass().getResourceAsStream("/loadLarge.sample"), largeFile);
+
+        DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
+
+        Map<byte[], byte[]> results = directoryStoreFile.load(directory);
+
+        assertThat(results).hasSize(1);
+
+    }
+
 }


### PR DESCRIPTION
Change data loaders to return input streams rather than byte arrays. 
1. Added test replicating issue #705
2. Sqlite doesn't support setBinaryStream so added work around for time being. 