### PR TITLE
Fix #705 out of memory error thrown by Files.readAllBytes

### DIFF
--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/BdbDumpFile.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/BdbDumpFile.java
@@ -1,7 +1,9 @@
 package com.quorum.tessera.data.migration;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -18,9 +20,9 @@ import org.bouncycastle.util.encoders.Hex;
 public class BdbDumpFile implements StoreLoader {
 
     @Override
-    public Map<byte[], byte[]> load(Path inputFile) throws IOException {
+    public Map<byte[], InputStream> load(Path inputFile) throws IOException {
 
-        Map<byte[], byte[]> results = new HashMap<>();
+        Map<byte[], InputStream> results = new HashMap<>();
 
         try (BufferedReader reader = Files.newBufferedReader(inputFile)) {
 
@@ -38,8 +40,11 @@ public class BdbDumpFile implements StoreLoader {
 
                 final String value = reader.readLine();
                 
-                
-                results.put(Base64.getDecoder().decode(Hex.decode(key)), Hex.decode(value));
+                InputStream inputStream = Optional.of(value)
+                    .map(Hex::decode)
+                    .map(ByteArrayInputStream::new)
+                    .get();
+                results.put(Base64.getDecoder().decode(Hex.decode(key)), inputStream);
             }
             return Collections.unmodifiableMap(results);
 

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/CmdLineExecutor.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/CmdLineExecutor.java
@@ -113,7 +113,7 @@ public class CmdLineExecutor {
         final StoreLoader storeLoader = StoreLoader.create(storeType);
 
         final Path inputpath = Paths.get(line.getOptionValue("inputpath"));
-        final Map<byte[], byte[]> data = storeLoader.load(inputpath);
+        final Map<byte[], InputStream> data = storeLoader.load(inputpath);
 
         final String username = line.getOptionValue("dbuser");
         final String password = line.getOptionValue("dbpass");

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/DataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/DataExporter.java
@@ -1,11 +1,12 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Map;
 
 public interface DataExporter {
 
-    void export(Map<byte[], byte[]> data, Path output, String username, String password) throws SQLException;
+    void export(Map<byte[], InputStream> data, Path output, String username, String password) throws SQLException;
 
 }

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/DirectoryStoreFile.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/DirectoryStoreFile.java
@@ -2,6 +2,7 @@ package com.quorum.tessera.data.migration;
 
 import com.quorum.tessera.io.FilesDelegate;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -15,7 +16,7 @@ public class DirectoryStoreFile implements StoreLoader {
     private final FilesDelegate fileDelegate = FilesDelegate.create();
     
     @Override
-    public Map<byte[], byte[]> load(Path directory) throws IOException {
+    public Map<byte[], InputStream> load(Path directory) throws IOException {
 
         Optional.ofNullable(directory)
                 .filter(p -> p.toFile().isDirectory())
@@ -24,7 +25,7 @@ public class DirectoryStoreFile implements StoreLoader {
         try (Stream<Path> stream = Files.list(directory)) {
             return stream.collect(Collectors.toMap(
                     p -> new Base32().decode(p.toFile().getName()),
-                    p -> fileDelegate.readAllBytes(p)));
+                    p -> fileDelegate.newInputStream(p)));
         }
     }
 

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/H2DataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/H2DataExporter.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.sql.SQLException;
@@ -10,7 +11,7 @@ public class H2DataExporter implements DataExporter {
     private static final String INSERT_ROW = "INSERT INTO ENCRYPTED_TRANSACTION (HASH,ENCODED_PAYLOAD) VALUES (?,?)";
 
     @Override
-    public void export(final Map<byte[], byte[]> data,
+    public void export(final Map<byte[], InputStream> data,
                        final Path output,
                        final String username,
                        final String password) throws SQLException {

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/JdbcDataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/JdbcDataExporter.java
@@ -2,6 +2,7 @@ package com.quorum.tessera.data.migration;
 
 import com.quorum.tessera.io.IOCallback;
 import com.quorum.tessera.io.UriCallback;
+import java.io.InputStream;
 
 import java.net.URL;
 import java.nio.file.Files;
@@ -29,7 +30,7 @@ public class JdbcDataExporter implements DataExporter {
     }
 
     @Override
-    public void export(Map<byte[], byte[]> data, Path output, String username, String password) throws SQLException {
+    public void export(Map<byte[], InputStream> data, Path output, String username, String password) throws SQLException {
 
         try (Connection conn = DriverManager.getConnection(jdbcUrl, username, password)) {
 
@@ -40,9 +41,9 @@ public class JdbcDataExporter implements DataExporter {
             }
 
             try (PreparedStatement insertStatement = conn.prepareStatement(insertRow)) {
-                for (Entry<byte[], byte[]> values : data.entrySet()) {
+                for (Entry<byte[], InputStream> values : data.entrySet()) {
                     insertStatement.setBytes(1, values.getKey());
-                    insertStatement.setBytes(2, values.getValue());
+                    insertStatement.setBinaryStream(2, values.getValue());
                     insertStatement.execute();
                 }
             }

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
@@ -1,8 +1,18 @@
 package com.quorum.tessera.data.migration;
 
-import java.net.URL;
+import com.quorum.tessera.io.IOCallback;
+import com.quorum.tessera.io.UriCallback;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
 import java.util.Map;
 
 public class SqliteDataExporter implements DataExporter {
@@ -10,16 +20,34 @@ public class SqliteDataExporter implements DataExporter {
     private static final String INSERT_ROW = "INSERT INTO ENCRYPTED_TRANSACTION (HASH,ENCODED_PAYLOAD) VALUES (?,?)";
 
     @Override
-    public void export(Map<byte[], byte[]> data, Path output, final String username, final String password) throws SQLException {
+    public void export(Map<byte[], InputStream> data, Path output, String username, String password) throws SQLException {
 
         final String connectionString = "jdbc:sqlite:" + output.toString();
 
-        final URL sqlFile = getClass().getResource("/ddls/h2-ddl.sql");
+        final URI sqlFile = UriCallback.execute(() -> getClass().getResource("/ddls/sqlite-ddl.sql").toURI());
 
-        final JdbcDataExporter jdbcDataExporter = new JdbcDataExporter(connectionString, INSERT_ROW, sqlFile);
+        List<String> createTables = IOCallback.execute(() -> Files.readAllLines(Paths.get(sqlFile)));
 
-        jdbcDataExporter.export(data, output, username, password);
+        try (Connection conn = DriverManager.getConnection(connectionString, username, password)) {
 
+            try (Statement stmt = conn.createStatement()) {
+                for (String createTable : createTables) {
+                    stmt.executeUpdate(createTable);
+                }
+            }
+
+            try (PreparedStatement insertStatement = conn.prepareStatement(INSERT_ROW)) {
+                for (Map.Entry<byte[], InputStream> values : data.entrySet()) {
+                    insertStatement.setBytes(1, values.getKey());
+
+                    insertStatement.setBytes(2, Utils.toByteArray(values.getValue()));
+
+                    insertStatement.execute();
+                }
+            }
+
+        }
     }
+
 
 }

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteLoader.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteLoader.java
@@ -1,6 +1,8 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -13,7 +15,7 @@ import java.util.Map;
 public class SqliteLoader implements StoreLoader {
 
     @Override
-    public Map<byte[], byte[]> load(Path input) throws IOException {
+    public Map<byte[], InputStream> load(Path input) throws IOException {
 
         final String url = "jdbc:sqlite:" + input.toString();
 
@@ -23,11 +25,11 @@ public class SqliteLoader implements StoreLoader {
                     Statement statement = conn.createStatement();
                     ResultSet results = statement.executeQuery("SELECT * FROM payload")) {
 
-                Map<byte[], byte[]> loadedData = new HashMap<>();
+                Map<byte[], InputStream> loadedData = new HashMap<>();
                 while (results.next()) {
 
                     byte[] key = results.getBytes("key");
-                    byte[] value = results.getBytes("bytes");
+                    InputStream value = new ByteArrayInputStream(results.getBytes("bytes"));
 
                     loadedData.put(key, value);
 

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/StoreLoader.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/StoreLoader.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.data.migration;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -9,18 +10,23 @@ import java.util.Optional;
 
 public interface StoreLoader {
 
-    Map<byte[], byte[]> load(Path input) throws IOException;
+
+
+    Map<byte[], InputStream> load(Path input) throws IOException;
 
     Map<StoreType, StoreLoader> LOOKUP = Collections.unmodifiableMap(
-        new HashMap<StoreType, StoreLoader>() {{
+        new HashMap<StoreType, StoreLoader>() {
+        {
             put(StoreType.BDB, new BdbDumpFile());
             put(StoreType.DIR, new DirectoryStoreFile());
             put(StoreType.SQLITE, new SqliteLoader());
-        }}
+        }
+    }
     );
 
     static StoreLoader create(StoreType storeType) {
         return Optional.ofNullable(LOOKUP.get(storeType)).get();
     }
+
 
 }

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/Utils.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/Utils.java
@@ -1,0 +1,22 @@
+package com.quorum.tessera.data.migration;
+
+import com.quorum.tessera.io.IOCallback;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+public interface Utils {
+
+    static byte[] toByteArray(InputStream in) {
+        return IOCallback.execute(() -> {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = in.read(buffer)) != -1) {
+                os.write(buffer, 0, len);
+            }
+
+            return os.toByteArray();
+        });
+    }
+}

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/BdbDumpFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/BdbDumpFileTest.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.data.migration;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -16,7 +17,7 @@ public class BdbDumpFileTest {
 
         Path inputFile = Paths.get(getClass().getResource("/bdb/bdb-sample.txt").toURI());
 
-        Map<byte[], byte[]> results = new BdbDumpFile().load(inputFile);
+        Map<byte[], InputStream> results = new BdbDumpFile().load(inputFile);
 
         assertThat(results).hasSize(12);
 
@@ -29,7 +30,7 @@ public class BdbDumpFileTest {
 
         Path inputFile = Paths.get(getClass().getResource("/bdb/single-entry.txt").toURI());
 
-        Map<byte[], byte[]> results = new BdbDumpFile().load(inputFile);
+        Map<byte[], InputStream> results = new BdbDumpFile().load(inputFile);
 
         assertThat(results).hasSize(1);
 

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
@@ -1,20 +1,16 @@
 package com.quorum.tessera.data.migration;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Base64;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
-import org.junit.Ignore;
 
 public class DirectoryStoreFileTest {
 
@@ -31,32 +27,21 @@ public class DirectoryStoreFileTest {
 
     }
 
-    @Ignore
     @Test
     public void loadLarge() throws Exception {
 
         Path baseDir = Paths.get(getClass().getResource("/").toURI());
-
+        
         Path directory = baseDir.resolve(UUID.randomUUID().toString());
 
         Files.createDirectories(directory);
 
         Path largeFile = Paths.get(directory.toAbsolutePath().toString(), "loadLarge");
 
-        try (java.io.BufferedWriter writer = Files.newBufferedWriter(largeFile)) {
-            IntStream.range(1, 50000000)
-                .mapToObj(i -> UUID.randomUUID())
-                .map(UUID::toString)
-                .map(String::getBytes)
-                .map(Base64.getEncoder()::encodeToString)
-                .forEach(s -> {
-                    try {
-                        writer.write(s);
-                    } catch (IOException ex) {
-                        throw new UncheckedIOException(ex);
-                    }
-                });
-        }
+        Random random = new Random();
+        byte[] data = new byte[Integer.MAX_VALUE - 8];
+        random.nextBytes(data);
+        Files.write(largeFile, data);
 
         DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
 

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
@@ -1,28 +1,37 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
+import org.junit.Ignore;
 
 public class DirectoryStoreFileTest {
-    
+
     @Test
     public void load() throws Exception {
-    
+
         Path directory = Paths.get(getClass().getResource("/dir/").toURI());
-        
+
         DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
 
         Map<byte[], InputStream> results = directoryStoreFile.load(directory);
 
         assertThat(results).hasSize(22);
-        
+
     }
 
+    @Ignore
     @Test
     public void loadLarge() throws Exception {
 
@@ -34,14 +43,26 @@ public class DirectoryStoreFileTest {
 
         Path largeFile = Paths.get(directory.toAbsolutePath().toString(), "loadLarge");
 
-        Files.copy(getClass().getResourceAsStream("/loadLarge.sample"), largeFile);
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(largeFile)) {
+            IntStream.range(1, 5000000)
+                .mapToObj(i -> UUID.randomUUID())
+                .map(UUID::toString)
+                .map(String::getBytes)
+                .map(Base64.getEncoder()::encodeToString)
+                .forEach(s -> {
+                    try {
+                        writer.write(s);
+                    } catch (IOException ex) {
+                        throw new UncheckedIOException(ex);
+                    }
+                });
+        }
 
         DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
 
-        Map<byte[], InputStream> results = directoryStoreFile.load(directory);
+        Map results = directoryStoreFile.load(directory);
 
         assertThat(results).hasSize(1);
-
     }
 
 }

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
@@ -44,7 +44,7 @@ public class DirectoryStoreFileTest {
         Path largeFile = Paths.get(directory.toAbsolutePath().toString(), "loadLarge");
 
         try (java.io.BufferedWriter writer = Files.newBufferedWriter(largeFile)) {
-            IntStream.range(1, 5000000)
+            IntStream.range(1, 50000000)
                 .mapToObj(i -> UUID.randomUUID())
                 .map(UUID::toString)
                 .map(String::getBytes)

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
@@ -39,7 +39,7 @@ public class DirectoryStoreFileTest {
         Path largeFile = Paths.get(directory.toAbsolutePath().toString(), "loadLarge");
 
         Random random = new Random();
-        byte[] data = new byte[Integer.MAX_VALUE - 8];
+        byte[] data = new byte[33554432];
         random.nextBytes(data);
         Files.write(largeFile, data);
 

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/DirectoryStoreFileTest.java
@@ -1,5 +1,7 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -14,11 +16,32 @@ public class DirectoryStoreFileTest {
         Path directory = Paths.get(getClass().getResource("/dir/").toURI());
         
         DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
-        
-        Map<byte[],byte[]> results = directoryStoreFile.load(directory);
-        
+
+        Map<byte[], InputStream> results = directoryStoreFile.load(directory);
+
         assertThat(results).hasSize(22);
         
     }
-    
+
+    @Test
+    public void loadLarge() throws Exception {
+
+        Path baseDir = Paths.get(getClass().getResource("/").toURI());
+
+        Path directory = baseDir.resolve(UUID.randomUUID().toString());
+
+        Files.createDirectories(directory);
+
+        Path largeFile = Paths.get(directory.toAbsolutePath().toString(), "loadLarge");
+
+        Files.copy(getClass().getResourceAsStream("/loadLarge.sample"), largeFile);
+
+        DirectoryStoreFile directoryStoreFile = new DirectoryStoreFile();
+
+        Map<byte[], InputStream> results = directoryStoreFile.load(directory);
+
+        assertThat(results).hasSize(1);
+
+    }
+
 }

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/H2DataExporterTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/H2DataExporterTest.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.ByteArrayInputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,6 +9,7 @@ import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.*;
@@ -52,8 +54,8 @@ public class H2DataExporterTest {
 
         Path outputpath = Files.createTempFile("exportSingleLine", ".db");
 
-        Map<byte[], byte[]> singleLineData = new HashMap<>();
-        singleLineData.put("HASH".getBytes(), "VALUE".getBytes());
+        Map<byte[], InputStream> singleLineData = new HashMap<>();
+        singleLineData.put("HASH".getBytes(), new ByteArrayInputStream("VALUE".getBytes()));
 
         exporter.export(singleLineData, outputpath, null, null);
 
@@ -88,8 +90,8 @@ public class H2DataExporterTest {
 
         final Path outputpath = Files.createTempFile("exportSingleLine", ".db");
 
-        final Map<byte[], byte[]> singleLineData = new HashMap<>();
-        singleLineData.put("HASH".getBytes(), "VALUE".getBytes());
+        final Map<byte[], InputStream> singleLineData = new HashMap<>();
+        singleLineData.put("HASH".getBytes(), new ByteArrayInputStream("VALUE".getBytes()));
 
         exporter.export(singleLineData, outputpath, username, password);
 
@@ -124,8 +126,8 @@ public class H2DataExporterTest {
 
         final Path outputpath = Files.createTempFile("exportSingleLine", ".db");
 
-        final Map<byte[], byte[]> singleLineData = new HashMap<>();
-        singleLineData.put("HASH".getBytes(), "VALUE".getBytes());
+        final Map<byte[], InputStream> singleLineData = new HashMap<>();
+        singleLineData.put("HASH".getBytes(), new ByteArrayInputStream("VALUE".getBytes()));
 
         exporter.export(singleLineData, outputpath, username, password);
 

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/JdbcDataExporterTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/JdbcDataExporterTest.java
@@ -2,6 +2,8 @@ package com.quorum.tessera.data.migration;
 
 import com.mockrunner.jdbc.BasicJDBCTestCaseAdapter;
 import com.mockrunner.mock.jdbc.JDBCMockObjectFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import org.junit.After;
 import org.junit.Test;
 
@@ -36,8 +38,8 @@ public class JdbcDataExporterTest extends BasicJDBCTestCaseAdapter{
 
         JdbcDataExporter exporter = new JdbcDataExporter("jdbc:bogus","insert stuff",sqlFile.toUri().toURL());
 
-        Map<byte[],byte[]> data = new HashMap<byte[],byte[]>() {{
-            put("ONE".getBytes(),"TWO".getBytes());
+        Map<byte[],InputStream> data = new HashMap<byte[],InputStream>() {{
+            put("ONE".getBytes(),new ByteArrayInputStream("TWO".getBytes()));
         }};
 
         Path output = mock(Path.class);

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/MockDataExporter.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/MockDataExporter.java
@@ -1,11 +1,12 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Map;
 
 public class MockDataExporter implements DataExporter {
 
-    private Map<byte[], byte[]> results;
+    private Map<byte[], InputStream> results;
 
     private Path path;
 
@@ -14,14 +15,14 @@ public class MockDataExporter implements DataExporter {
     private String password;
 
     @Override
-    public void export(Map<byte[], byte[]> data, Path path, String username, String password) {
+    public void export(Map<byte[], InputStream> data, Path path, String username, String password) {
         this.results = data;
         this.path = path;
         this.username = username;
         this.password = password;
     }
 
-    public Map<byte[], byte[]> getResults() {
+    public Map<byte[], InputStream> getResults() {
         return results;
     }
 

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/SqliteDataExporterTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/SqliteDataExporterTest.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.data.migration;
 
+import java.io.ByteArrayInputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,6 +9,7 @@ import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.*;
@@ -47,8 +49,8 @@ public class SqliteDataExporterTest {
     @Test
     public void exportSingleLine() throws SQLException, IOException {
 
-        Map<byte[], byte[]> singleLineData = new HashMap<>();
-        singleLineData.put("HASH".getBytes(), "VALUE".getBytes());
+        Map<byte[], InputStream> singleLineData = new HashMap<>();
+        singleLineData.put("HASH".getBytes(), new ByteArrayInputStream("VALUE".getBytes()));
 
         exporter.export(singleLineData, outputPath, null, null);
 
@@ -82,8 +84,8 @@ public class SqliteDataExporterTest {
         final String username = "sa";
         final String password = "pass";
 
-        final Map<byte[], byte[]> singleLineData = new HashMap<>();
-        singleLineData.put("HASH".getBytes(), "VALUE".getBytes());
+        final Map<byte[], InputStream> singleLineData = new HashMap<>();
+        singleLineData.put("HASH".getBytes(), new ByteArrayInputStream("VALUE".getBytes()));
 
         exporter.export(singleLineData, outputPath, username, password);
 

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/SqliteLoaderTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/SqliteLoaderTest.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.data.migration;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -37,7 +38,7 @@ public class SqliteLoaderTest {
 
         dbfilePath = Files.createTempFile("sample", ".db");
         try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + dbfilePath);
-             Statement statement = conn.createStatement();) {
+            Statement statement = conn.createStatement();) {
             statement.execute("CREATE TABLE payload (key LONGVARBINARY,bytes LONGVARBINARY)");
             try (PreparedStatement insertStatement = conn.prepareStatement("INSERT INTO payload (key,bytes) values (?,?)")) {
                 for (Entry<String, String> entry : fixtures.entrySet()) {
@@ -60,15 +61,17 @@ public class SqliteLoaderTest {
     @Test
     public void load() throws IOException {
 
-        Map<byte[], byte[]> results = loader.load(dbfilePath);
+        Map<byte[], InputStream> results = loader.load(dbfilePath);
 
         assertThat(results).hasSize(fixtures.size());
 
         Map<String, String> resultz = results.entrySet().stream()
-            .collect(Collectors.toMap(entry -> new String(entry.getKey()), entry -> new String(entry.getValue())));
+            .collect(Collectors.toMap(entry -> new String(entry.getKey()), entry -> new String(Utils.toByteArray(entry.getValue()))));
 
         assertThat(resultz).containsAllEntriesOf(fixtures);
 
     }
+
+
 
 }

--- a/tests/acceptance-test/src/test/java/exec/EnclaveExecManager.java
+++ b/tests/acceptance-test/src/test/java/exec/EnclaveExecManager.java
@@ -71,7 +71,7 @@ public class EnclaveExecManager implements ExecManager {
 
         Future<Boolean> future = executorService.submit(serverStatusCheckExecutor);
 
-        Boolean result = future.get(2, TimeUnit.MINUTES);
+        Boolean result = future.get(3, TimeUnit.MINUTES);
 
         if (!result) {
             throw new IllegalStateException("Enclave server not started");

--- a/tests/acceptance-test/src/test/java/suite/HttpsServerStatusCheck.java
+++ b/tests/acceptance-test/src/test/java/suite/HttpsServerStatusCheck.java
@@ -32,6 +32,8 @@ public class HttpsServerStatusCheck implements ServerStatusCheck {
 
             return true;
         } catch (IOException ex) {
+            LOGGER.warn(ex.getMessage());
+            LOGGER.debug(null, ex);
             return false;
         } finally {
             if (httpsConnection != null) {

--- a/tests/acceptance-test/src/test/java/suite/ServerStatusCheckExecutor.java
+++ b/tests/acceptance-test/src/test/java/suite/ServerStatusCheckExecutor.java
@@ -18,6 +18,7 @@ public class ServerStatusCheckExecutor implements Callable<Boolean> {
 
     @Override
     public Boolean call() throws Exception {
+        LOGGER.info("Connecting {}",serverStatusCheck);
         do {
             LOGGER.debug("Unable to connect try again in 1 sec. {}",serverStatusCheck);
             TimeUnit.SECONDS.sleep(1);


### PR DESCRIPTION
Change data loaders to return input streams rather than byte arrays.

1. Added test replicating issue #705
2. Sqlite doesn't support setBinaryStream so added work around for time being.