### PR TITLE
Remove excess newlines from migration and GRPC modules

### DIFF
--- a/config-migration/src/main/java/com/quorum/tessera/config/builder/ConfigBuilder.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/builder/ConfigBuilder.java
@@ -254,8 +254,6 @@ public class ConfigBuilder {
                 null
         );
 
-
-
         //TODO must add P2P and Q2T server configs. Maybe ThirdParty too - in disabled state.
         //serverHostname, serverPort, 50521, CommunicationType.REST, sslConfig, null, null, null
         final DeprecatedServerConfig serverConfig = new DeprecatedServerConfig();
@@ -273,24 +271,17 @@ public class ConfigBuilder {
             peerList = null;
         }
 
-
-        final List<String> forwardingKeys;
+        final List<String> forwardingKeys = new ArrayList<>();
         if(alwaysSendTo != null) {
-            List<String> keyList = new ArrayList<>();
 
             for(String keyPath : alwaysSendTo) {
                 try {
                     List<String> keysFromFile = Files.readAllLines(toPath(workDir, keyPath));
-                    keyList.addAll(keysFromFile);
+                    forwardingKeys.addAll(keysFromFile);
                 } catch (IOException e) {
                     System.err.println("Error reading alwayssendto file: " + e.getMessage());
                 }
             }
-
-            forwardingKeys = keyList.stream()
-                .collect(Collectors.toList());
-        } else {
-            forwardingKeys = Collections.emptyList();
         }
 
         Config config = new Config();

--- a/config-migration/src/main/java/com/quorum/tessera/config/builder/JdbcConfigFactory.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/builder/JdbcConfigFactory.java
@@ -1,16 +1,14 @@
-
 package com.quorum.tessera.config.builder;
 
 import com.quorum.tessera.config.JdbcConfig;
-import java.util.Optional;
 
+import java.util.Optional;
 
 public interface JdbcConfigFactory {
 
     static JdbcConfig fromLegacyStorageString(String storage) {
         
-        Optional.ofNullable(storage)
-                .orElseThrow(IllegalArgumentException::new);
+        Optional.ofNullable(storage).orElseThrow(IllegalArgumentException::new);
         
         if(storage.startsWith("jdbc")) {
             return new JdbcConfig(null, null, storage);
@@ -25,13 +23,6 @@ public interface JdbcConfigFactory {
         }
 
         throw new UnsupportedOperationException(String.format("%s is not a supported storage option.", storage));
-        
-        
-        
     }
-    
-    
-    
 
-    
 }

--- a/config-migration/src/main/java/com/quorum/tessera/config/builder/SslTrustModeFactory.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/builder/SslTrustModeFactory.java
@@ -1,4 +1,3 @@
-
 package com.quorum.tessera.config.builder;
 
 import com.quorum.tessera.config.SslTrustMode;
@@ -6,11 +5,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public interface SslTrustModeFactory {
     
-     Map<String, SslTrustMode> TRUST_MODE_LOOKUP = 
-             Collections.unmodifiableMap(new HashMap<String, SslTrustMode>() {
+     Map<String, SslTrustMode> TRUST_MODE_LOOKUP = Collections.unmodifiableMap(new HashMap<String, SslTrustMode>() {
         {
             put("ca", SslTrustMode.CA);
             put("tofu", SslTrustMode.TOFU);
@@ -24,6 +21,5 @@ public interface SslTrustModeFactory {
     static SslTrustMode resolveByLegacyValue(String value) {
         return TRUST_MODE_LOOKUP.getOrDefault(value, SslTrustMode.NONE);
     }
-    
-    
+
 }

--- a/config-migration/src/main/java/com/quorum/tessera/config/migration/LegacyCliAdapter.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/migration/LegacyCliAdapter.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 
 public class LegacyCliAdapter implements CliAdapter {
 
-
     private final FilesDelegate fileDelegate = FilesDelegate.create();
 
     private final TomlConfigFactory configFactory;

--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
@@ -65,7 +65,6 @@ public class ConfigBuilderTest {
         assertThat(result.getServer().getInfluxConfig()).isNull();
     }
 
-
     @Test
     public void alwaysSendToFileNotFoundPrintsErrorMessageToTerminal() {
         List<String> alwaysSendTo = new ArrayList<>();

--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/JdbcConfigFactoryTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/JdbcConfigFactoryTest.java
@@ -12,8 +12,7 @@ public class JdbcConfigFactoryTest {
 
         JdbcConfig jdbcConfig = JdbcConfigFactory.fromLegacyStorageString("sqlite:somepath");
 
-        assertThat(jdbcConfig.getUrl())
-                .isEqualTo("jdbc:sqlite:somepath");
+        assertThat(jdbcConfig.getUrl()).isEqualTo("jdbc:sqlite:somepath");
         assertThat(jdbcConfig.getUsername()).isNull();
         assertThat(jdbcConfig.getPassword()).isNull();
 
@@ -24,8 +23,7 @@ public class JdbcConfigFactoryTest {
 
         JdbcConfig jdbcConfig = JdbcConfigFactory.fromLegacyStorageString("memory");
 
-        assertThat(jdbcConfig.getUrl())
-                .isEqualTo("jdbc:h2:mem:tessera");
+        assertThat(jdbcConfig.getUrl()).isEqualTo("jdbc:h2:mem:tessera");
         assertThat(jdbcConfig.getUsername()).isNull();
         assertThat(jdbcConfig.getPassword()).isNull();
 
@@ -34,7 +32,6 @@ public class JdbcConfigFactoryTest {
     @Test(expected = IllegalArgumentException.class)
     public void nullIsNotAllowed() {
         JdbcConfigFactory.fromLegacyStorageString(null);
-
     }
 
     @Test
@@ -50,6 +47,5 @@ public class JdbcConfigFactoryTest {
     public void unknownIsNotSupported() {
         JdbcConfigFactory.fromLegacyStorageString("unknown");
     }
-
 
 }

--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/KeyDataBuilderTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/KeyDataBuilderTest.java
@@ -30,7 +30,6 @@ public class KeyDataBuilderTest {
             Files.createTempFile("buildThreeLocked3", ".txt")
         );
 
-
         final byte[] privateKeyData = FixtureUtil.createLockedPrivateKey().toString().getBytes();
         for (Path p : privateKeyPaths) {
             Files.write(p, privateKeyData);
@@ -78,7 +77,6 @@ public class KeyDataBuilderTest {
                 Files.createTempFile("buildThreeLocked2", ".txt"),
                 Files.createTempFile("buildThreeLocked3", ".txt")
         );
-
         
         final byte[] privateKeyData = FixtureUtil.createLockedPrivateKey().toString().getBytes();
         for (Path p : privateKeyPaths) {
@@ -91,7 +89,6 @@ public class KeyDataBuilderTest {
         
         Path passwordsFile = Files.createTempFile("buildThreeLockedPasswordsFile", ".txt");
         Files.write(passwordsFile, privateKeyPasswords);
-        
         
         List<ConfigKeyPair> result = KeyDataBuilder.create()
                 .withPrivateKeys(privateKeys)

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/MockSystemAdapter.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/MockSystemAdapter.java
@@ -2,8 +2,8 @@ package com.quorum.tessera.config.migration;
 
 import com.quorum.tessera.io.NoopSystemAdapter;
 import com.quorum.tessera.io.SystemAdapter;
-import java.io.PrintStream;
 
+import java.io.PrintStream;
 
 public class MockSystemAdapter implements SystemAdapter {
 
@@ -14,6 +14,7 @@ public class MockSystemAdapter implements SystemAdapter {
     public MockSystemAdapter(NoopSystemAdapter defualtInstance) {
         this(defualtInstance.out(),defualtInstance.err());
     }
+
     public MockSystemAdapter() {
         this(new NoopSystemAdapter());
     }
@@ -40,4 +41,5 @@ public class MockSystemAdapter implements SystemAdapter {
     public PrintStream err() {
         return errPrintStream;
     }
+
 }

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
@@ -62,8 +62,6 @@ public class TomlConfigFactoryTest {
         Config result = tomlConfigFactory.create(template, null).build();
 
         assertThat(result.getServer().getHostName()).isEqualTo("http://127.0.0.1");
-
-
     }
 
     @Test
@@ -83,7 +81,6 @@ public class TomlConfigFactoryTest {
         Path passwordFile = Files.createTempFile("password", ".txt");
         InputStream template = getClass().getResourceAsStream("/sample.conf");
 
-
         try (InputStream configData = template) {
             Config result = tomlConfigFactory.create(configData, null).build();
             assertThat(result).isNotNull();
@@ -100,7 +97,6 @@ public class TomlConfigFactoryTest {
 
         Files.deleteIfExists(passwordFile);
     }
-
 
     @Test
     public void createConfigFromSampleFileAndAddedPasswordsFile() throws IOException {

--- a/grpc-service/src/main/java/com/quorum/tessera/client/GrpcClient.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/client/GrpcClient.java
@@ -1,8 +1,6 @@
-
 package com.quorum.tessera.client;
 
 import com.quorum.tessera.grpc.p2p.ResendRequest;
-
 
 interface GrpcClient {
 

--- a/grpc-service/src/main/java/com/quorum/tessera/client/GrpcClientImpl.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/client/GrpcClientImpl.java
@@ -20,7 +20,6 @@ final class GrpcClientImpl implements GrpcClient {
 
     private final P2PTransactionGrpc.P2PTransactionBlockingStub transactionBlockingStub;
 
-
     GrpcClientImpl(final ManagedChannel channel) {
         this.channel = channel;
         this.partyInfoBlockingStub = PartyInfoGrpc.newBlockingStub(channel);

--- a/grpc-service/src/main/java/com/quorum/tessera/client/GrpcP2pClient.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/client/GrpcP2pClient.java
@@ -5,7 +5,6 @@ import com.quorum.tessera.api.model.ResendRequest;
 
 import java.util.Objects;
 
-
 class GrpcP2pClient implements P2pClient {
     
     private final GrpcClientFactory grpcClientFactory;
@@ -33,6 +32,5 @@ class GrpcP2pClient implements P2pClient {
         com.quorum.tessera.grpc.p2p.ResendRequest grpcObj = Convertor.toGrpc(request);
         return grpcClientFactory.getClient(targetUrl).makeResendRequest(grpcObj);
     }
-    
-    
+
 }

--- a/grpc-service/src/main/java/com/quorum/tessera/client/GrpcP2pClientFactory.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/client/GrpcP2pClientFactory.java
@@ -1,9 +1,7 @@
-
 package com.quorum.tessera.client;
 
 import com.quorum.tessera.config.CommunicationType;
 import com.quorum.tessera.config.Config;
-
 
 public class GrpcP2pClientFactory implements P2pClientFactory {
 

--- a/grpc-service/src/main/java/com/quorum/tessera/grpc/StreamObserverCallback.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/grpc/StreamObserverCallback.java
@@ -1,6 +1,4 @@
-
 package com.quorum.tessera.grpc;
-
 
 @FunctionalInterface
 public interface StreamObserverCallback<T> {

--- a/grpc-service/src/main/java/com/quorum/tessera/grpc/api/APITransactionGrpcService.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/grpc/api/APITransactionGrpcService.java
@@ -72,6 +72,5 @@ public class APITransactionGrpcService extends APITransactionGrpc.APITransaction
         });
 
     }
-    
-    
+
 }

--- a/grpc-service/src/main/java/com/quorum/tessera/grpc/p2p/Convertor.java
+++ b/grpc-service/src/main/java/com/quorum/tessera/grpc/p2p/Convertor.java
@@ -27,14 +27,12 @@ public class Convertor {
             .setType(resendRequestType).build();
     }
 
-
     public static DeleteRequest toModel(com.quorum.tessera.grpc.p2p.DeleteRequest grpcRequest) {
         DeleteRequest request = new DeleteRequest();
         request.setKey(grpcRequest.getKey());
 
         return request;
     }
-
 
     public static com.quorum.tessera.api.model.ResendRequest toModel(com.quorum.tessera.grpc.p2p.ResendRequest grpcObject) {
         com.quorum.tessera.api.model.ResendRequest resendRequest = new ResendRequest();
@@ -49,4 +47,5 @@ public class Convertor {
 
         return resendRequest;
     }
+
 }

--- a/grpc-service/src/test/java/com/quorum/tessera/client/GrpcClientFactoryTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/client/GrpcClientFactoryTest.java
@@ -6,8 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GrpcClientFactoryTest {
 
-
-    
     @Test
     public void testCreateNewClient() {
         GrpcClientFactory grpcClientFactory = new GrpcClientFactory();
@@ -20,4 +18,5 @@ public class GrpcClientFactoryTest {
         assertThat(grpcClientFactory.getClient("bogus.com")).isEqualTo(client1);
         assertThat(grpcClientFactory.getClient("morebogus.com")).isEqualTo(client2);
     }
+
 }

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/GrpcAppTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/GrpcAppTest.java
@@ -23,7 +23,6 @@ public class GrpcAppTest {
 
     private ServiceLocator serviceLocator;
 
-
     private GrpcApp grpcApp;
 
     @Before

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/GrpcITConfig.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/GrpcITConfig.java
@@ -1,14 +1,13 @@
-
 package com.quorum.tessera.grpc;
 
-import com.quorum.tessera.transaction.TransactionManagerImpl;
 import com.quorum.tessera.node.PartyInfoParser;
 import com.quorum.tessera.node.PartyInfoService;
-import static org.mockito.Mockito.mock;
+import com.quorum.tessera.transaction.TransactionManagerImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
+import static org.mockito.Mockito.mock;
 
 @Configuration
 @ImportResource(locations="classpath:tessera-grpc-spring.xml")

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/StreamObserverTemplateTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/StreamObserverTemplateTest.java
@@ -40,9 +40,7 @@ public class StreamObserverTemplateTest {
 
         Object outcome = "HAPPY";
 
-        template.handle(() -> {
-            return outcome;
-        });
+        template.handle(() -> outcome);
 
         verify(observer).onNext(outcome);
         verify(observer).onCompleted();
@@ -84,11 +82,9 @@ public class StreamObserverTemplateTest {
             throw exception;
         });
 
-
         verify(observer).onError(exception);
 
     }
-
 
     @Test
     public void executeAutoDiscoveryDisabled() {
@@ -105,7 +101,6 @@ public class StreamObserverTemplateTest {
         AutoDiscoveryDisabledException exception = mock(AutoDiscoveryDisabledException.class);
         when(exception.getMessage()).thenReturn(exceptionMessage);
 
-
         template.handle(() -> {
             throw exception;
         });
@@ -118,4 +113,5 @@ public class StreamObserverTemplateTest {
 
         verify(observer).onError(result);
     }
+
 }

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/api/APITransactionGrpcServiceTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/api/APITransactionGrpcServiceTest.java
@@ -35,9 +35,7 @@ public class APITransactionGrpcServiceTest {
 
     @After
     public void onTearDown() {
-        verifyNoMoreInteractions(
-                sendResponseObserver,
-                receiveResponseObserver);
+        verifyNoMoreInteractions(sendResponseObserver, receiveResponseObserver);
     }
 
     @Test
@@ -84,7 +82,6 @@ public class APITransactionGrpcServiceTest {
 
         com.quorum.tessera.api.model.ReceiveResponse r = new com.quorum.tessera.api.model.ReceiveResponse("SOME DATA".getBytes());
 
-        
         when(enclaveMediator.receive(any())).thenReturn(r);
 
         ReceiveRequest request = ReceiveRequest.newBuilder()
@@ -112,9 +109,7 @@ public class APITransactionGrpcServiceTest {
                 .setKey("ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=")
                 .build();
 
-
         service.receive(request, receiveResponseObserver);
-        
 
         verify(receiveResponseObserver).onError(any());
     }
@@ -143,6 +138,5 @@ public class APITransactionGrpcServiceTest {
         verify(receiveResponseObserver).onError(any());
 
     }
-    
 
 }

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/p2p/ConvertorTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/p2p/ConvertorTest.java
@@ -1,9 +1,12 @@
 package com.quorum.tessera.grpc.p2p;
 
+import org.junit.Test;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import static org.assertj.core.api.Assertions.*;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class ConvertorTest {
 
@@ -33,7 +36,6 @@ public class ConvertorTest {
         assertThat(result).isNotNull();
         assertThat(result.getKey()).isEqualTo(key);
     }
-
 
     @Test
     public void toModelResendRequest() {

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/p2p/P2PTransactionGrpcServiceTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/p2p/P2PTransactionGrpcServiceTest.java
@@ -40,10 +40,7 @@ public class P2PTransactionGrpcServiceTest {
 
     @After
     public void onTearDown() {
-        verifyNoMoreInteractions(
-                deleteResponseObserver,
-                pushResponseObserver,
-                resendResponseObserver);
+        verifyNoMoreInteractions(deleteResponseObserver, pushResponseObserver, resendResponseObserver);
     }
 
     @Test
@@ -117,7 +114,5 @@ public class P2PTransactionGrpcServiceTest {
         verify(deleteResponseObserver).onError(any());
 
     }
-
-
 
 }

--- a/grpc-service/src/test/java/com/quorum/tessera/grpc/p2p/PartyInfoGrpcServiceTest.java
+++ b/grpc-service/src/test/java/com/quorum/tessera/grpc/p2p/PartyInfoGrpcServiceTest.java
@@ -74,7 +74,6 @@ public class PartyInfoGrpcServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.getPartyInfo().toByteArray()).isEqualTo(resultData);
 
-
         verify(partyInfoParser).from(data);
         verify(partyInfoService).updatePartyInfo(partyInfo);
         verify(partyInfoParser).to(partyInfo);

--- a/server/grpc-server/src/main/java/com/quorum/tessera/grpc/server/GrpcServerFactory.java
+++ b/server/grpc-server/src/main/java/com/quorum/tessera/grpc/server/GrpcServerFactory.java
@@ -6,6 +6,7 @@ import com.quorum.tessera.grpc.GrpcApp;
 import com.quorum.tessera.server.TesseraServer;
 import com.quorum.tessera.server.TesseraServerFactory;
 import io.grpc.ServerBuilder;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
@@ -13,8 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 
 public class GrpcServerFactory implements TesseraServerFactory<Object> {
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(GrpcServerFactory.class);
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcServerFactory.class);
 
     @Override
     public TesseraServer createServer(ServerConfig serverConfig, Set<Object> services) {
@@ -37,7 +38,6 @@ public class GrpcServerFactory implements TesseraServerFactory<Object> {
         }
 
         return null;
-
     }
 
     @Override


### PR DESCRIPTION
Continuation of #699

Applies the EmptyLineSeparator check to the migration and GRPC modules
No functional changes are part of this change.
One logic code change for the following:
    - As the `ConfigBuilder` collects all forwarding keys from provided files, it will put into the final list instead of creating intermediate lists and adding them together. Result is the same in both cases.

- Removed excess newlines in code
- Added separation between class members for more readability (not to interfaces)