### PR TITLE
Load resource stream over file

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -68,7 +68,7 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        
+
 
     </dependencies>
 

--- a/config/src/main/java/com/quorum/tessera/config/ServerConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/ServerConfig.java
@@ -159,6 +159,4 @@ public class ServerConfig extends ConfigItem {
         this.crossDomainConfig = crossDomainConfig;
     }
 
-
-
 }

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/CmdLineExecutor.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/CmdLineExecutor.java
@@ -99,7 +99,6 @@ public class CmdLineExecutor {
                 .required()
                 .build());
 
-
         options.addOption(
             Option.builder()
                 .longOpt("exporttype")

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/H2DataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/H2DataExporter.java
@@ -1,14 +1,13 @@
 package com.quorum.tessera.data.migration;
 
-import org.apache.commons.io.IOUtils;
-
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class H2DataExporter implements DataExporter {
 
@@ -24,9 +23,11 @@ public class H2DataExporter implements DataExporter {
 
         final String connectionString = "jdbc:h2:" + output.toString();
 
-        final byte[] data = IOUtils.resourceToByteArray(CREATE_TABLE_RESOURCE);
-        final String dataAsString = new String(data, UTF_8);
-        final List<String> createTableStatements = Arrays.asList(dataAsString.split("\n"));
+        final List<String> createTableStatements = Stream.of(getClass().getResourceAsStream(CREATE_TABLE_RESOURCE))
+            .map(InputStreamReader::new)
+            .map(BufferedReader::new)
+            .flatMap(BufferedReader::lines)
+            .collect(Collectors.toList());
 
         final JdbcDataExporter jdbcDataExporter
             = new JdbcDataExporter(connectionString, INSERT_ROW, createTableStatements);

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/H2DataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/H2DataExporter.java
@@ -1,15 +1,14 @@
 package com.quorum.tessera.data.migration;
 
-import com.quorum.tessera.io.IOCallback;
-import com.quorum.tessera.io.UriCallback;
+import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class H2DataExporter implements DataExporter {
 
@@ -25,9 +24,9 @@ public class H2DataExporter implements DataExporter {
 
         final String connectionString = "jdbc:h2:" + output.toString();
 
-        final URL sqlFile = getClass().getResource(CREATE_TABLE_RESOURCE);
-        final Path uri = UriCallback.execute(() -> Paths.get(sqlFile.toURI()));
-        final List<String> createTableStatements = IOCallback.execute(() -> Files.readAllLines(uri));
+        final byte[] data = IOUtils.resourceToByteArray(CREATE_TABLE_RESOURCE);
+        final String dataAsString = new String(data, UTF_8);
+        final List<String> createTableStatements = Arrays.asList(dataAsString.split("\n"));
 
         final JdbcDataExporter jdbcDataExporter
             = new JdbcDataExporter(connectionString, INSERT_ROW, createTableStatements);

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/Main.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/Main.java
@@ -1,5 +1,7 @@
 package com.quorum.tessera.data.migration;
 
+import java.util.Arrays;
+
 public class Main {
     
     private Main() {
@@ -12,7 +14,14 @@ public class Main {
             final int result = new CmdLineExecutor().execute(args);
             System.exit(result);
         } catch (final Exception ex) {
-            System.err.println(ex.getMessage());
+            System.err.println("An error has occurred: " + ex.getMessage());
+
+            if (Arrays.asList(args).contains("debug")) {
+                System.err.println();
+                System.err.println("Exception message: " + ex.getMessage());
+                System.err.println("Exception class: " + ex.getClass());
+            }
+
             System.exit(1);
         }
 

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
@@ -2,16 +2,23 @@ package com.quorum.tessera.data.migration;
 
 import org.apache.commons.io.IOUtils;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.sql.*;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SqliteDataExporter implements DataExporter {
 
     private static final String INSERT_ROW = "INSERT INTO ENCRYPTED_TRANSACTION (HASH, ENCODED_PAYLOAD) VALUES (?, ?)";
+
+    private static final String CREATE_TABLE_RESOURCE = "/ddls/sqlite-ddl.sql";
 
     @Override
     public void export(final StoreLoader loader,
@@ -21,9 +28,11 @@ public class SqliteDataExporter implements DataExporter {
 
         final String connectionString = "jdbc:sqlite:" + output.toString();
 
-        final byte[] sqlData = IOUtils.resourceToByteArray("/ddls/sqlite-ddl.sql");
-        final String dataAsString = new String(sqlData, UTF_8);
-        final String[] createTableStatements = dataAsString.split("\n");
+        final List<String> createTableStatements = Stream.of(getClass().getResourceAsStream(CREATE_TABLE_RESOURCE))
+            .map(InputStreamReader::new)
+            .map(BufferedReader::new)
+            .flatMap(BufferedReader::lines)
+            .collect(Collectors.toList());
 
         try (Connection conn = DriverManager.getConnection(connectionString, username, password)) {
 

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
@@ -1,17 +1,13 @@
 package com.quorum.tessera.data.migration;
 
-import com.quorum.tessera.io.IOCallback;
-import com.quorum.tessera.io.UriCallback;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.*;
-import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SqliteDataExporter implements DataExporter {
 
@@ -25,14 +21,14 @@ public class SqliteDataExporter implements DataExporter {
 
         final String connectionString = "jdbc:sqlite:" + output.toString();
 
-        final URI sqlFile = UriCallback.execute(() -> getClass().getResource("/ddls/sqlite-ddl.sql").toURI());
-
-        final List<String> createTables = IOCallback.execute(() -> Files.readAllLines(Paths.get(sqlFile)));
+        final byte[] sqlData = IOUtils.resourceToByteArray("/ddls/sqlite-ddl.sql");
+        final String dataAsString = new String(sqlData, UTF_8);
+        final String[] createTableStatements = dataAsString.split("\n");
 
         try (Connection conn = DriverManager.getConnection(connectionString, username, password)) {
 
             try (Statement stmt = conn.createStatement()) {
-                for (final String createTable : createTables) {
+                for (final String createTable : createTableStatements) {
                     stmt.executeUpdate(createTable);
                 }
             }

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/SqliteDataExporter.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 public class SqliteDataExporter implements DataExporter {
 
     private static final String INSERT_ROW = "INSERT INTO ENCRYPTED_TRANSACTION (HASH, ENCODED_PAYLOAD) VALUES (?, ?)";

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/MainTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/MainTest.java
@@ -21,4 +21,10 @@ public class MainTest {
         Main.main();
     }
 
+    @Test
+    public void outputDebugInformationWithNullCause() {
+        expectedSystemExit.expectSystemExitWithStatus(1);
+        Main.main("debug");
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -979,7 +979,6 @@
             <scope>runtime</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Fixes https://github.com/jpmorganchase/tessera/issues/732

Getting the file path of a resource was causing a `FileSystemNotFound` exception to be thrown, which happens when trying to access the `Path` of the included database schemas.
To fix this, we get a stream for the resource instead of using the file directly.

Add extra debug info that contains the exception type, which proved useful in debugging this scenario; more can be added as needed.