### PR TITLE
Upgrade jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <owasp.plugin.version>5.0.0-M2</owasp.plugin.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
     </properties>
 
     <build>


### PR DESCRIPTION
CVE-2018-19360 More information

high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the axis2-transport-jms class from polymorphic deserialization.
CVE-2018-19361 More information

high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the openjpa class from polymorphic deserialization.
CVE-2018-19362 More information

high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization.