### PR TITLE
Add url validation when updating recipients.

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoRecipientUpdateCheck.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/node/PartyInfoRecipientUpdateCheck.java
@@ -1,0 +1,50 @@
+
+package com.quorum.tessera.node;
+
+import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.node.model.PartyInfo;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PartyInfoRecipientUpdateCheck {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartyInfoRecipientUpdateCheck.class);
+    
+    private final PartyInfo existingPartyInfo;
+    
+    private final PartyInfo newPartyInfo;
+
+    public PartyInfoRecipientUpdateCheck(PartyInfo existingPartyInfo, PartyInfo newPartyInfo) {
+        this.existingPartyInfo = Objects.requireNonNull(existingPartyInfo);
+        this.newPartyInfo = Objects.requireNonNull(newPartyInfo);
+    }
+
+    public boolean validateKeysToUrls() {
+
+        final Map<PublicKey, String> existingRecipientKeyUrlMap = existingPartyInfo.getRecipients()
+            .stream()
+            .collect(Collectors.toMap(r -> r.getKey(), r -> r.getUrl()));
+
+        final Map<PublicKey, String> newRecipientKeyUrlMap = newPartyInfo.getRecipients()
+            .stream()
+            .collect(Collectors.toMap(r -> r.getKey(), r -> r.getUrl()));
+
+        for(Map.Entry<PublicKey,String> e : newRecipientKeyUrlMap.entrySet()) {
+            PublicKey key = e.getKey();
+            if(existingRecipientKeyUrlMap.containsKey(key)) {
+                
+                String existingUrl = existingRecipientKeyUrlMap.get(key);
+                String newUrl = newRecipientKeyUrlMap.get(key);
+                if(!existingUrl.equalsIgnoreCase(newUrl)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+    
+    
+}

--- a/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoRecipientUpdateCheckTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoRecipientUpdateCheckTest.java
@@ -1,0 +1,53 @@
+
+package com.quorum.tessera.node;
+
+import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.node.model.PartyInfo;
+import com.quorum.tessera.node.model.Recipient;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+
+public class PartyInfoRecipientUpdateCheckTest {
+    
+    
+    @Test
+    public void validateEmpty() {
+        
+        String url = "http://somedomain.com";
+        
+        Set<Recipient> existingRecipients = new HashSet<>();
+        Set<Recipient> newRecipients = new HashSet<>();
+        PartyInfo existingPartyInfo = new PartyInfo(url, existingRecipients, Collections.EMPTY_SET);
+        PartyInfo newPartyInfo = new PartyInfo(url, newRecipients, Collections.EMPTY_SET);
+        PartyInfoRecipientUpdateCheck check = new PartyInfoRecipientUpdateCheck(existingPartyInfo,newPartyInfo);
+        
+        assertThat(check.validateKeysToUrls()).isTrue();
+        
+    }
+    
+    @Test
+    public void attemptToChangeUrl() {
+        
+        String url = "http://somedomain.com";
+        
+        PublicKey key = PublicKey.from("ONE".getBytes());
+        
+        Recipient existingRecipient = new Recipient(key,"http://one.com");
+        Set<Recipient> existingRecipients = Collections.singleton(existingRecipient);
+        
+        Recipient newRecipient = new Recipient(key,"http://two.com");
+        Set<Recipient> newRecipients = Collections.singleton(newRecipient);
+        
+        
+        PartyInfo existingPartyInfo = new PartyInfo(url, existingRecipients, Collections.EMPTY_SET);
+        PartyInfo newPartyInfo = new PartyInfo(url, newRecipients, Collections.EMPTY_SET);
+        
+        PartyInfoRecipientUpdateCheck check = new PartyInfoRecipientUpdateCheck(existingPartyInfo,newPartyInfo);
+        assertThat(check.validateKeysToUrls()).isFalse();
+        
+    } 
+}

--- a/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoStoreTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/node/PartyInfoStoreTest.java
@@ -136,5 +136,28 @@ public class PartyInfoStoreTest {
         assertThat(firstContact).isBeforeOrEqualTo(secondContact);
 
     }
+    
+    @Test
+    public void attemptToUpdateReciepentWithExistingKeyWithNewUrlIsIgnored() {
+        
+        final PublicKey testKey = PublicKey.from("some-key".getBytes());
+
+        final Set<Recipient> ourKeys = singleton(new Recipient(testKey, uri));
+
+        final PartyInfo initial = new PartyInfo(uri, ourKeys, emptySet());
+
+        partyInfoStore.store(initial);
+        
+        
+        final Set<Recipient> newRecipients = singleton(new Recipient(testKey, "http://other.com"));
+        final PartyInfo updated = new PartyInfo(uri, newRecipients, emptySet());
+        
+        partyInfoStore.store(updated);
+
+        final Set<Recipient> retrievedRecipients = partyInfoStore.getPartyInfo().getRecipients();
+
+        assertThat(retrievedRecipients).hasSize(1)
+            .containsExactly(new Recipient(testKey, uri));
+    }
 
 }


### PR DESCRIPTION
When party info is received that existing key = url recipient pairs match the updated ones. This prevents attempts for malicious parties to register themselves and effectively redirect transactions to them . This is a partial fix for issues raised in #649 . Additional node registration dialogue to ensure that newly joining nodes are able to decypt as expected to be completed in separate PR.  