### PR TITLE
Revert "Remove the key-converter module"

### DIFF
--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/EnclaveFactory.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/EnclaveFactory.java
@@ -8,6 +8,7 @@ import com.quorum.tessera.config.util.EnvironmentVariableProvider;
 import com.quorum.tessera.encryption.KeyManagerImpl;
 import com.quorum.tessera.encryption.KeyPair;
 import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.keypairconverter.KeyPairConverter;
 import com.quorum.tessera.nacl.NaclFacadeFactory;
 
 import java.util.Collection;

--- a/enclave/enclave-api/src/test/resources/META-INF/services/com.quorum.tessera.key.vault.KeyVaultServiceFactory
+++ b/enclave/enclave-api/src/test/resources/META-INF/services/com.quorum.tessera.key.vault.KeyVaultServiceFactory
@@ -1,2 +1,0 @@
-com.quorum.tessera.enclave.MockAzureKeyVaultServiceFactory
-com.quorum.tessera.enclave.MockHashicorpKeyVaultServiceFactory

--- a/key-pair-converter/pom.xml
+++ b/key-pair-converter/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tessera</artifactId>
+        <groupId>com.jpmorgan.quorum</groupId>
+        <version>0.10-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>key-pair-converter</artifactId>
+    <dependencies>
+
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>encryption-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>key-vault-api</artifactId>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/key-pair-converter/src/main/java/com/quorum/tessera/keypairconverter/KeyPairConverter.java
+++ b/key-pair-converter/src/main/java/com/quorum/tessera/keypairconverter/KeyPairConverter.java
@@ -1,4 +1,4 @@
-package com.quorum.tessera.enclave;
+package com.quorum.tessera.keypairconverter;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.KeyVaultType;

--- a/key-pair-converter/src/test/java/com/quorum/tessera/keypairconverter/KeyPairConverterTest.java
+++ b/key-pair-converter/src/test/java/com/quorum/tessera/keypairconverter/KeyPairConverterTest.java
@@ -1,4 +1,4 @@
-package com.quorum.tessera.enclave;
+package com.quorum.tessera.keypairconverter;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.keypairs.*;

--- a/key-pair-converter/src/test/java/com/quorum/tessera/keypairconverter/MockAzureKeyVaultServiceFactory.java
+++ b/key-pair-converter/src/test/java/com/quorum/tessera/keypairconverter/MockAzureKeyVaultServiceFactory.java
@@ -1,9 +1,9 @@
-package com.quorum.tessera.enclave;
+package com.quorum.tessera.keypairconverter;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
-import com.quorum.tessera.config.vault.data.HashicorpGetSecretData;
+import com.quorum.tessera.config.vault.data.AzureGetSecretData;
 import com.quorum.tessera.key.vault.KeyVaultService;
 import com.quorum.tessera.key.vault.KeyVaultServiceFactory;
 
@@ -11,12 +11,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MockHashicorpKeyVaultServiceFactory implements KeyVaultServiceFactory {
+public class MockAzureKeyVaultServiceFactory implements KeyVaultServiceFactory {
     @Override
     public KeyVaultService create(Config config, EnvironmentVariableProvider envProvider) {
         KeyVaultService mock = mock(KeyVaultService.class);
 
-        when(mock.getSecret(any(HashicorpGetSecretData.class)))
+        when(mock.getSecret(any(AzureGetSecretData.class)))
             .thenReturn("publicSecret")
             .thenReturn("privSecret");
 
@@ -25,6 +25,6 @@ public class MockHashicorpKeyVaultServiceFactory implements KeyVaultServiceFacto
 
     @Override
     public KeyVaultType getType() {
-        return KeyVaultType.HASHICORP;
+        return KeyVaultType.AZURE;
     }
 }

--- a/key-pair-converter/src/test/java/com/quorum/tessera/keypairconverter/MockHashicorpKeyVaultServiceFactory.java
+++ b/key-pair-converter/src/test/java/com/quorum/tessera/keypairconverter/MockHashicorpKeyVaultServiceFactory.java
@@ -1,9 +1,9 @@
-package com.quorum.tessera.enclave;
+package com.quorum.tessera.keypairconverter;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
-import com.quorum.tessera.config.vault.data.AzureGetSecretData;
+import com.quorum.tessera.config.vault.data.HashicorpGetSecretData;
 import com.quorum.tessera.key.vault.KeyVaultService;
 import com.quorum.tessera.key.vault.KeyVaultServiceFactory;
 
@@ -11,12 +11,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MockAzureKeyVaultServiceFactory implements KeyVaultServiceFactory {
+public class MockHashicorpKeyVaultServiceFactory implements KeyVaultServiceFactory {
     @Override
     public KeyVaultService create(Config config, EnvironmentVariableProvider envProvider) {
         KeyVaultService mock = mock(KeyVaultService.class);
 
-        when(mock.getSecret(any(AzureGetSecretData.class)))
+        when(mock.getSecret(any(HashicorpGetSecretData.class)))
             .thenReturn("publicSecret")
             .thenReturn("privSecret");
 
@@ -25,6 +25,6 @@ public class MockAzureKeyVaultServiceFactory implements KeyVaultServiceFactory {
 
     @Override
     public KeyVaultType getType() {
-        return KeyVaultType.AZURE;
+        return KeyVaultType.HASHICORP;
     }
 }

--- a/key-pair-converter/src/test/resources/META-INF/services/com.quorum.tessera.key.vault.KeyVaultServiceFactory
+++ b/key-pair-converter/src/test/resources/META-INF/services/com.quorum.tessera.key.vault.KeyVaultServiceFactory
@@ -1,0 +1,2 @@
+com.quorum.tessera.keypairconverter.MockAzureKeyVaultServiceFactory
+com.quorum.tessera.keypairconverter.MockHashicorpKeyVaultServiceFactory

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,7 @@
         <module>jaxrs-client</module>
         <module>key-vault</module>
         <module>key-generation</module>
+        <module>key-pair-converter</module>
         <module>ddls</module>
         <module>enclave</module>
         <module>tessera-dist</module>


### PR DESCRIPTION
This has classic case of "it worked on my machine".

The maven dependency still existing locally, so compilation and running was fine. On a fresh machine, references to the removed module existed and could not be resolved.

This also throws up a potential issue with Travis not cleaning it's cache properly, to catch issues like this.

Reverts https://github.com/jpmorganchase/tessera/pull/796