### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
       script:
         - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
         - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
-        - travis_wait 30 mvn deploy --settings .maven.xml -B -P release,reduce-logging -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djavadoc.skip=true || travis_terminate 1
+        - travis_wait 60 mvn deploy --settings .maven.xml -B -P release,reduce-logging -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djavadoc.skip=true || travis_terminate 1
 
     - stage: tag and deploy
       name: "Tag on GitHub and deploy to OSSRH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
       script:
         - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
         - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
-        - travis_wait 30 mvn deploy --settings .maven.xml -B -P release,reduce-logging -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn || travis_terminate 1
+        - travis_wait 30 mvn deploy --settings .maven.xml -B -P release,reduce-logging -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djavadoc.skip=true || travis_terminate 1
 
     - stage: tag and deploy
       name: "Tag on GitHub and deploy to OSSRH"

--- a/ddls/pom.xml
+++ b/ddls/pom.xml
@@ -80,7 +80,7 @@
                     <properties>
                         <eclipselink.ddlgen-terminate-statements>true</eclipselink.ddlgen-terminate-statements>
                         <eclipselink.weaving>false</eclipselink.weaving>
-                        <eclipselink.logging.level>FINEST</eclipselink.logging.level>
+                        <eclipselink.logging.level>INFO</eclipselink.logging.level>
                         <javax.persistence.schema-generation.scripts.action>create</javax.persistence.schema-generation.scripts.action>   
                     </properties>
                     <source>

--- a/logback-build.xml
+++ b/logback-build.xml
@@ -8,8 +8,8 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %replace(%msg){'[\r\n]', ''}%n</pattern>
         </encoder>
     </appender>
-    <logger name="exec" level="DEBUG" />
-    <root level="INFO">
+    <logger name="exec" level="INFO" />
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
https://github.com/jpmorganchase/tessera/issues/738

Output less to the CI logs, to stop hitting the limit
Increase the timeout for the build, since they can be quite slow on the Travis machines.