### PR TITLE
Applies "EmptyLineSeparator" check style to TLS/security module

### DIFF
--- a/security/src/main/java/com/quorum/tessera/ssl/context/SSLContextBuilder.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/context/SSLContextBuilder.java
@@ -24,12 +24,19 @@ public class SSLContextBuilder {
     private static final String PROTOCOL = "TLS";
 
     private String address;
+
     private Path keyStore;
+
     private String keyStorePassword;
+
     private Path key;
+
     private Path certificate;
+
     private Path trustStore;
+
     private String trustStorePassword;
+
     private List<Path> trustedCertificates;
 
     private SSLContext sslContext;
@@ -47,7 +54,6 @@ public class SSLContextBuilder {
 
         this.sslContext = SSLContext.getInstance(PROTOCOL);
     }
-
 
     public static SSLContextBuilder createBuilder(String address, Path keyStore, String keyStorePassword, Path trustStore, String trustStorePassword) throws NoSuchAlgorithmException {
         return new SSLContextBuilder(
@@ -70,14 +76,12 @@ public class SSLContextBuilder {
         return sslContext;
     }
 
-
     public SSLContextBuilder forWhiteList(Path knownHosts) throws GeneralSecurityException, IOException, OperatorCreationException {
 
         sslContext.init(buildKeyManagers(), new TrustManager[]{new WhiteListTrustManager(knownHosts)}, null);
 
         return this;
     }
-
 
     public SSLContextBuilder forCASignedCertificates() throws GeneralSecurityException, IOException, OperatorCreationException {
 
@@ -90,14 +94,12 @@ public class SSLContextBuilder {
         return this;
     }
 
-
     public SSLContextBuilder forAllCertificates() throws GeneralSecurityException, IOException, OperatorCreationException {
 
         sslContext.init(buildKeyManagers(), new TrustManager[]{new TrustAllManager()}, null);
 
         return this;
     }
-
 
     public SSLContextBuilder forTrustOnFirstUse(Path knownHostsFile) throws GeneralSecurityException, IOException, OperatorCreationException {
 
@@ -127,7 +129,6 @@ public class SSLContextBuilder {
 
     }
 
-
     private KeyManager[] buildKeyManagers() throws GeneralSecurityException, IOException, OperatorCreationException {
 
         if (Objects.nonNull(this.keyStore)) {
@@ -139,7 +140,6 @@ public class SSLContextBuilder {
             return SSLKeyStoreLoader.fromPemKeyFile(this.key, this.certificate);
         }
     }
-
 
     private TrustManager[] buildTrustManagers() throws GeneralSecurityException, IOException {
 

--- a/security/src/main/java/com/quorum/tessera/ssl/context/SSLKeyStoreLoader.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/context/SSLKeyStoreLoader.java
@@ -31,6 +31,7 @@ final class SSLKeyStoreLoader {
             "([a-z0-9+/=\\r\\n]+)" +
             "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",
         2);
+
     private static final Pattern CERTIFICATE_PATTERN = Pattern.compile(
         "-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+" +
             "([a-z0-9+/=\\r\\n]+)" +
@@ -38,7 +39,9 @@ final class SSLKeyStoreLoader {
         2);
 
     private static final String KEYSTORE_TYPE="JKS";
+
     private static final String ALIAS = "tessera-node";
+
     private static final char[] EMPTY_PASSWORD = "".toCharArray();
 
     private static final Base64.Decoder decoder = Base64.getMimeDecoder();
@@ -46,7 +49,6 @@ final class SSLKeyStoreLoader {
     private SSLKeyStoreLoader(){
 
     }
-
 
     static KeyManager[] fromJksKeyStore(Path keyStoreFile, String keyStorePassword) throws NoSuchAlgorithmException, IOException, KeyStoreException, CertificateException, UnrecoverableKeyException {
 

--- a/security/src/main/java/com/quorum/tessera/ssl/context/model/SSLContextProperties.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/context/model/SSLContextProperties.java
@@ -6,13 +6,21 @@ import java.util.List;
 public class SSLContextProperties {
 
     private String address;
+
     private Path keyStore;
+
     private String keyStorePassword;
+
     private Path key;
+
     private Path certificate;
+
     private Path trustStore;
+
     private String trustStorePassword;
+
     private List<Path> trustedCertificates;
+
     private Path knownHosts;
 
     public SSLContextProperties(String address,
@@ -70,4 +78,5 @@ public class SSLContextProperties {
     public Path getKnownHosts() {
         return knownHosts;
     }
+
 }

--- a/security/src/main/java/com/quorum/tessera/ssl/exception/TesseraSecurityException.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/exception/TesseraSecurityException.java
@@ -1,10 +1,8 @@
-
 package com.quorum.tessera.ssl.exception;
-
 
 public class TesseraSecurityException extends RuntimeException {
 
-    public TesseraSecurityException(Throwable cause) {
+    public TesseraSecurityException(final Throwable cause) {
         super(cause);
     }
     

--- a/security/src/main/java/com/quorum/tessera/ssl/trust/AbstractTrustManager.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/trust/AbstractTrustManager.java
@@ -19,6 +19,7 @@ abstract class AbstractTrustManager implements X509TrustManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTrustManager.class);
 
     private Path knownHostsFile;
+
     private Map<String, String> certificates;
 
     AbstractTrustManager(final Path knownHostsFile) throws IOException {

--- a/security/src/main/java/com/quorum/tessera/ssl/trust/CompositeTrustManager.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/trust/CompositeTrustManager.java
@@ -52,5 +52,4 @@ public class CompositeTrustManager extends AbstractTrustManager {
         return new X509Certificate[0];
     }
 
-
 }

--- a/security/src/main/java/com/quorum/tessera/ssl/util/TlsUtils.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/util/TlsUtils.java
@@ -26,7 +26,6 @@ import java.util.Date;
 
 public interface TlsUtils {
 
-
     String ENCRYPTION = "RSA";
     String COMMON_NAME_STRING = "CN=";
     String SIGNATURE_ALGORITHM = "SHA512WithRSAEncryption";
@@ -101,6 +100,5 @@ public interface TlsUtils {
         return new TlsUtils() {
         };
     }
-
 
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/context/ClientSSLContextFactoryTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/context/ClientSSLContextFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 public class ClientSSLContextFactoryTest {
 
     private EnvironmentVariableProvider envVarProvider;
+
     private String envVarPrefix = "PREFIX";
 
     @Before
@@ -324,7 +325,6 @@ public class ClientSSLContextFactoryTest {
 
         assertThat(result).isEqualTo(prefixedEnvVal);
     }
-
 
     @Test(expected = TesseraSecurityException.class)
     public void securityExceptionsAreThrownAsTesseraException() throws Exception {

--- a/security/src/test/java/com/quorum/tessera/ssl/context/SSLContextBuilderTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/context/SSLContextBuilderTest.java
@@ -39,15 +39,11 @@ public class SSLContextBuilderTest {
 
     private List<Path> trustedCertificates;
 
-
     private static final String PASSWORD = "quorum";
 
     private static final String LOCALHOST = "localhost";
 
     private SSLContextBuilder sslContextBuilder;
-
-    public SSLContextBuilderTest() {
-    }
 
     @Before
     public void setUp() throws NoSuchAlgorithmException, OperatorCreationException, InvalidKeyException, IOException, KeyStoreException, SignatureException, NoSuchProviderException, CertificateException, URISyntaxException {
@@ -89,7 +85,6 @@ public class SSLContextBuilderTest {
             .extracting("trustManager").isNotNull()
             .extracting("tm").isNotNull()
             .hasAtLeastOneElementOfType(WhiteListTrustManager.class);
-
 
     }
 

--- a/security/src/test/java/com/quorum/tessera/ssl/context/SSLKeyStoreLoaderTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/context/SSLKeyStoreLoaderTest.java
@@ -27,7 +27,6 @@ public class SSLKeyStoreLoaderTest {
 
     private Path invalidPemFile;
 
-
     @Before
     public void setUp() throws URISyntaxException, IOException {
         key = Paths.get(getClass().getResource("/key.pem").toURI());
@@ -59,4 +58,5 @@ public class SSLKeyStoreLoaderTest {
                 .hasMessageContaining("NO CERTIFICATE FOUND IN FILE");
         }
     }
+
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/context/ServerSSLContextFactoryTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/context/ServerSSLContextFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 public class ServerSSLContextFactoryTest {
 
     private EnvironmentVariableProvider envVarProvider;
+
     private String envVarPrefix = "PREFIX";
     
     @Before

--- a/security/src/test/java/com/quorum/tessera/ssl/context/model/SSLContextPropertiesTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/context/model/SSLContextPropertiesTest.java
@@ -8,7 +8,6 @@ import com.openpojo.validation.rule.impl.NoPublicFieldsExceptStaticFinalRule;
 import com.openpojo.validation.test.impl.GetterTester;
 import org.junit.Test;
 
-
 public class SSLContextPropertiesTest {
 
     @Test
@@ -24,4 +23,5 @@ public class SSLContextPropertiesTest {
         pojoValidator.validateRecursively("com.quorum.tessera.ssl.context.model");
 
     }
+
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/strategy/TrustModeTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/strategy/TrustModeTest.java
@@ -3,132 +3,77 @@ package com.quorum.tessera.ssl.strategy;
 import com.quorum.tessera.ssl.context.model.SSLContextProperties;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class TrustModeTest {
 
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
-
     private Path tmpFile;
 
     private Path tmpKnownHosts;
 
     @Before
-    public void setUp() {
-        tmpFile = Paths.get(tmpDir.getRoot().getPath(), "tmpFile");
-        tmpKnownHosts = Paths.get(tmpDir.getRoot().getPath(),"knownHosts");
-    }
+    public void setUp() throws IOException {
+        final Path folder = Files.createTempDirectory("tmp");
 
+        this.tmpFile = folder.resolve("tmpFile");
+        this.tmpKnownHosts = folder.resolve("knownHosts");
+    }
 
     @Test
     public void testNone() throws IOException, GeneralSecurityException, OperatorCreationException {
+        final SSLContextProperties props = new SSLContextProperties(
+            "http://localhost:8080", tmpFile, "quorum", null, null, tmpFile, "quorum", null, tmpKnownHosts
+        );
 
-        assertThat(
-            TrustMode.NONE.createSSLContext(
-                new SSLContextProperties(
-                    "http://localhost:8080",
-                    tmpFile,
-                    "quorum",
-                    null,
-                    null,
-                    tmpFile,
-                    "quorum",
-                    null,
-                    tmpKnownHosts
-                )
-            )
-        ).isNotNull();
-
+        assertThat(TrustMode.NONE.createSSLContext(props)).isNotNull();
     }
 
     @Test
     public void testWhiteList() throws IOException, GeneralSecurityException, OperatorCreationException {
-        assertThat(
-            TrustMode.getValueIfPresent("WHITELIST").get().createSSLContext(
-                new SSLContextProperties(
-                    "http://localhost:8080",
-                    tmpFile,
-                    "quorum",
-                    null,
-                    null,
-                    tmpFile,
-                    "quorum",
-                    null,
-                    tmpKnownHosts
-                )
-            )
-        ).isNotNull();
+        final SSLContextProperties props = new SSLContextProperties(
+            "http://localhost:8080", tmpFile, "quorum", null, null, tmpFile, "quorum", null, tmpKnownHosts
+        );
+
+        assertThat(TrustMode.getValueIfPresent("WHITELIST").get().createSSLContext(props)).isNotNull();
     }
 
     @Test
     public void testCA() throws IOException, GeneralSecurityException, OperatorCreationException {
-        assertThat(
-            TrustMode.getValueIfPresent("CA").get().createSSLContext(
-                new SSLContextProperties(
-                    "http://localhost:8080",
-                    tmpFile,
-                    "quorum",
-                    null,
-                    null,
-                    tmpFile,
-                    "quorum",
-                    null,
-                    tmpKnownHosts
-                )
-            )
-        ).isNotNull();
+        final SSLContextProperties props = new SSLContextProperties(
+            "http://localhost:8080", tmpFile, "quorum", null, null, tmpFile, "quorum", null, tmpKnownHosts
+        );
+
+        assertThat(TrustMode.getValueIfPresent("CA").get().createSSLContext(props)).isNotNull();
     }
 
     @Test
     public void testTOFU() throws IOException, GeneralSecurityException, OperatorCreationException {
-        assertThat(
-            TrustMode.getValueIfPresent("TOFU").get().createSSLContext(
-                new SSLContextProperties(
-                    "http://localhost:8080",
-                    tmpFile,
-                    "quorum",
-                    null,
-                    null,
-                    tmpFile,
-                    "quorum",
-                    null,
-                    tmpKnownHosts
-                )
-            )
-        ).isNotNull();
+        final SSLContextProperties props = new SSLContextProperties(
+            "http://localhost:8080", tmpFile, "quorum", null, null, tmpFile, "quorum", null, tmpKnownHosts
+        );
+
+        assertThat(TrustMode.getValueIfPresent("TOFU").get().createSSLContext(props)).isNotNull();
     }
 
     @Test
     public void testCAOrTOFU() throws IOException, GeneralSecurityException, OperatorCreationException {
-        assertThat(
-            TrustMode.getValueIfPresent("CA_OR_TOFU").get().createSSLContext(
-                new SSLContextProperties(
-                    "http://localhost:8080",
-                    tmpFile,
-                    "quorum",
-                    null,
-                    null,
-                    tmpFile,
-                    "quorum",
-                    null,
-                    tmpKnownHosts
-                )
-            )
-        ).isNotNull();
+        final SSLContextProperties props = new SSLContextProperties(
+            "http://localhost:8080", tmpFile, "quorum", null, null, tmpFile, "quorum", null, tmpKnownHosts
+        );
+
+        assertThat(TrustMode.getValueIfPresent("CA_OR_TOFU").get().createSSLContext(props)).isNotNull();
     }
 
     @Test
     public void testInvalidMode() {
         assertThat(TrustMode.getValueIfPresent("SOMETHING").isPresent()).isFalse();
     }
+
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/trust/CompositeTrustManagerTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/trust/CompositeTrustManagerTest.java
@@ -96,5 +96,4 @@ public class CompositeTrustManagerTest {
         assertThat(trustManager.getAcceptedIssuers()).isEmpty();
     }
 
-
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/trust/TrustOnFirstUseManagerTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/trust/TrustOnFirstUseManagerTest.java
@@ -5,8 +5,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.security.auth.x500.X500Principal;
 import java.io.IOException;
@@ -18,12 +16,10 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.*;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 
 public class TrustOnFirstUseManagerTest {
 
@@ -32,22 +28,21 @@ public class TrustOnFirstUseManagerTest {
 
     private TrustOnFirstUseManager trustManager;
 
-    Path knownHosts;
+    private Path knownHosts;
 
-    @Mock
-    X509Certificate certificate;
+    private X509Certificate certificate;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
-        knownHosts = Paths.get(tmpDir.getRoot().getPath(), "parent", "knownHosts");
+        this.certificate = mock(X509Certificate.class);
+
+        this.knownHosts = Paths.get(tmpDir.getRoot().getPath(), "parent", "knownHosts");
     }
 
     @After
     public void after() {
         verifyNoMoreInteractions(certificate);
     }
-
 
     @Test
     public void testAddThumbPrintToKnownHostsList() throws CertificateException, IOException {
@@ -162,7 +157,6 @@ public class TrustOnFirstUseManagerTest {
         verify(certificate, times(3)).getEncoded();
         verify(certificate, times(3)).getSubjectX500Principal();
 
-
     }
 
     @Test
@@ -170,4 +164,5 @@ public class TrustOnFirstUseManagerTest {
         trustManager = new TrustOnFirstUseManager(knownHosts);
         assertThat(trustManager.getAcceptedIssuers()).isEmpty();
     }
+
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/trust/WhiteListTrustManagerTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/trust/WhiteListTrustManagerTest.java
@@ -32,7 +32,6 @@ public class WhiteListTrustManagerTest {
     @Mock
     X509Certificate certificate;
 
-
     @Before
     public void setUp() throws IOException, CertificateException {
         MockitoAnnotations.initMocks(this);
@@ -41,8 +40,7 @@ public class WhiteListTrustManagerTest {
         when(certificate.getSubjectX500Principal()).thenReturn(cn);
         knownHosts = Files.createTempFile("test", "knownHosts");
 
-        try (BufferedWriter writer = Files.newBufferedWriter(knownHosts, StandardOpenOption.APPEND))
-        {
+        try (BufferedWriter writer = Files.newBufferedWriter(knownHosts, StandardOpenOption.APPEND)) {
             writer.write("someaddress somethumbprint");
             writer.newLine();
             writer.write("localhost" + " " + CertificateUtil.create().thumbPrint(certificate));

--- a/security/src/test/java/com/quorum/tessera/ssl/util/CertificateUtilTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/util/CertificateUtilTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 public class CertificateUtilTest {
 
-
     @Test
     public void testGenerateThumbPrint() throws CertificateException {
 
@@ -38,4 +37,5 @@ public class CertificateUtilTest {
                 .hasMessageContaining("Cannot generate thumbprint for this certificate");
         }
     }
+
 }

--- a/security/src/test/java/com/quorum/tessera/ssl/util/TlsUtilsTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/util/TlsUtilsTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public class TlsUtilsTest {
 
     private static final String FILE = "test-keystore";
+
     private static final String PASSWORD ="quorum";
+
     private static final String ALIAS = "tessera";
 
     Path privateKeyFile = Paths.get(FILE);


### PR DESCRIPTION
Continuation of #699

Applies the EmptyLineSeparator check to the `security` module.
No functional changes are part of this change.

- Removed excess newlines in code
- Added separation between class members for more readability (not to interfaces)
