### PR TITLE
Jackson databind vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1185,7 +1185,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.version}.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://github.com/jpmorganchase/tessera/issues/738

[CVE-2019-12814] Information Exposure

A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically crafted JSON message that allows them to read arbitrary local files on the server.

https://ossindex.sonatype.org/vuln/3e008100-e0d4-45bf-afd2-9d5e9b13efa7