### PR TITLE
Clean up tests from deleting temp files

### DIFF
--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
@@ -5,10 +5,10 @@ import com.quorum.tessera.config.DeprecatedServerConfig;
 import com.quorum.tessera.config.SslConfig;
 import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 import com.quorum.tessera.config.migration.test.FixtureUtil;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +16,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigBuilderTest {
+
+    @Rule
+    public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
     private final ConfigBuilder builderWithValidValues = FixtureUtil.builderWithValidValues();
 
@@ -71,20 +74,11 @@ public class ConfigBuilderTest {
         alwaysSendTo.add("doesntexist.txt");
         alwaysSendTo.add("alsodoesntexist.txt");
 
-        final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-        final PrintStream originalErr = System.err;
-
-        System.setErr(new PrintStream(errContent));
-
         final ConfigBuilder builder = builderWithValidValues.alwaysSendTo(alwaysSendTo);
         builder.build();
 
-        assertThat(errContent.toString()).isEqualTo(
-            "Error reading alwayssendto file: doesntexist.txt\nError reading alwayssendto file: alsodoesntexist.txt\n"
-        );
-
-        System.setErr(originalErr);
-
+        assertThat(systemErrRule.getLog())
+            .isEqualTo("Error reading alwayssendto file: doesntexist.txt\nError reading alwayssendto file: alsodoesntexist.txt\n");
     }
 
     @Test

--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/KeyDataBuilderTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/KeyDataBuilderTest.java
@@ -97,19 +97,6 @@ public class KeyDataBuilderTest {
                 .build().getKeyData();
 
         assertThat(result).hasSize(3);
-
-//        assertThat(result.get(0).getConfig().getPassword()).isEqualTo("SECRET1");
-//        assertThat(result.get(1).getConfig().getPassword()).isEqualTo("SECRET2");
-//        assertThat(result.get(2).getConfig().getPassword()).isEqualTo("SECRET3");
-
-//        assertThat(result.get(0).getPublicKey()).isEqualTo("PUB1");
-//        assertThat(result.get(1).getPublicKey()).isEqualTo("PUB2");
-//        assertThat(result.get(2).getPublicKey()).isEqualTo("PUB3");
-
-        for (Path p : privateKeyPaths) {
-            Files.deleteIfExists(p);
-        }
-
     }
 
     @Test

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
@@ -50,8 +50,6 @@ public class TomlConfigFactoryTest {
             assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
 
         }
-
-        Files.deleteIfExists(passwordFile);
     }
 
     @Test
@@ -125,7 +123,6 @@ public class TomlConfigFactoryTest {
             }
         }
 
-        Files.deleteIfExists(passwordsFile);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/config/src/test/java/com/quorum/tessera/config/JaxbConfigFactoryTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/JaxbConfigFactoryTest.java
@@ -2,13 +2,13 @@ package com.quorum.tessera.config;
 
 import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 import com.quorum.tessera.config.keypairs.InlineKeypair;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -34,12 +34,6 @@ public class JaxbConfigFactoryTest {
         );
 
         this.factory = new JaxbConfigFactory();
-    }
-
-    @After
-    public void after() throws IOException {
-        Files.deleteIfExists(Paths.get("newPasses.txt"));
-        Files.deleteIfExists(Paths.get("passwords.txt"));
     }
 
     @Test
@@ -85,19 +79,22 @@ public class JaxbConfigFactoryTest {
         assertThat(config.getKeys().getPasswordFile()).isNotNull();
         final List<String> passes = Files.readAllLines(config.getKeys().getPasswordFile());
         assertThat(passes).hasSize(1).containsExactly("pass");
+        Files.deleteIfExists(config.getKeys().getPasswordFile());
     }
 
     @Test
     public void cantAppendToPasswordFileThrowsError() throws IOException {
-
-        Files.createFile(Paths.get("newPasses.txt"));
-        Paths.get("newPasses.txt").toFile().setWritable(false);
+        final Path file = Paths.get("newPasses.txt");
+        Files.createFile(file);
+        file.toFile().setWritable(false);
 
         final InputStream inputStream = getClass().getResourceAsStream("/keypassupdate/newLockedKeyAddToFile.json");
 
         final Throwable throwable = catchThrowable(() -> factory.create(inputStream, singletonList(sampleGeneratedKey)));
 
         assertThat(throwable).hasMessage("Could not store new passwords: newPasses.txt");
+
+        Files.deleteIfExists(file);
     }
 
     @Test

--- a/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
@@ -53,7 +53,6 @@ public class PathValidatorTest {
 
     @Test
     public void validateFileExistsWhenFileDoesExist() throws IOException {
-
         ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
 
         ValidPath validPath = mock(ValidPath.class);
@@ -62,13 +61,9 @@ public class PathValidatorTest {
         PathValidator pathValidator = new PathValidator();
         pathValidator.initialize(validPath);
 
-        Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        Path actualFile = Files.createTempFile(tempDir, UUID.randomUUID().toString(), ".txt");
+        Path actualFile = Files.createTempFile(UUID.randomUUID().toString(), ".txt");
 
         assertThat(pathValidator.isValid(actualFile, context)).isTrue();
-
-        Files.deleteIfExists(actualFile);
-
     }
 
     @Test
@@ -90,8 +85,7 @@ public class PathValidatorTest {
 
     @Test
     public void checkCanCreateFile() throws IOException {
-
-        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+        final ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
 
         ValidPath validPath = mock(ValidPath.class);
         when(validPath.checkCanCreate()).thenReturn(true);
@@ -99,13 +93,12 @@ public class PathValidatorTest {
         PathValidator pathValidator = new PathValidator();
         pathValidator.initialize(validPath);
 
-        Path path = Paths.get(UUID.randomUUID().toString());
+        Path path = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
+        Files.deleteIfExists(path);
 
         assertThat(pathValidator.isValid(path, context)).isTrue();
 
         verifyZeroInteractions(context);
-        Files.deleteIfExists(path);
-
     }
 
     @Test

--- a/key-generation/src/test/java/com/quorum/tessera/key/generation/FileKeyGeneratorTest.java
+++ b/key-generation/src/test/java/com/quorum/tessera/key/generation/FileKeyGeneratorTest.java
@@ -73,25 +73,16 @@ public class FileKeyGeneratorTest {
         doReturn(keyPair).when(nacl).generateNewKeys();
 
         String filename = UUID.randomUUID().toString();
+        final Path tmpDir = Files.createTempDirectory("keygen").toAbsolutePath().resolve(filename);
 
-        final FilesystemKeyPair generated = generator.generate(filename, null, null);
+        final FilesystemKeyPair generated = generator.generate(tmpDir.toString(), null, null);
 
         assertThat(generated).isInstanceOf(FilesystemKeyPair.class);
         assertThat(generated.getPublicKey()).isEqualTo("cHVibGljS2V5");
         assertThat(generated.getPrivateKey()).isEqualTo("cHJpdmF0ZUtleQ==");
         assertThat(generated.getInlineKeypair().getPrivateKeyConfig().getType()).isEqualTo(UNLOCKED);
 
-
         verify(nacl).generateNewKeys();
-
-        Files.list(Paths.get(""))
-            .filter(f -> f.toString().contains(filename))
-            .forEach(f -> {
-                try {
-                    Files.deleteIfExists(f);
-                } catch (IOException ex) {
-                }
-            });
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -947,8 +947,6 @@
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-rules</artifactId>
                 <version>1.18.0</version>
-                <scope>test</scope>
-                <type>jar</type>
             </dependency>
 
             <!--  GRPC-->

--- a/security/src/test/java/com/quorum/tessera/ssl/context/SSLContextBuilderTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/context/SSLContextBuilderTest.java
@@ -144,9 +144,6 @@ public class SSLContextBuilderTest {
         assertThat(otherContextBuilder.forCASignedCertificates().build()).isNotNull();
 
         assertThat(Files.exists(nonExistedFile)).isTrue();
-
-        Files.deleteIfExists(nonExistedFile);
-
     }
 
     @Test

--- a/security/src/test/java/com/quorum/tessera/ssl/util/TlsUtilsTest.java
+++ b/security/src/test/java/com/quorum/tessera/ssl/util/TlsUtilsTest.java
@@ -1,14 +1,12 @@
 package com.quorum.tessera.ssl.util;
 
 import org.bouncycastle.operator.OperatorCreationException;
-import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -18,26 +16,19 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class TlsUtilsTest {
 
-    private static final String FILE = "test-keystore";
-
-    private static final String PASSWORD ="quorum";
+    private static final String PASSWORD = "quorum";
 
     private static final String ALIAS = "tessera";
-
-    Path privateKeyFile = Paths.get(FILE);
-
-    @After
-    public void tearDown() throws IOException {
-        Files.deleteIfExists(privateKeyFile);
-        assertThat(Files.exists(privateKeyFile)).isFalse();
-    }
 
     @Test
     public void testGenerateKeys() throws OperatorCreationException, InvalidKeyException, NoSuchAlgorithmException, IOException, SignatureException, NoSuchProviderException, CertificateException, KeyStoreException {
 
+        final Path privateKeyFile = Files.createTempFile("privatekey", ".tmp");
+        Files.deleteIfExists(privateKeyFile);
+
         assertThat(Files.exists(privateKeyFile)).isFalse();
 
-        TlsUtils.create().generateKeyStoreWithSelfSignedCertificate("https://localhost:8080", privateKeyFile,PASSWORD);
+        TlsUtils.create().generateKeyStoreWithSelfSignedCertificate("https://localhost:8080", privateKeyFile, PASSWORD);
 
         assertThat(Files.exists(privateKeyFile)).isTrue();
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/cli/KeyGenIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/cli/KeyGenIT.java
@@ -1,10 +1,12 @@
 package com.quorum.tessera.test.cli;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,17 +17,13 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class KeyGenIT {
 
-    private static final Path buildDir = Paths.get("target/");
+    private static Path buildDir;
 
     private ExecutorService executorService;
 
@@ -33,7 +31,7 @@ public class KeyGenIT {
 
     private final List<String> argList;
 
-    public KeyGenIT(KeyGenTestConfig testConfig) throws IOException {
+    public KeyGenIT(KeyGenTestConfig testConfig) {
         this.testConfig = testConfig;
 
         this.argList = new ArrayList<>();
@@ -45,20 +43,13 @@ public class KeyGenIT {
     }
 
     @Before
-    public void onSetup() throws IOException {
-
+    public void onSetup() {
         executorService = Executors.newFixedThreadPool(2);
-        Files.deleteIfExists(testConfig.getExpectedKeyPath());
-        Files.deleteIfExists(testConfig.getExpectedPubKeyPath());
     }
 
     @After
-    public void onTearDown() throws IOException {
-
+    public void onTearDown() {
         executorService.shutdown();
-
-        Files.deleteIfExists(testConfig.getExpectedKeyPath());
-        Files.deleteIfExists(testConfig.getExpectedPubKeyPath());
     }
 
     @Test
@@ -80,7 +71,9 @@ public class KeyGenIT {
     }
 
     @Parameterized.Parameters(name = "tessera -keygen '{index}'")
-    public static List<KeyGenTestConfig> parameters() {
+    public static List<KeyGenTestConfig> parameters() throws IOException {
+
+        buildDir = Files.createTempDirectory("target");
 
         String appPath = System.getProperty("application.jar");
         if(Objects.equals("", appPath)) {


### PR DESCRIPTION
Remove majority of manual file deletes at end of tests
Remove instances of manually overriding system streams for test purposes