### PR TITLE
Vulnerable dependency

### DIFF
--- a/key-vault/azure-key-vault/pom.xml
+++ b/key-vault/azure-key-vault/pom.xml
@@ -9,15 +9,6 @@
 
     <artifactId>azure-key-vault</artifactId>
 
-    <dependencyManagement>
-        <dependencies>
-
-
-            
-
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
 
         <dependency>

--- a/key-vault/hashicorp-key-vault/pom.xml
+++ b/key-vault/hashicorp-key-vault/pom.xml
@@ -16,12 +16,6 @@
                 <artifactId>spring-vault-core</artifactId>
                 <version>2.1.1.RELEASE</version>
             </dependency>
-
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>3.12.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1168,7 +1168,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
Upgrade version of okhttp beyond 3.12.0 to suppress vulnerability CVE-2018-20200.
More details at https://nvd.nist.gov/vuln/detail/CVE-2018-20200