### PR TITLE
Skip maven enforcer plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM maven:3.5.4-jdk-8 as builder
 # do not use root as there are test cases validating file accessibility
 USER nobody:nogroup
 ADD --chown=nobody:nogroup . /tessera
-RUN cd /tessera && mvn clean -Dmaven.repo.local=/tessera/.m2/repository -DskipTests package
+RUN cd /tessera && mvn clean -Dmaven.repo.local=/tessera/.m2/repository -DskipTests -Denforcer.skip=true package
 
 # Create docker image with only distribution jar
 FROM openjdk:8-jre-alpine


### PR DESCRIPTION
https://github.com/jpmorganchase/tessera/issues/738

During a Docker build, the enforcer plugin tries to access a directory that doesn't exist/doesn't have access too. The enforcer plugin is only used for merges to master, and is not required for Docker builds (which build from a working master branch) so we can safely disable this.