### PR TITLE
Undo the removal of the deprecated configuration

### DIFF
--- a/cli/admin-cli/src/test/resources/sample-config.json
+++ b/cli/admin-cli/src/test/resources/sample-config.json
@@ -22,7 +22,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -30,7 +30,20 @@
             "enabled": true,
             "serverAddress": "http://localhost:8091",
             "sslConfig": {
-                "tls": "OFF"
+                "tls": "OFF",
+                "generateKeyStoreIfNotExisted": "false",
+                "serverKeyStore": "./ssl/server1-keystore",
+                "serverKeyStorePassword": "quorum",
+                "serverTrustStore": "./ssl/server-truststore",
+                "serverTrustStorePassword": "quorum",
+                "serverTrustMode": "CA",
+                "clientKeyStore": "./ssl/client1-keystore",
+                "clientKeyStorePassword": "quorum",
+                "clientTrustStore": "./ssl/client-truststore",
+                "clientTrustStorePassword": "quorum",
+                "clientTrustMode": "CA",
+                "knownClientsFile": "./ssl/knownClients1",
+                "knownServersFile": "./ssl/knownServers1"
             },
             "communicationType": "REST"
         }
@@ -59,5 +72,6 @@
     },
     "alwaysSendTo": [
         "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc="
-    ]
+    ],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/cli/cli-api/src/test/resources/sample-config.json
+++ b/cli/cli-api/src/test/resources/sample-config.json
@@ -22,7 +22,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -30,7 +30,20 @@
             "enabled": true,
             "serverAddress": "http://localhost:8091",
             "sslConfig": {
-                "tls": "OFF"
+                "tls": "OFF",
+                "generateKeyStoreIfNotExisted": "false",
+                "serverKeyStore": "./ssl/server1-keystore",
+                "serverKeyStorePassword": "quorum",
+                "serverTrustStore": "./ssl/server-truststore",
+                "serverTrustStorePassword": "quorum",
+                "serverTrustMode": "CA",
+                "clientKeyStore": "./ssl/client1-keystore",
+                "clientKeyStorePassword": "quorum",
+                "clientTrustStore": "./ssl/client-truststore",
+                "clientTrustStorePassword": "quorum",
+                "clientTrustMode": "CA",
+                "knownClientsFile": "./ssl/knownClients1",
+                "knownServersFile": "./ssl/knownServers1"
             },
             "communicationType": "REST"
         }
@@ -59,5 +72,6 @@
     },
     "alwaysSendTo": [
         "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc="
-    ]
+    ],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/DefaultCliAdapterTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/DefaultCliAdapterTest.java
@@ -11,7 +11,6 @@ import com.quorum.tessera.config.util.JaxbUtil;
 import com.quorum.tessera.key.generation.KeyGenerator;
 import com.quorum.tessera.test.util.ElUtil;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -275,8 +274,6 @@ public class DefaultCliAdapterTest {
 
     }
 
-    //TODO: enable when overrides allow a full config to be constructed
-    @Ignore
     @Test
     public void withEmptyConfigOverrideAll() throws Exception {
 
@@ -289,7 +286,9 @@ public class DefaultCliAdapterTest {
         try {
             CliResult result = cliDelegate.execute(
                 "-configfile",
-                configFile.toString()
+                configFile.toString(),
+                "--unixSocketFile",
+                unixSocketFile.toString()
             );
 
             assertThat(result).isNotNull();

--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/OverrideUtilTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/OverrideUtilTest.java
@@ -50,6 +50,7 @@ public class OverrideUtilTest {
             "keys.hashicorpKeyVaultConfig.tlsTrustStorePath",
             "keys.hashicorpKeyVaultConfig.url",
             "alwaysSendTo",
+            "unixSocketFile",
             "useWhiteList",
             "disablePeerDiscovery",
             "serverConfigs.serverAddress",
@@ -107,7 +108,59 @@ public class OverrideUtilTest {
             "serverConfigs.sslConfig.tls",
             "serverConfigs.sslConfig.knownServersFile",
             "serverConfigs.sslConfig.environmentVariablePrefix",
-            "serverConfigs.sslConfig.sslConfigType"
+            "serverConfigs.sslConfig.sslConfigType",
+            "server.hostName",
+            "server.sslConfig.knownServersFile",
+            "server.sslConfig.clientTrustStorePassword",
+            "server.sslConfig.clientKeyStorePassword",
+            "server.sslConfig.clientTlsKeyPath",
+            "server.sslConfig.clientTrustCertificates",
+            "server.sslConfig.knownClientsFile",
+            "server.communicationType",
+            "server.sslConfig.serverTrustStorePassword",
+            "server.sslConfig.serverTrustCertificates",
+            "server.sslConfig.clientTrustStore",
+            "server.sslConfig.tls",
+            "server.sslConfig.serverTlsCertificatePath",
+            "server.grpcPort",
+            "server.sslConfig.serverKeyStore",
+            "server.port",
+            "server.sslConfig.generateKeyStoreIfNotExisted",
+            "server.sslConfig.clientTlsCertificatePath",
+            "server.sslConfig.serverTlsKeyPath",
+            "server.sslConfig.serverTrustStore",
+            "server.bindingAddress",
+            "server.sslConfig.serverTrustMode",
+            "server.sslConfig.clientKeyStore",
+            "server.sslConfig.clientTrustMode",
+            "server.sslConfig.serverKeyStorePassword",
+            "server.sslConfig.environmentVariablePrefix",
+            "server.sslConfig.sslConfigType",
+            "server.influxConfig.serverAddress",
+            "server.influxConfig.dbName",
+            "server.influxConfig.pushIntervalInSecs",
+            "server.influxConfig.sslConfig.serverTrustMode",
+            "server.influxConfig.sslConfig.clientTrustStore",
+            "server.influxConfig.sslConfig.environmentVariablePrefix",
+            "server.influxConfig.sslConfig.clientTlsKeyPath",
+            "server.influxConfig.sslConfig.clientTrustMode",
+            "server.influxConfig.sslConfig.serverKeyStore",
+            "server.influxConfig.sslConfig.serverTlsKeyPath",
+            "server.influxConfig.sslConfig.serverTrustCertificates",
+            "server.influxConfig.sslConfig.knownClientsFile",
+            "server.influxConfig.sslConfig.serverTrustStorePassword",
+            "server.influxConfig.sslConfig.serverTrustStore",
+            "server.influxConfig.sslConfig.clientTrustStorePassword",
+            "server.influxConfig.sslConfig.clientTlsCertificatePath",
+            "server.influxConfig.sslConfig.serverTlsCertificatePath",
+            "server.influxConfig.sslConfig.clientKeyStorePassword",
+            "server.influxConfig.sslConfig.knownServersFile",
+            "server.influxConfig.sslConfig.tls",
+            "server.influxConfig.sslConfig.clientTrustCertificates",
+            "server.influxConfig.sslConfig.clientKeyStore",
+            "server.influxConfig.sslConfig.generateKeyStoreIfNotExisted",
+            "server.influxConfig.sslConfig.serverKeyStorePassword",
+            "server.influxConfig.sslConfig.sslConfigType"
         );
 
         final Map<String, Class> results = OverrideUtil.buildConfigOptions();
@@ -243,7 +296,7 @@ public class OverrideUtilTest {
     @Test
     public void initialiseNestedObjects() {
 
-        Config config = new Config(null, null, null, null, null, true, true);
+        Config config = new Config(null, null, null, null, null, null, true, true);
 
         OverrideUtil.initialiseNestedObjects(config);
 
@@ -321,6 +374,8 @@ public class OverrideUtilTest {
 
         assertThat(config.getJdbcConfig().getUsername()).isEqualTo("someuser");
         assertThat(config.getJdbcConfig().getPassword()).isEqualTo("tiger");
+
+        assertThat(config.getUnixSocketFile()).isEqualTo(Paths.get("${unixSocketPath}"));
     }
 
     //TODO: Need to support oerrides in config module

--- a/cli/config-cli/src/test/resources/keygen-sample.json
+++ b/cli/config-cli/src/test/resources/keygen-sample.json
@@ -15,7 +15,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -23,7 +23,20 @@
             "enabled": true,
             "serverAddress": "http://localhost:8091",
             "sslConfig": {
-                "tls": "OFF"
+                "tls": "OFF",
+                "generateKeyStoreIfNotExisted": "false",
+                "serverKeyStore": "./ssl/server1-keystore",
+                "serverKeyStorePassword": "quorum",
+                "serverTrustStore": "./ssl/server-truststore",
+                "serverTrustStorePassword": "quorum",
+                "serverTrustMode": "CA",
+                "clientKeyStore": "./ssl/client1-keystore",
+                "clientKeyStorePassword": "quorum",
+                "clientTrustStore": "./ssl/client-truststore",
+                "clientTrustStorePassword": "quorum",
+                "clientTrustMode": "CA",
+                "knownClientsFile": "./ssl/knownClients1",
+                "knownServersFile": "./ssl/knownServers1"
             },
             "communicationType": "REST"
         }
@@ -37,8 +50,10 @@
         }
     ],
     "keys": {
-        "passwords": [],
+        "passwords": [
+        ],
         "keyData": []
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/cli/config-cli/src/test/resources/keytests/passwordsMissing.json
+++ b/cli/config-cli/src/test/resources/keytests/passwordsMissing.json
@@ -5,23 +5,13 @@
         "password": "",
         "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 9001,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:9001/"
@@ -37,5 +27,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/passwordsWrong.json
+++ b/cli/config-cli/src/test/resources/keytests/passwordsWrong.json
@@ -5,23 +5,13 @@
         "password": "",
         "url": "jdbc:h2:./target/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 9001,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:9001/"
@@ -38,5 +28,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/pubPrivInlineLocked.json
+++ b/cli/config-cli/src/test/resources/keytests/pubPrivInlineLocked.json
@@ -5,23 +5,13 @@
         "password": "",
         "url": "jdbc:h2:./qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 9001,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:9001/"
@@ -51,5 +41,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/pubPrivInlineUnlocked.json
+++ b/cli/config-cli/src/test/resources/keytests/pubPrivInlineUnlocked.json
@@ -5,23 +5,13 @@
         "password": "",
         "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 9001,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:9001/"
@@ -40,5 +30,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsLocked.json
+++ b/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsLocked.json
@@ -5,23 +5,13 @@
         "password": "",
         "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 9001,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:9001/"
@@ -38,5 +28,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsUnlocked.json
+++ b/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsUnlocked.json
@@ -1,39 +1,30 @@
 {
-    "useWhiteList": false,
-    "jdbc": {
-        "username": "sa",
-        "password": "",
-        "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
-    },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
-        }
-    ],
-    "peer": [
-        {
-            "url": "http://localhost:9001/"
-        }
-    ],
-    "keys": {
-        "keyData": [
-            {
-                "privateKeyPath": "./src/test/resources/unlockedprivatekey.json",
-                "publicKeyPath": "./src/test/resources/publicKey.pub"
-            }
-        ]
-    },
-    "alwaysSendTo": []
+  "useWhiteList": false,
+  "jdbc": {
+    "username": "sa",
+    "password": "",
+    "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+  },
+  "server": {
+    "port": 9001,
+    "hostName": "http://localhost",
+    "sslConfig": {
+      "tls": "OFF"
+    }
+  },
+  "peer": [
+    {
+      "url": "http://localhost:9001/"
+    }
+  ],
+  "keys": {
+    "keyData": [
+      {
+        "privateKeyPath": "./src/test/resources/unlockedprivatekey.json",
+        "publicKeyPath": "./src/test/resources/publicKey.pub"
+      }
+    ]
+  },
+  "alwaysSendTo": [],
+  "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsUnlocked_missingPrivateKey.json
+++ b/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsUnlocked_missingPrivateKey.json
@@ -1,39 +1,30 @@
 {
-    "useWhiteList": false,
-    "jdbc": {
-        "username": "sa",
-        "password": "",
-        "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
-    },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
-        }
-    ],
-    "peer": [
-        {
-            "url": "http://localhost:9001/"
-        }
-    ],
-    "keys": {
-        "keyData": [
-            {
-                "privateKeyPath": "BOGUS.key",
-                "publicKeyPath": "./src/test/resources/publicKey.pub"
-            }
-        ]
-    },
-    "alwaysSendTo": []
+  "useWhiteList": false,
+  "jdbc": {
+    "username": "sa",
+    "password": "",
+    "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+  },
+  "server": {
+    "port": 9001,
+    "hostName": "http://localhost",
+    "sslConfig": {
+      "tls": "OFF"
+    }
+  },
+  "peer": [
+    {
+      "url": "http://localhost:9001/"
+    }
+  ],
+  "keys": {
+    "keyData": [
+      {
+        "privateKeyPath": "BOGUS.key",
+        "publicKeyPath": "./src/test/resources/publicKey.pub"
+      }
+    ]
+  },
+  "alwaysSendTo": [],
+  "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsUnlocked_missingPublicKey.json
+++ b/cli/config-cli/src/test/resources/keytests/pubPrivUsingPathsUnlocked_missingPublicKey.json
@@ -1,39 +1,30 @@
 {
-    "useWhiteList": false,
-    "jdbc": {
-        "username": "sa",
-        "password": "",
-        "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
-    },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
-        }
-    ],
-    "peer": [
-        {
-            "url": "http://localhost:9001/"
-        }
-    ],
-    "keys": {
-        "keyData": [
-            {
-                "privateKeyPath": "./src/test/resources/unlockedprivatekey.json",
-                "publicKeyPath": "BOGUS.pub"
-            }
-        ]
-    },
-    "alwaysSendTo": []
+  "useWhiteList": false,
+  "jdbc": {
+    "username": "sa",
+    "password": "",
+    "url": "jdbc:h2:./target/qdata/c1/db1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+  },
+  "server": {
+    "port": 9001,
+    "hostName": "http://localhost",
+    "sslConfig": {
+      "tls": "OFF"
+    }
+  },
+  "peer": [
+    {
+      "url": "http://localhost:9001/"
+    }
+  ],
+  "keys": {
+    "keyData": [
+      {
+        "privateKeyPath": "./src/test/resources/unlockedprivatekey.json",
+        "publicKeyPath": "BOGUS.pub"
+      }
+    ]
+  },
+  "alwaysSendTo": [],
+  "unixSocketFile": "/Users/peter/IdeaProjects/quorum-ex/examples/7nodes/qdata/c1/tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/missing-config.json
+++ b/cli/config-cli/src/test/resources/missing-config.json
@@ -1,17 +1,8 @@
 {
     "useWhiteList": false,
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "serverAddress": "http://localhost:8080"
-        }
-    ],
+    "server": {
+        "port": 99
+    },
     "peer": [
         {
             "url": "http://bogus1.com"
@@ -39,5 +30,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/cli/config-cli/src/test/resources/sample-config-invalidpath.json
+++ b/cli/config-cli/src/test/resources/sample-config-invalidpath.json
@@ -15,7 +15,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:tm.ipc",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -23,7 +23,20 @@
             "enabled": true,
             "serverAddress": "http://localhost:8091",
             "sslConfig": {
-                "tls": "OFF"
+                "tls": "OFF",
+                "generateKeyStoreIfNotExisted": "false",
+                "serverKeyStore": "./ssl/server1-keystore",
+                "serverKeyStorePassword": "quorum",
+                "serverTrustStore": "./ssl/server-truststore",
+                "serverTrustStorePassword": "quorum",
+                "serverTrustMode": "CA",
+                "clientKeyStore": "./ssl/client1-keystore",
+                "clientKeyStorePassword": "quorum",
+                "clientTrustStore": "./ssl/client-truststore",
+                "clientTrustStorePassword": "quorum",
+                "clientTrustMode": "CA",
+                "knownClientsFile": "./ssl/knownClients1",
+                "knownServersFile": "./ssl/knownServers1"
             },
             "communicationType": "REST"
         }
@@ -47,5 +60,6 @@
     },
     "alwaysSendTo": [
         "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc="
-    ]
+    ],
+    "unixSocketFile": "tm.ipc"
 }

--- a/cli/config-cli/src/test/resources/sample-config.json
+++ b/cli/config-cli/src/test/resources/sample-config.json
@@ -22,7 +22,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -30,7 +30,20 @@
             "enabled": true,
             "serverAddress": "http://localhost:8091",
             "sslConfig": {
-                "tls": "OFF"
+                "tls": "OFF",
+                "generateKeyStoreIfNotExisted": "false",
+                "serverKeyStore": "./ssl/server1-keystore",
+                "serverKeyStorePassword": "quorum",
+                "serverTrustStore": "./ssl/server-truststore",
+                "serverTrustStorePassword": "quorum",
+                "serverTrustMode": "CA",
+                "clientKeyStore": "./ssl/client1-keystore",
+                "clientKeyStorePassword": "quorum",
+                "clientTrustStore": "./ssl/client-truststore",
+                "clientTrustStorePassword": "quorum",
+                "clientTrustMode": "CA",
+                "knownClientsFile": "./ssl/knownClients1",
+                "knownServersFile": "./ssl/knownServers1"
             },
             "communicationType": "REST"
         }
@@ -59,5 +72,6 @@
     },
     "alwaysSendTo": [
         "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc="
-    ]
+    ],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/config-migration/src/main/java/com/quorum/tessera/config/builder/ConfigBuilder.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/builder/ConfigBuilder.java
@@ -224,7 +224,7 @@ public class ConfigBuilder {
 
         boolean generateKeyStoreIfNotExisted = false;
 
-        final SslConfig sslConfig = new SslConfig(
+        SslConfig sslConfig = new SslConfig(
                 sslAuthenticationMode,
                 generateKeyStoreIfNotExisted,
                 toPath(workDir, sslServerKeyStorePath),
@@ -254,24 +254,19 @@ public class ConfigBuilder {
                 null
         );
 
-        final ServerConfig q2tConfig = new ServerConfig();
-        q2tConfig.setEnabled(true);
-        q2tConfig.setApp(AppType.Q2T);
-        q2tConfig.setCommunicationType(CommunicationType.REST);
-        q2tConfig.setServerAddress("unix:"+ toPath(workDir, unixSocketFile));
-
-        final ServerConfig p2pConfig = new ServerConfig();
-        final String port = (serverPort == null) ? "" : ":"+serverPort;
-        final String hostname = (serverHostname == null) ? null : serverHostname + port;
-        p2pConfig.setEnabled(true);
-        p2pConfig.setApp(AppType.P2P);
-        p2pConfig.setCommunicationType(CommunicationType.REST);
-        p2pConfig.setServerAddress(hostname);
-        p2pConfig.setSslConfig(sslConfig);
-
+        //TODO must add P2P and Q2T server configs. Maybe ThirdParty too - in disabled state.
+        //serverHostname, serverPort, 50521, CommunicationType.REST, sslConfig, null, null, null
+        final DeprecatedServerConfig serverConfig = new DeprecatedServerConfig();
+        serverConfig.setPort(serverPort);
+        serverConfig.setHostName(serverHostname);
+        serverConfig.setCommunicationType(CommunicationType.REST);
+        serverConfig.setSslConfig(sslConfig);
+        
         final List<Peer> peerList;
         if(peers != null) {
-            peerList = peers.stream().map(Peer::new).collect(Collectors.toList());
+            peerList = peers.stream()
+                            .map(Peer::new)
+                            .collect(Collectors.toList());
         } else {
             peerList = null;
         }
@@ -289,11 +284,12 @@ public class ConfigBuilder {
             }
         }
 
-        final Config config = new Config();
-        config.setServerConfigs(Arrays.asList(q2tConfig, p2pConfig));
+        Config config = new Config();
+        config.setServer(serverConfig);
         config.setJdbcConfig(jdbcConfig);
         config.setPeers(peerList);
         config.setAlwaysSendTo(forwardingKeys);
+        config.setUnixSocketFile(toPath(workDir, unixSocketFile));
         config.setUseWhiteList(useWhiteList);
         config.setKeys(keyData);
         config.setDisablePeerDiscovery(false);

--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
@@ -1,7 +1,7 @@
 package com.quorum.tessera.config.builder;
 
 import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.config.DeprecatedServerConfig;
 import com.quorum.tessera.config.SslConfig;
 import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 import com.quorum.tessera.config.migration.test.FixtureUtil;
@@ -34,23 +34,18 @@ public class ConfigBuilderTest {
 
         assertThat(result).isNotNull();
 
-        final ServerConfig q2tConfig = result.getServerConfigs()
-            .stream()
-            .filter(ServerConfig::isUnixSocket)
-            .findAny()
-            .get();
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:somepath.ipc");
+        assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get("somepath.ipc"));
 
         assertThat(result.getKeys().getKeyData()).hasSize(1);
         final ConfigKeyPair keyData = result.getKeys().getKeyData().get(0);
         assertThat(keyData).isNotNull().extracting("privateKeyPath").containsExactly(Paths.get("private"));
         assertThat(keyData).isNotNull().extracting("publicKeyPath").containsExactly(Paths.get("public"));
 
-        final ServerConfig serverConfig = result.getP2PServerConfig();
+        final DeprecatedServerConfig serverConfig = result.getServer();
         assertThat(serverConfig).isNotNull();
-
+        assertThat(serverConfig.getPort()).isEqualTo(892);
+        assertThat(serverConfig.getHostName()).isEqualTo("http://bogus.com");
         assertThat(serverConfig.getBindingAddress()).isEqualTo("http://bogus.com:892");
-        assertThat(serverConfig.getServerAddress()).isEqualTo("http://bogus.com:892");
 
         final SslConfig sslConfig = serverConfig.getSslConfig();
         assertThat(sslConfig).isNotNull();
@@ -70,7 +65,7 @@ public class ConfigBuilderTest {
     public void influxHostNameEmptyThenInfluxConfigIsNull() {
         final Config result = builderWithValidValues.build();
 
-        result.getServerConfigs().forEach(config -> assertThat(config.getInfluxConfig()).isNull());
+        assertThat(result.getServer().getInfluxConfig()).isNull();
     }
 
     @Test

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/LegacyCliAdapterTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/LegacyCliAdapterTest.java
@@ -55,9 +55,9 @@ public class LegacyCliAdapterTest {
         Files.deleteIfExists(Paths.get("tessera-config.json"));
 
         Files.walk(dataDirectory)
-            .sorted(Comparator.reverseOrder())
-            .map(Path::toFile)
-            .forEach(File::delete);
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
     }
 
     @Test
@@ -67,8 +67,7 @@ public class LegacyCliAdapterTest {
 
     @Test
     public void help() throws Exception {
-        final CliResult result = instance.execute("help");
-
+        CliResult result = instance.execute("help");
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isNotPresent();
         assertThat(result.getStatus()).isEqualTo(0);
@@ -76,8 +75,7 @@ public class LegacyCliAdapterTest {
 
     @Test
     public void noArgs() throws Exception {
-        final CliResult result = instance.execute();
-
+        CliResult result = instance.execute();
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isNotPresent();
         assertThat(result.getStatus()).isEqualTo(1);
@@ -88,9 +86,9 @@ public class LegacyCliAdapterTest {
         dataDirectory = Paths.get("data");
         Files.createDirectory(dataDirectory);
 
-        final Path alwaysSendTo1 = Files.createFile(dataDirectory.resolve("alwayssendto1"));
-        final String keys1 = "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\njWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=";
-        Files.write(alwaysSendTo1, keys1.getBytes());
+        Path alwaysSendTo1 = Files.createFile(dataDirectory.resolve("alwayssendto1"));
+        Files.write(alwaysSendTo1, ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n"
+                                    + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=").getBytes());
 
         Path alwaysSendTo2 = Files.createFile(dataDirectory.resolve("alwayssendto2"));
         Files.write(alwaysSendTo2, "yGcjkFyZklTTXrn8+WIkYwicA2EGBn9wZFkctAad4X0=".getBytes());
@@ -111,28 +109,10 @@ public class LegacyCliAdapterTest {
         assertThat(result.getConfig()).isPresent();
         final Config config = result.getConfig().get();
 
-        final ServerConfig q2tConfig = this.getQ2tServer(config.getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:data/constellation.ipc");
-
-        final ServerConfig p2pConfig = this.getP2pServer(config.getServerConfigs());
-        assertThat(p2pConfig.getServerAddress()).isEqualTo("http://127.0.0.1:9001");
-        assertThat(p2pConfig.getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
-        assertThat(p2pConfig.getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.STRICT);
-        assertThat(p2pConfig.getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("data/tls-server-cert.pem");
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().size()).isEqualTo(2);
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("data/chain1");
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().get(1).toString()).isEqualTo("data/chain2");
-        assertThat(p2pConfig.getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("data/tls-server-key.pem");
-        assertThat(p2pConfig.getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownClientsFile().toString()).isEqualTo("data/tls-known-clients");
-        assertThat(p2pConfig.getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("data/tls-client-cert.pem");
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().size()).isEqualTo(2);
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("data/clientchain1");
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().get(1).toString()).isEqualTo("data/clientchain2");
-        assertThat(p2pConfig.getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("data/tls-client-key.pem");
-        assertThat(p2pConfig.getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownServersFile().toString()).isEqualTo("data/tls-known-servers");
-
+        assertThat(config.getServer().getHostName()).isEqualTo("http://127.0.0.1");
+        assertThat(config.getServer().getPort()).isEqualTo(9001);
+        assertThat(config.getServer().getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
+        assertThat(config.getUnixSocketFile().toString()).isEqualTo("data/constellation.ipc");
         assertThat(config.getPeers().size()).isEqualTo(2);
         assertThat(config.getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
         assertThat(config.getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
@@ -148,6 +128,21 @@ public class LegacyCliAdapterTest {
         assertThat(config.getKeys().getPasswordFile().toString()).isEqualTo("data/passwords");
         assertThat(config.getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
         assertThat(config.isUseWhiteList()).isTrue();
+        assertThat(config.getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.STRICT);
+        assertThat(config.getServer().getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("data/tls-server-cert.pem");
+        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(2);
+        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("data/chain1");
+        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().get(1).toString()).isEqualTo("data/chain2");
+        assertThat(config.getServer().getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("data/tls-server-key.pem");
+        assertThat(config.getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(config.getServer().getSslConfig().getKnownClientsFile().toString()).isEqualTo("data/tls-known-clients");
+        assertThat(config.getServer().getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("data/tls-client-cert.pem");
+        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(2);
+        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("data/clientchain1");
+        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().get(1).toString()).isEqualTo("data/clientchain2");
+        assertThat(config.getServer().getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("data/tls-client-key.pem");
+        assertThat(config.getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
+        assertThat(config.getServer().getSslConfig().getKnownServersFile().toString()).isEqualTo("data/tls-known-servers");
     }
 
     @Test
@@ -155,14 +150,16 @@ public class LegacyCliAdapterTest {
 
         Path sampleFile = Paths.get(getClass().getResource("/sample.conf").toURI());
 
-        String data = new String(Files.readAllBytes(sampleFile));
+        String data = Files.readAllLines(sampleFile)
+            .stream()
+            .collect(Collectors.joining(System.lineSeparator()));
 
         Path configFile = Files.createTempFile("noOptions", ".txt");
         Files.write(configFile, data.getBytes());
 
         Path workdir = Paths.get("override");
 
-        if (Files.exists(workdir)) {
+        if(Files.exists(workdir)) {
             Files.walk(workdir)
                 .sorted(Comparator.reverseOrder())
                 .map(Path::toFile)
@@ -207,39 +204,34 @@ public class LegacyCliAdapterTest {
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
 
-        final Config config = result.getConfig().get();
-
-        final ServerConfig q2tConfig = this.getQ2tServer(config.getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:override/cli.ipc");
-
-        final ServerConfig p2pConfig = this.getP2pServer(config.getServerConfigs());
-        assertThat(p2pConfig.getBindingAddress()).isEqualTo("http://override:1111");
-        assertThat(p2pConfig.getServerAddress()).isEqualTo("http://override:1111");
-        assertThat(p2pConfig.getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
-        assertThat(p2pConfig.getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("override/over-server-cert.pem");
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().size()).isEqualTo(1);
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("override/serverchain.file");
-        assertThat(p2pConfig.getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("override/over-server-key.pem");
-        assertThat(p2pConfig.getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.WHITELIST);
-        assertThat(p2pConfig.getSslConfig().getKnownClientsFile().toString()).isEqualTo("override/over-known-clients");
-        assertThat(p2pConfig.getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("override/over-client-cert.pem");
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().size()).isEqualTo(1);
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("override/clientchain.file");
-        assertThat(p2pConfig.getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("override/over-client-key.pem");
-        assertThat(p2pConfig.getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownServersFile().toString()).isEqualTo("override/over-known-servers");
-
-        assertThat(config.getPeers().size()).isEqualTo(1);
-        assertThat(config.getPeers().get(0).getUrl()).isEqualTo("http://others");
-        assertThat(config.getKeys().getKeyData().size()).isEqualTo(1);
-        assertThat(config.getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
-        assertThat(config.getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
-        assertThat(config.getAlwaysSendTo().size()).isEqualTo(2);
-        assertThat(config.getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        assertThat(config.getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
-        assertThat(config.getKeys().getPasswordFile().toString()).isEqualTo("override/pw.txt");
-        assertThat(config.getJdbcConfig().getUrl()).isEqualTo("jdbc:test");
-        assertThat(config.isUseWhiteList()).isTrue();
+        assertThat(result.getConfig().get().getServer().getHostName()).isEqualTo("http://override");
+        assertThat(result.getConfig().get().getServer().getPort()).isEqualTo(1111);
+        assertThat(result.getConfig().get().getServer().getBindingAddress()).isEqualTo("http://override:1111");
+        assertThat(result.getConfig().get().getUnixSocketFile().toString()).isEqualTo("override/cli.ipc");
+        assertThat(result.getConfig().get().getPeers().size()).isEqualTo(1);
+        assertThat(result.getConfig().get().getPeers().get(0).getUrl()).isEqualTo("http://others");
+        assertThat(result.getConfig().get().getKeys().getKeyData().size()).isEqualTo(1);
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
+        assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(2);
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
+        assertThat(result.getConfig().get().getKeys().getPasswordFile().toString()).isEqualTo("override/pw.txt");
+        assertThat(result.getConfig().get().getJdbcConfig().getUrl()).isEqualTo("jdbc:test");
+        assertThat(result.getConfig().get().isUseWhiteList()).isTrue();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("override/over-server-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(1);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("override/serverchain.file");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("override/over-server-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.WHITELIST);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile().toString()).isEqualTo("override/over-known-clients");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("override/over-client-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(1);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("override/clientchain.file");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("override/over-client-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile().toString()).isEqualTo("override/over-known-servers");
 
         Files.walk(workdir)
             .sorted(Comparator.reverseOrder())
@@ -270,30 +262,24 @@ public class LegacyCliAdapterTest {
         assertThat(result.getConfig()).isPresent();
         assertThat(result.getStatus()).isEqualTo(0);
 
-        final Config config = result.getConfig().get();
-
-        final ServerConfig q2tConfig = this.getQ2tServer(config.getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:myipcfile.ipc");
-
-        final ServerConfig p2pConfig = this.getP2pServer(config.getServerConfigs());
-        assertThat(p2pConfig.getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
-        assertThat(p2pConfig.getSslConfig().getServerTlsCertificatePath()).isNull();
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().size()).isEqualTo(0);
-        assertThat(p2pConfig.getSslConfig().getServerTlsKeyPath()).isNull();
-        assertThat(p2pConfig.getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownClientsFile()).isNull();
-        assertThat(p2pConfig.getSslConfig().getClientTlsCertificatePath()).isNull();
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().size()).isEqualTo(0);
-        assertThat(p2pConfig.getSslConfig().getClientTlsKeyPath()).isNull();
-        assertThat(p2pConfig.getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownServersFile()).isNull();
-
+        assertThat(result.getConfig().get().getUnixSocketFile().toString()).isEqualTo("myipcfile.ipc");
         //Empty List
         assertThat(Optional.ofNullable(result.getConfig().get().getKeys().getKeyData()).isPresent()).isEqualTo(true);
         assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(0);
         assertThat(result.getConfig().get().getKeys().getPasswordFile()).isNull();
         assertThat(result.getConfig().get().getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
         assertThat(result.getConfig().get().isUseWhiteList()).isFalse();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath()).isNull();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(0);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath()).isNull();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile()).isNull();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath()).isNull();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(0);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath()).isNull();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile()).isNull();
     }
 
     @Test
@@ -301,7 +287,7 @@ public class LegacyCliAdapterTest {
 
         Path workdir = Paths.get("override");
 
-        if (Files.exists(workdir)) {
+        if(Files.exists(workdir)) {
             Files.walk(workdir)
                 .sorted(Comparator.reverseOrder())
                 .map(Path::toFile)
@@ -336,43 +322,39 @@ public class LegacyCliAdapterTest {
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
 
-        final Config config = result.getConfig().get();
-
-        final ServerConfig q2tConfig = this.getQ2tServer(config.getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:override/constellation.ipc");
-
-        final ServerConfig p2pConfig = this.getP2pServer(config.getServerConfigs());
-        assertThat(p2pConfig.getServerAddress()).isEqualTo("http://127.0.0.1:9001");
-        assertThat(p2pConfig.getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
-        assertThat(p2pConfig.getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("override/tls-server-cert.pem");
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().size()).isEqualTo(2);
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("override/chain1");
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates().get(1).toString()).isEqualTo("override/chain2");
-        assertThat(p2pConfig.getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("override/tls-server-key.pem");
-        assertThat(p2pConfig.getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownClientsFile().toString()).isEqualTo("override/tls-known-clients");
-        assertThat(p2pConfig.getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("override/tls-client-cert.pem");
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().size()).isEqualTo(2);
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("override/clientchain1");
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates().get(1).toString()).isEqualTo("override/clientchain2");
-        assertThat(p2pConfig.getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("override/tls-client-key.pem");
-        assertThat(p2pConfig.getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
-        assertThat(p2pConfig.getSslConfig().getKnownServersFile().toString()).isEqualTo("override/tls-known-servers");
-
-        assertThat(config.getPeers().size()).isEqualTo(2);
-        assertThat(config.getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
-        assertThat(config.getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
-        assertThat(config.getKeys().getKeyData().size()).isEqualTo(1);
-        assertThat(config.getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
-        assertThat(config.getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
-        assertThat(config.getAlwaysSendTo().size()).isEqualTo(4);
-        assertThat(config.getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        assertThat(config.getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
-        assertThat(config.getAlwaysSendTo().get(2)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        assertThat(config.getAlwaysSendTo().get(3)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
-        assertThat(config.getKeys().getPasswordFile().toString()).isEqualTo("override/passwords");
-        assertThat(config.getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
-        assertThat(config.isUseWhiteList()).isTrue();
+        assertThat(result.getConfig().get().getServer().getHostName()).isEqualTo("http://127.0.0.1");
+        assertThat(result.getConfig().get().getServer().getPort()).isEqualTo(9001);
+        assertThat(result.getConfig().get().getServer().getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
+        assertThat(result.getConfig().get().getUnixSocketFile().toString()).isEqualTo("override/constellation.ipc");
+        assertThat(result.getConfig().get().getPeers().size()).isEqualTo(2);
+        assertThat(result.getConfig().get().getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
+        assertThat(result.getConfig().get().getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
+        assertThat(result.getConfig().get().getKeys().getKeyData().size()).isEqualTo(1);
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
+        assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(4);
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(2)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(3)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
+        assertThat(result.getConfig().get().getKeys().getPasswordFile().toString()).isEqualTo("override/passwords");
+        assertThat(result.getConfig().get().getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
+        assertThat(result.getConfig().get().isUseWhiteList()).isTrue();
+        assertThat(result.getConfig().get().getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("override/tls-server-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(2);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("override/chain1");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(1).toString()).isEqualTo("override/chain2");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("override/tls-server-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile().toString()).isEqualTo("override/tls-known-clients");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("override/tls-client-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(2);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("override/clientchain1");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(1).toString()).isEqualTo("override/clientchain2");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("override/tls-client-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile().toString()).isEqualTo("override/tls-known-servers");
     }
 
     @Test
@@ -391,8 +373,7 @@ public class LegacyCliAdapterTest {
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
 
-        final ServerConfig q2tConfig = this.getP2pServer(result.getConfig().get().getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isNull();
+        assertThat(result.getConfig().get().getServer().getHostName()).isNull();
     }
 
     @Test
@@ -411,8 +392,7 @@ public class LegacyCliAdapterTest {
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
 
-        final ServerConfig q2tConfig = this.getP2pServer(result.getConfig().get().getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("http://127.0.0.1:9001");
+        assertThat(result.getConfig().get().getServer().getHostName()).isEqualTo("http://127.0.0.1");
     }
 
     @Test
@@ -446,8 +426,8 @@ public class LegacyCliAdapterTest {
         params.put("serverKeyStorePath", serverKeyStorePath);
 
         String data = Files.readAllLines(sampleFile)
-            .stream()
-            .collect(Collectors.joining(System.lineSeparator()));
+                .stream()
+                .collect(Collectors.joining(System.lineSeparator()));
 
         Path configFile = Files.createTempFile("noOptions", ".txt");
         Files.write(configFile, data.getBytes());
@@ -500,7 +480,7 @@ public class LegacyCliAdapterTest {
         LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
 
         assertThat(errContent.toString())
-            .isEqualTo("Info: Public/Private key data not provided in overrides.  Overriden password file has not been added to config.\n");
+                .isEqualTo("Info: Public/Private key data not provided in overrides.  Overriden password file has not been added to config.\n");
 
     }
 
@@ -565,14 +545,14 @@ public class LegacyCliAdapterTest {
         when(line.getOptionValue("socket")).thenReturn(socketFilepath);
 
         String tomlWorkDir = "toml";
-        ConfigBuilder configBuilder = ConfigBuilder.create().workdir(tomlWorkDir);
+        ConfigBuilder configBuilder = ConfigBuilder.create()
+                                                .workdir(tomlWorkDir);
 
         ConfigBuilder result = LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
 
         Path expected = Paths.get(tomlWorkDir, socketFilepath);
 
-        final ServerConfig q2tConfig = this.getQ2tServer(result.build().getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:" + expected.toString());
+        assertThat(result.build().getUnixSocketFile()).isEqualByComparingTo(expected);
     }
 
     @Test
@@ -590,8 +570,7 @@ public class LegacyCliAdapterTest {
 
         Path expected = Paths.get(overrideWorkDir, socketFilepath);
 
-        final ServerConfig q2tConfig = this.getQ2tServer(result.build().getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:" + expected.toString());
+        assertThat(result.build().getUnixSocketFile()).isEqualByComparingTo(expected);
     }
 
     @Test
@@ -605,8 +584,9 @@ public class LegacyCliAdapterTest {
 
         ConfigBuilder result = LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
 
-        final ServerConfig q2tConfig = this.getQ2tServer(result.build().getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:" + socketFilepath);
+        Path expected = Paths.get(socketFilepath);
+
+        assertThat(result.build().getUnixSocketFile()).isEqualByComparingTo(expected);
     }
 
     @Test
@@ -624,8 +604,7 @@ public class LegacyCliAdapterTest {
 
         Path expected = Paths.get(overrideWorkDir, socketFilepath);
 
-        final ServerConfig q2tConfig = this.getQ2tServer(result.build().getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:" + expected.toString());
+        assertThat(result.build().getUnixSocketFile()).isEqualByComparingTo(expected);
     }
 
     @Test
@@ -644,26 +623,44 @@ public class LegacyCliAdapterTest {
         when(commandLine.getOptionValue("port")).thenReturn(String.valueOf(portOverride));
         when(commandLine.getOptionValue("workdir")).thenReturn(workdirOverride);
         when(commandLine.getOptionValue("socket")).thenReturn(unixSocketFileOverride);
+
         when(commandLine.getOptionValues("othernodes"))
-            .thenReturn(overridePeers.stream().map(Peer::getUrl).toArray(String[]::new));
-        when(commandLine.getOptionValues("publickeys")).thenReturn(new String[]{"ONE", "TWO"});
+                .thenReturn(
+                        overridePeers.stream().map(Peer::getUrl).toArray(String[]::new)
+                );
+
+        when(commandLine.getOptionValues("publickeys"))
+                .thenReturn(new String[]{"ONE", "TWO"});
+
         when(commandLine.getOptionValue("storage")).thenReturn("sqlite:somepath");
+
         when(commandLine.getOptionValue("tlsservertrust")).thenReturn("whitelist");
+
         when(commandLine.getOptionValue("tlsclienttrust")).thenReturn("ca");
+
         when(commandLine.getOptionValue("tlsservercert")).thenReturn("tlsservercert.cert");
+
         when(commandLine.getOptionValue("tlsclientcert")).thenReturn("tlsclientcert.cert");
-        when(commandLine.getOptionValues("tlsserverchain"))
-            .thenReturn(new String[]{"server1.crt", "server2.crt", "server3.crt"});
-        when(commandLine.getOptionValues("tlsclientchain"))
-            .thenReturn(new String[]{"client1.crt", "client2.crt", "client3.crt"});
-        when(commandLine.getOptionValue("tlsserverkey")).thenReturn("tlsserverkey.key");
-        when(commandLine.getOptionValue("tlsclientkey")).thenReturn("tlsclientkey.key");
+
+        when(commandLine.getOptionValues("tlsserverchain")).thenReturn(new String[]{
+            "server1.crt", "server2.crt", "server3.crt"
+        });
+
+        when(commandLine.getOptionValues("tlsclientchain")).thenReturn(new String[]{
+            "client1.crt", "client2.crt", "client3.crt"
+        });
+
+        when(commandLine.getOptionValue("tlsserverkey"))
+                .thenReturn("tlsserverkey.key");
+
+        when(commandLine.getOptionValue("tlsclientkey"))
+                .thenReturn("tlsclientkey.key");
 
         doReturn(new String[]{}).when(commandLine).getOptionValues("alwayssendto");
 
         List<Path> privateKeyPaths = Arrays.asList(
-            Files.createTempFile("applyOverrides1", ".txt"),
-            Files.createTempFile("applyOverrides2", ".txt")
+                Files.createTempFile("applyOverrides1", ".txt"),
+                Files.createTempFile("applyOverrides2", ".txt")
         );
 
         when(commandLine.getOptionValue("tlsknownservers")).thenReturn("tlsknownservers.file");
@@ -675,7 +672,10 @@ public class LegacyCliAdapterTest {
             Files.write(p, privateKeyData);
         }
 
-        final String[] privateKeyPathStrings = privateKeyPaths.stream().map(Path::toString).toArray(String[]::new);
+        final String[] privateKeyPathStrings = privateKeyPaths
+                .stream()
+                .map(Path::toString)
+                .toArray(String[]::new);
 
         when(commandLine.getOptionValues("privatekeys")).thenReturn(privateKeyPathStrings);
 
@@ -689,63 +689,72 @@ public class LegacyCliAdapterTest {
         Config result = LegacyCliAdapter.applyOverrides(commandLine, builderWithValidValues, KeyDataBuilder.create()).build();
 
         assertThat(result).isNotNull();
-
-        final ServerConfig q2tConfig = this.getQ2tServer(result.getServerConfigs());
-        assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:" + Paths.get(workdirOverride, unixSocketFileOverride).toString());
-
-        final ServerConfig p2pConfig = this.getP2pServer(result.getServerConfigs());
-        assertThat(p2pConfig.getBindingAddress()).isEqualTo("http://junit.com:" + portOverride);
-        assertThat(p2pConfig.getServerAddress()).isEqualTo("http://junit.com:" + portOverride);
-        assertThat(p2pConfig.getSslConfig().getServerTrustMode()).isEqualTo(SslTrustMode.WHITELIST);
-        assertThat(p2pConfig.getSslConfig().getClientTrustMode()).isEqualTo(SslTrustMode.CA);
-        assertThat(p2pConfig.getSslConfig().getClientTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsclientcert.cert"));
-        assertThat(p2pConfig.getSslConfig().getServerTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsservercert.cert"));
-        assertThat(p2pConfig.getSslConfig().getServerTrustCertificates()).containsExactly(Paths.get(workdirOverride, "server1.crt"), Paths.get(workdirOverride, "server2.crt"), Paths.get(workdirOverride, "server3.crt"));
-        assertThat(p2pConfig.getSslConfig().getClientTrustCertificates()).containsExactly(Paths.get(workdirOverride, "client1.crt"), Paths.get(workdirOverride, "client2.crt"), Paths.get(workdirOverride, "client3.crt"));
-        assertThat(p2pConfig.getSslConfig().getServerKeyStore()).isEqualTo(Paths.get("workdirOverride/sslServerKeyStorePath"));
-        assertThat(p2pConfig.getSslConfig().getClientKeyStore()).isEqualTo(Paths.get("workdirOverride/sslClientKeyStorePath"));
-        assertThat(p2pConfig.getSslConfig().getKnownServersFile()).isEqualTo(Paths.get("workdirOverride/tlsknownservers.file"));
-        assertThat(p2pConfig.getSslConfig().getKnownClientsFile()).isEqualTo(Paths.get(workdirOverride, "tlsknownclients.file"));
-
+        assertThat(result.getServer().getHostName()).isEqualTo("http://junit.com");
+        assertThat(result.getServer().getPort()).isEqualTo(portOverride);
+        assertThat(result.getServer().getBindingAddress()).isEqualTo("http://junit.com:" + portOverride);
+        assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get(workdirOverride, unixSocketFileOverride));
         assertThat(result.getPeers()).containsExactly(overridePeers.toArray(new Peer[0]));
         assertThat(result.getKeys().getKeyData()).hasSize(2);
         assertThat(result.getJdbcConfig()).isNotNull();
         assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:sqlite:somepath");
+
+        assertThat(result.getServer().getSslConfig().getServerTrustMode()).isEqualTo(SslTrustMode.WHITELIST);
+        assertThat(result.getServer().getSslConfig().getClientTrustMode()).isEqualTo(SslTrustMode.CA);
+
+        assertThat(result.getServer().getSslConfig().getClientTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsclientcert.cert"));
+
+        assertThat(result.getServer().getSslConfig().getServerTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsservercert.cert"));
+
+        assertThat(result.getServer().getSslConfig().getServerTrustCertificates())
+                .containsExactly(Paths.get(workdirOverride, "server1.crt"), Paths.get(workdirOverride, "server2.crt"), Paths.get(workdirOverride, "server3.crt"));
+
+        assertThat(result.getServer().getSslConfig().getClientTrustCertificates())
+                .containsExactly(Paths.get(workdirOverride, "client1.crt"), Paths.get(workdirOverride, "client2.crt"), Paths.get(workdirOverride, "client3.crt"));
+
+        assertThat(result.getServer().getSslConfig().getServerKeyStore())
+                .isEqualTo(Paths.get("workdirOverride/sslServerKeyStorePath"));
+        assertThat(result.getServer().getSslConfig().getClientKeyStore())
+                .isEqualTo(Paths.get("workdirOverride/sslClientKeyStorePath"));
+        assertThat(result.getServer().getSslConfig().getKnownServersFile())
+                .isEqualTo(Paths.get("workdirOverride/tlsknownservers.file"));
+        assertThat(result.getServer().getSslConfig().getKnownClientsFile())
+                .isEqualTo(Paths.get(workdirOverride, "tlsknownclients.file"));
     }
 
-//    @Test
-//    public void applyOverridesNullValues() {
-//        Config expectedValues = builderWithValidValues.build();
-//
-//        CommandLine commandLine = mock(CommandLine.class);
-//
-//        Config result = LegacyCliAdapter.applyOverrides(commandLine, builderWithValidValues, KeyDataBuilder.create()).build();
-//
-//        assertThat(result).isNotNull();
-//
-//        final DeprecatedServerConfig expectedServerConfig = expectedValues.getServer();
-//        final DeprecatedServerConfig realServerConfig = result.getServer();
-//        final SslConfig sslConfig = realServerConfig.getSslConfig();
-//
-//        assertThat(realServerConfig.getHostName()).isEqualTo(expectedServerConfig.getHostName());
-//        assertThat(realServerConfig.getPort()).isEqualTo(expectedServerConfig.getPort());
-//        assertThat(realServerConfig.getBindingAddress()).isEqualTo(expectedServerConfig.getBindingAddress());
-//
-//        assertThat(result.getUnixSocketFile()).isEqualTo(expectedValues.getUnixSocketFile());
-//
-//        assertThat(result.getPeers()).containsOnlyElementsOf(expectedValues.getPeers());
-//
-//        assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:bogus");
-//
-//        assertThat(sslConfig.getServerTrustMode()).isEqualTo(SslTrustMode.TOFU);
-//        assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
-//        assertThat(sslConfig.getClientKeyStore()).isEqualTo(Paths.get("sslClientKeyStorePath"));
-//        assertThat(sslConfig.getServerKeyStore()).isEqualTo(Paths.get("sslServerKeyStorePath"));
-//        assertThat(sslConfig.getServerTrustCertificates()).containsExactly(Paths.get("sslServerTrustCertificates"));
-//        assertThat(sslConfig.getClientTrustCertificates()).containsExactly(Paths.get("sslClientTrustCertificates"));
-//        assertThat(sslConfig.getKnownServersFile()).isEqualTo(Paths.get("knownServersFile"));
-//        assertThat(sslConfig.getKnownClientsFile()).isEqualTo(Paths.get("knownClientsFile"));
-//    }
+    @Test
+    public void applyOverridesNullValues() {
+
+        Config expectedValues = builderWithValidValues.build();
+
+        CommandLine commandLine = mock(CommandLine.class);
+
+        Config result = LegacyCliAdapter.applyOverrides(commandLine, builderWithValidValues, KeyDataBuilder.create()).build();
+
+        assertThat(result).isNotNull();
+
+        final DeprecatedServerConfig expectedServerConfig = expectedValues.getServer();
+        final DeprecatedServerConfig realServerConfig = result.getServer();
+        final SslConfig sslConfig = realServerConfig.getSslConfig();
+
+        assertThat(realServerConfig.getHostName()).isEqualTo(expectedServerConfig.getHostName());
+        assertThat(realServerConfig.getPort()).isEqualTo(expectedServerConfig.getPort());
+        assertThat(realServerConfig.getBindingAddress()).isEqualTo(expectedServerConfig.getBindingAddress());
+
+        assertThat(result.getUnixSocketFile()).isEqualTo(expectedValues.getUnixSocketFile());
+
+        assertThat(result.getPeers()).containsOnlyElementsOf(expectedValues.getPeers());
+
+        assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:bogus");
+
+        assertThat(sslConfig.getServerTrustMode()).isEqualTo(SslTrustMode.TOFU);
+        assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
+        assertThat(sslConfig.getClientKeyStore()).isEqualTo(Paths.get("sslClientKeyStorePath"));
+        assertThat(sslConfig.getServerKeyStore()).isEqualTo(Paths.get("sslServerKeyStorePath"));
+        assertThat(sslConfig.getServerTrustCertificates()).containsExactly(Paths.get("sslServerTrustCertificates"));
+        assertThat(sslConfig.getClientTrustCertificates()).containsExactly(Paths.get("sslClientTrustCertificates"));
+        assertThat(sslConfig.getKnownServersFile()).isEqualTo(Paths.get("knownServersFile"));
+        assertThat(sslConfig.getKnownClientsFile()).isEqualTo(Paths.get("knownClientsFile"));
+    }
 
     @Test
     public void writeToOutputFileValidationError() throws Exception {
@@ -756,14 +765,6 @@ public class LegacyCliAdapterTest {
         CliResult result = LegacyCliAdapter.writeToOutputFile(config, outputPath);
 
         assertThat(result.getStatus()).isEqualTo(2);
-    }
-
-    private ServerConfig getQ2tServer(final List<ServerConfig> serverConfigs) {
-        return serverConfigs.stream().filter(config -> AppType.Q2T.equals(config.getApp())).findFirst().orElse(null);
-    }
-
-    private ServerConfig getP2pServer(final List<ServerConfig> serverConfigs) {
-        return serverConfigs.stream().filter(config -> AppType.P2P.equals(config.getApp())).findFirst().orElse(null);
     }
 
 }

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
@@ -36,28 +36,30 @@ public class TomlConfigFactoryTest {
         try (InputStream configData = ElUtil.process(template, params)) {
             Config result = tomlConfigFactory.create(configData, null).build();
             assertThat(result).isNotNull();
+            assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get("data", "myipcfile.ipc"));
+            assertThat(result.getServer()).isNotNull();
+            assertThat(result.getServer().getSslConfig()).isNotNull();
 
-            final ServerConfig q2tConfig = result.getServerConfigs().stream().filter(ServerConfig::isUnixSocket).findAny().get();
-            assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:data/myipcfile.ipc");
+            SslConfig sslConfig = result.getServer().getSslConfig();
 
-            assertThat(result.getP2PServerConfig()).isNotNull();
-            assertThat(result.getP2PServerConfig().getServerAddress()).isEqualTo("http://127.0.0.1:9001");
-            assertThat(result.getP2PServerConfig().getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
+            assertThat(result.getServer().getHostName()).isEqualTo("http://127.0.0.1");
+            assertThat(result.getServer().getPort()).isEqualTo(9001);
+            assertThat(result.getServer().getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
 
-            final SslConfig sslConfig = result.getP2PServerConfig().getSslConfig();
-            assertThat(sslConfig).isNotNull();
             assertThat(sslConfig.getClientTlsKeyPath()).isEqualTo(Paths.get("data/tls-client-key.pem"));
             assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
+
         }
     }
 
     @Test
     public void urlPortNotSetInConfig() {
+
         InputStream template = getClass().getResourceAsStream("/sample-all-values-urlport-not-present.conf");
 
         Config result = tomlConfigFactory.create(template, null).build();
 
-        assertThat(result.getP2PServerConfig().getServerAddress()).isEqualTo("http://127.0.0.1");
+        assertThat(result.getServer().getHostName()).isEqualTo("http://127.0.0.1");
     }
 
     @Test
@@ -74,21 +76,24 @@ public class TomlConfigFactoryTest {
     @Test
     public void createConfigFromSampleFileOnly() throws IOException {
 
-        try (InputStream configData = getClass().getResourceAsStream("/sample.conf")) {
-            final Config result = tomlConfigFactory.create(configData, null).build();
+        Path passwordFile = Files.createTempFile("password", ".txt");
+        InputStream template = getClass().getResourceAsStream("/sample.conf");
+
+        try (InputStream configData = template) {
+            Config result = tomlConfigFactory.create(configData, null).build();
             assertThat(result).isNotNull();
+            assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get("data", "constellation.ipc"));
+            assertThat(result.getServer()).isNotNull();
+            assertThat(result.getServer().getSslConfig()).isNotNull();
 
-            final ServerConfig q2tConfig = result.getServerConfigs().stream().filter(ServerConfig::isUnixSocket).findAny().get();
-            assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:data/constellation.ipc");
-
-            assertThat(result.getP2PServerConfig()).isNotNull();
-            assertThat(result.getP2PServerConfig().getSslConfig()).isNotNull();
-
-            final SslConfig sslConfig = result.getP2PServerConfig().getSslConfig();
+            SslConfig sslConfig = result.getServer().getSslConfig();
 
             assertThat(sslConfig.getClientTlsKeyPath()).isEqualTo(Paths.get("data/tls-client-key.pem"));
             assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
+
         }
+
+        Files.deleteIfExists(passwordFile);
     }
 
     @Test
@@ -117,6 +122,7 @@ public class TomlConfigFactoryTest {
 
             }
         }
+
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/config-migration/src/test/resources/sample-all-values-urlport-not-present.conf
+++ b/config-migration/src/test/resources/sample-all-values-urlport-not-present.conf
@@ -1,3 +1,6 @@
 ## Externally accessible URL for this node's public API (this is what's
 ## advertised to other nodes on the network, and must be reachable by them.)
 url = "http://127.0.0.1"
+
+## Port to listen on for the public API.
+port = 9001

--- a/config/src/main/java/com/quorum/tessera/config/Config.java
+++ b/config/src/main/java/com/quorum/tessera/config/Config.java
@@ -1,16 +1,20 @@
 package com.quorum.tessera.config;
 
+import com.quorum.tessera.config.adapters.PathAdapter;
 import com.quorum.tessera.config.constraints.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
+@ValidEitherServerConfigsOrServer
 public class Config extends ConfigItem {
 
     @NotNull
@@ -19,7 +23,6 @@ public class Config extends ConfigItem {
     private JdbcConfig jdbcConfig;
 
     @Valid
-    @NotNull
     @ValidServerConfigs
     @XmlElement(name = "serverConfigs", required = true)
     private List<@Valid @ValidServerConfig ServerConfig> serverConfigs;
@@ -39,25 +42,35 @@ public class Config extends ConfigItem {
     @XmlElement(name = "alwaysSendTo")
     private List<@ValidBase64 String> alwaysSendTo = new ArrayList<>();
 
+    @ValidPath(checkCanCreate = true)
+    @XmlElement(required = true, type = String.class)
+    @XmlJavaTypeAdapter(PathAdapter.class)
+    private Path unixSocketFile;
+
     @XmlAttribute
     private boolean useWhiteList;
 
     @XmlAttribute
     private boolean disablePeerDiscovery;
 
+    @XmlElement
+    private DeprecatedServerConfig server;
+
     @Deprecated
     public Config(final JdbcConfig jdbcConfig,
-                  final List<ServerConfig> serverConfigs,
-                  final List<Peer> peers,
-                  final KeyConfiguration keyConfiguration,
-                  final List<String> alwaysSendTo,
-                  final boolean useWhiteList,
-                  final boolean disablePeerDiscovery) {
+        final List<ServerConfig> serverConfigs,
+        final List<Peer> peers,
+        final KeyConfiguration keyConfiguration,
+        final List<String> alwaysSendTo,
+        final Path unixSocketFile,
+        final boolean useWhiteList,
+        final boolean disablePeerDiscovery) {
         this.jdbcConfig = jdbcConfig;
         this.serverConfigs = serverConfigs;
         this.peers = peers;
         this.keys = keyConfiguration;
         this.alwaysSendTo = alwaysSendTo;
+        this.unixSocketFile = unixSocketFile;
         this.useWhiteList = useWhiteList;
         this.disablePeerDiscovery = disablePeerDiscovery;
     }
@@ -70,15 +83,27 @@ public class Config extends ConfigItem {
         return this.jdbcConfig;
     }
 
+    
+    //TODO: Shouldn't need to laziely recalcuate on a getter
     public List<ServerConfig> getServerConfigs() {
-        if (this.serverConfigs == null) {
-            this.serverConfigs = new ArrayList<>();
+        if (null != this.serverConfigs) {
+            return this.serverConfigs;
         }
-        return this.serverConfigs;
+        return DeprecatedServerConfig.from(server, unixSocketFile);
+
+    }
+
+    public boolean isServerConfigsNull(){
+        return null == this.serverConfigs;
+    }
+
+    @Deprecated
+    public Path getUnixSocketFile() {
+        return unixSocketFile;
     }
 
     public List<Peer> getPeers() {
-        if (peers == null) {
+        if(peers == null) {
             return null;
         }
         return Collections.unmodifiableList(peers);
@@ -101,8 +126,8 @@ public class Config extends ConfigItem {
     }
 
     public void addPeer(Peer peer) {
-        if (peers == null) {
-            this.peers = new ArrayList<>();
+        if(peers == null) {
+         this.peers = new ArrayList<>();
         }
         this.peers.add(peer);
     }
@@ -114,6 +139,16 @@ public class Config extends ConfigItem {
             .filter(sc -> sc.getApp() == AppType.P2P)
             .findFirst()
             .orElse(null);
+    }
+    
+    @Deprecated
+    public DeprecatedServerConfig getServer() {
+        return server;
+    }
+    
+    @Deprecated
+    public void setServer(DeprecatedServerConfig server) {
+        this.server = server;
     }
 
     public void setJdbcConfig(JdbcConfig jdbcConfig) {
@@ -134,6 +169,11 @@ public class Config extends ConfigItem {
 
     public void setAlwaysSendTo(List<String> alwaysSendTo) {
         this.alwaysSendTo = alwaysSendTo;
+    }
+
+    @Deprecated
+    public void setUnixSocketFile(Path unixSocketFile) {
+        this.unixSocketFile = unixSocketFile;
     }
 
     public void setUseWhiteList(boolean useWhiteList) {

--- a/config/src/main/java/com/quorum/tessera/config/DeprecatedServerConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/DeprecatedServerConfig.java
@@ -1,0 +1,142 @@
+package com.quorum.tessera.config;
+
+import com.quorum.tessera.config.constraints.ValidSsl;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Deprecated
+@XmlAccessorType(XmlAccessType.FIELD)
+public class DeprecatedServerConfig extends ConfigItem {
+
+    @NotNull
+    @XmlElement(required = true)
+    private String hostName;
+
+    @NotNull
+    @XmlElement
+    private Integer port;
+
+    @XmlElement
+    private Integer grpcPort;
+
+    @XmlElement
+    private CommunicationType communicationType;
+
+    @Valid
+    @XmlElement
+    @ValidSsl
+    private SslConfig sslConfig;
+
+    @Valid
+    @XmlElement
+    private InfluxConfig influxConfig;
+
+    @XmlElement
+    private String bindingAddress;
+
+    public DeprecatedServerConfig() {
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Integer getGrpcPort() {
+        return grpcPort;
+    }
+
+    public void setGrpcPort(Integer grpcPort) {
+        this.grpcPort = grpcPort;
+    }
+
+    public CommunicationType getCommunicationType() {
+        return communicationType;
+    }
+
+    public void setCommunicationType(CommunicationType communicationType) {
+        this.communicationType = communicationType;
+    }
+
+    public SslConfig getSslConfig() {
+        return sslConfig;
+    }
+
+    public void setSslConfig(SslConfig sslConfig) {
+        this.sslConfig = sslConfig;
+    }
+
+    public InfluxConfig getInfluxConfig() {
+        return influxConfig;
+    }
+
+    public void setInfluxConfig(InfluxConfig influxConfig) {
+        this.influxConfig = influxConfig;
+    }
+
+    public String getBindingAddress() {
+        if (bindingAddress == null) {
+            this.bindingAddress = hostName + ":" + port;
+        }
+        return bindingAddress;
+    }
+
+    public void setBindingAddress(String bindingAddress) {
+        this.bindingAddress = bindingAddress;
+    }
+
+    public static List<ServerConfig> from(DeprecatedServerConfig server, Path unixSocketFile) {
+        if (null == server) {
+            return Collections.emptyList();
+        }
+
+        ServerConfig q2tConfig = new ServerConfig();
+        q2tConfig.setEnabled(true);
+        q2tConfig.setApp(AppType.Q2T);
+        q2tConfig.setCommunicationType(CommunicationType.REST);
+        String uriValue = "unix:"+ String.valueOf(unixSocketFile);
+        q2tConfig.setServerAddress(uriValue);
+        q2tConfig.setInfluxConfig(server.getInfluxConfig());
+
+        ServerConfig p2pConfig = new ServerConfig();
+        p2pConfig.setEnabled(true);
+        p2pConfig.setApp(AppType.P2P);
+
+        if (server.getCommunicationType() == CommunicationType.GRPC) {
+            p2pConfig.setServerAddress(server.getHostName() +":"+ server.getGrpcPort());
+            p2pConfig.setCommunicationType(CommunicationType.GRPC);
+        } else {
+            p2pConfig.setServerAddress(server.getHostName() +":"+ server.getPort());
+            p2pConfig.setCommunicationType(CommunicationType.REST);
+        }
+        p2pConfig.setInfluxConfig(server.getInfluxConfig());
+        p2pConfig.setSslConfig(server.getSslConfig());
+        p2pConfig.setBindingAddress(server.getBindingAddress());
+
+        List<ServerConfig> srvConfigs = new ArrayList<>();
+        srvConfigs.add(q2tConfig);
+        srvConfigs.add(p2pConfig);
+
+        return srvConfigs;
+    }
+
+}

--- a/config/src/main/java/com/quorum/tessera/config/JaxbConfigFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/JaxbConfigFactory.java
@@ -71,6 +71,7 @@ public class JaxbConfigFactory implements ConfigFactory {
                     config.getPeers(),
                     new KeyConfiguration(Paths.get("passwords.txt"), null, config.getKeys().getKeyData(), config.getKeys().getAzureKeyVaultConfig(), config.getKeys().getHashicorpKeyVaultConfig()),
                     config.getAlwaysSendTo(),
+                    config.getUnixSocketFile(),
                     config.isUseWhiteList(),
                     config.isDisablePeerDiscovery()
             );

--- a/config/src/main/java/com/quorum/tessera/config/constraints/EitherServerConfigsOrServerValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/EitherServerConfigsOrServerValidator.java
@@ -1,0 +1,48 @@
+package com.quorum.tessera.config.constraints;
+
+import com.quorum.tessera.config.Config;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EitherServerConfigsOrServerValidator implements ConstraintValidator<ValidEitherServerConfigsOrServer, Config> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EitherServerConfigsOrServerValidator.class);
+
+    @Override
+    public boolean isValid(Config config, ConstraintValidatorContext constraintContext) {
+        if (config == null) {
+            return true;
+        }
+
+        if (null == config.getServer() && config.isServerConfigsNull()) {
+            LOGGER.debug("One of server/serverConfigs must be provided.");
+            constraintContext.disableDefaultConstraintViolation();
+            constraintContext.buildConstraintViolationWithTemplate("One of server/serverConfigs must be provided.")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        if (null != config.getServer() && !config.isServerConfigsNull()) {
+            LOGGER.debug("Either one of server/serverConfigs can be configured (not both).");
+            constraintContext.disableDefaultConstraintViolation();
+            constraintContext.buildConstraintViolationWithTemplate("Either one of server/serverConfigs can be configured (not both).")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        if (Objects.nonNull(config.getServer()) && Objects.isNull(config.getUnixSocketFile())) {
+            LOGGER.debug("Unix socket file must be configured is using deprecated server config");
+            constraintContext.disableDefaultConstraintViolation();
+            constraintContext.buildConstraintViolationWithTemplate("Unix socket file must be configured is using deprecated server config. Check config.unixSocketFile")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/config/src/main/java/com/quorum/tessera/config/constraints/ValidEitherServerConfigsOrServer.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ValidEitherServerConfigsOrServer.java
@@ -1,0 +1,24 @@
+package com.quorum.tessera.config.constraints;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = EitherServerConfigsOrServerValidator.class)
+@Documented
+public @interface ValidEitherServerConfigsOrServer {
+
+    String message() default "{ValidEitherServerConfigsOrServer.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/config/src/main/java/com/quorum/tessera/config/util/JaxbUtil.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/JaxbUtil.java
@@ -33,6 +33,7 @@ public final class JaxbUtil {
         Peer.class,
         PrivateKeyType.class,
         ServerConfig.class,
+        DeprecatedServerConfig.class,
         SslAuthenticationMode.class,
         SslConfig.class,
         SslTrustMode.class

--- a/config/src/test/java/com/quorum/tessera/config/ConfigTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ConfigTest.java
@@ -1,10 +1,11 @@
 package com.quorum.tessera.config;
 
-import org.junit.Test;
-
+import java.nio.file.Path;
 import java.util.Arrays;
-
+import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
 
 public class ConfigTest {
 
@@ -16,7 +17,7 @@ public class ConfigTest {
 
     @Test
     public void createWithNullArgs() {
-        Config config = new Config(null, null, null, null, null, false, false);
+        Config config = new Config(null, null, null, null, null, null, false, false);
         assertThat(config).isNotNull();
     }
 
@@ -41,6 +42,7 @@ public class ConfigTest {
         Config config = new Config();
 
         assertThat(config.getP2PServerConfig()).isNull();
+
     }
 
     @Test
@@ -64,7 +66,33 @@ public class ConfigTest {
         serverConfig.setEnabled(true);
         config.setServerConfigs(Arrays.asList(serverConfig));
 
-        assertThat(config.getP2PServerConfig()).isNull();
+        assertThat(config.getP2PServerConfig())
+            .isNull();
+
+    }
+
+    @Test
+    public void setNullServerDoesNothing() {
+        Config config = new Config();
+        config.setServer(null);
+
+        assertThat(config.getServerConfigs()).isEmpty();
+        assertThat(config.getServer()).isNull();
+
+    }
+
+    @Test
+    public void areServerConfigsNull() {
+        Config config = new Config();
+        Path unixServerPath = mock(Path.class);
+        config.setUnixSocketFile(unixServerPath);
+        
+        assertThat(config.getServerConfigs()).isEmpty();
+        assertThat(config.isServerConfigsNull()).isTrue();
+
+        config.setServerConfigs(Collections.EMPTY_LIST);
+        assertThat(config.isServerConfigsNull()).isFalse();
+
     }
 
 }

--- a/config/src/test/java/com/quorum/tessera/config/DeprecatedServerConfigTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/DeprecatedServerConfigTest.java
@@ -1,0 +1,98 @@
+package com.quorum.tessera.config;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeprecatedServerConfigTest {
+
+    @Test
+    public void createConfigsFromDeprecatedServerConfigWithCommTypeRest() {
+
+        DeprecatedServerConfig deprecatedServerConfig = new DeprecatedServerConfig();
+        deprecatedServerConfig.setHostName("somehost");
+        deprecatedServerConfig.setPort(99);
+        deprecatedServerConfig.setCommunicationType(CommunicationType.REST);
+        InfluxConfig influxConfig = new InfluxConfig();
+        deprecatedServerConfig.setInfluxConfig(influxConfig);
+
+        Path unixSocketFile = Paths.get("unixSocketFile");
+
+        List<ServerConfig> results = DeprecatedServerConfig.from(deprecatedServerConfig, unixSocketFile);
+
+        assertThat(results).hasSize(2);
+        ServerConfig q2t = results.get(0);
+        assertThat(q2t.getCommunicationType()).isEqualTo(CommunicationType.REST);
+        assertThat(q2t.getServerUri()).isEqualTo(URI.create("unix:unixSocketFile"));
+        assertThat(q2t.isEnabled()).isTrue();
+        assertThat(q2t.getApp()).isEqualTo(AppType.Q2T);
+        assertThat(q2t.getInfluxConfig()).isEqualTo(influxConfig);
+
+        ServerConfig p2p = results.get(1);
+        assertThat(p2p.getCommunicationType()).isEqualTo(CommunicationType.REST);
+        assertThat(p2p.getServerUri()).isEqualTo(URI.create("somehost:99"));
+        assertThat(p2p.isEnabled()).isTrue();
+        assertThat(p2p.getApp()).isEqualTo(AppType.P2P);
+        assertThat(p2p.getInfluxConfig()).isEqualTo(influxConfig);
+    }
+
+    @Test
+    public void createConfigsFromDeprecatedServerConfigWithCommTypeGRPC() {
+
+        DeprecatedServerConfig deprecatedServerConfig = new DeprecatedServerConfig();
+        deprecatedServerConfig.setHostName("somehost");
+        deprecatedServerConfig.setGrpcPort(99);
+
+        deprecatedServerConfig.setCommunicationType(CommunicationType.GRPC);
+
+        Path unixSocketFile = Paths.get("unixSocketFile");
+
+        List<ServerConfig> results = DeprecatedServerConfig.from(deprecatedServerConfig, unixSocketFile);
+
+        assertThat(results).hasSize(2);
+        ServerConfig q2t = results.get(0);
+        assertThat(q2t.getCommunicationType()).isEqualTo(CommunicationType.REST);
+        assertThat(q2t.getServerUri()).isEqualTo(URI.create("unix:unixSocketFile"));
+        assertThat(q2t.isEnabled()).isTrue();
+        assertThat(q2t.getApp()).isEqualTo(AppType.Q2T);
+
+        ServerConfig p2p = results.get(1);
+        assertThat(p2p.getCommunicationType()).isEqualTo(CommunicationType.GRPC);
+        assertThat(p2p.getServerUri()).isEqualTo(URI.create("somehost:99"));
+        assertThat(p2p.isEnabled()).isTrue();
+        assertThat(p2p.getApp()).isEqualTo(AppType.P2P);
+    }
+
+
+    // TODO UNIX_SOCKET will be eliminated when the netty server will be able to cope with both Inet and Unix socket types
+    @Test
+    public void createConfigsFromDeprecatedServerConfigWithCommTypeUnixSocket() {
+
+        DeprecatedServerConfig deprecatedServerConfig = new DeprecatedServerConfig();
+        deprecatedServerConfig.setHostName("somehost");
+        deprecatedServerConfig.setPort(99);
+        deprecatedServerConfig.setCommunicationType(CommunicationType.REST);
+
+        Path unixSocketFile = Paths.get("unixSocketFile");
+
+        List<ServerConfig> results = DeprecatedServerConfig.from(deprecatedServerConfig, unixSocketFile);
+
+        assertThat(results).hasSize(2);
+        ServerConfig q2t = results.get(0);
+        assertThat(q2t.getCommunicationType()).isEqualTo(CommunicationType.REST);
+        assertThat(q2t.getServerUri()).isEqualTo(URI.create("unix:unixSocketFile"));
+        assertThat(q2t.isEnabled()).isTrue();
+        assertThat(q2t.getApp()).isEqualTo(AppType.Q2T);
+
+        ServerConfig p2p = results.get(1);
+        assertThat(p2p.getCommunicationType()).isEqualTo(CommunicationType.REST);
+        assertThat(p2p.getServerUri()).isEqualTo(URI.create("somehost:99"));
+        assertThat(p2p.isEnabled()).isTrue();
+        assertThat(p2p.getApp()).isEqualTo(AppType.P2P);
+    }
+}

--- a/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
@@ -107,7 +107,7 @@ public class ValidationTest {
 
         List<String> alwaysSendTo = singletonList("BOGUS");
 
-        Config config = new Config(null, null, null, null, alwaysSendTo, false, false);
+        Config config = new Config(null, null, null, null, alwaysSendTo, null, false, false);
 
         Set<ConstraintViolation<Config>> violations = validator.validateProperty(config, "alwaysSendTo");
 
@@ -125,7 +125,7 @@ public class ValidationTest {
 
         List<String> alwaysSendTo = singletonList(value);
 
-        Config config = new Config(null, null, null, null, alwaysSendTo, false, false);
+        Config config = new Config(null, null, null, null, alwaysSendTo, null, false, false);
 
         Set<ConstraintViolation<Config>> violations = validator.validateProperty(config, "alwaysSendTo");
 
@@ -258,7 +258,7 @@ public class ValidationTest {
     public void azureKeyPairProvidedWithoutKeyVaultConfigCreatesViolation() {
         AzureVaultKeyPair keyPair = new AzureVaultKeyPair("publicVauldId", "privateVaultId", null, null);
         KeyConfiguration keyConfiguration = new KeyConfiguration(null, null, singletonList(keyPair), null, null);
-        Config config = new Config(null, null, null, keyConfiguration, null, false, false);
+        Config config = new Config(null, null, null, keyConfiguration, null, null, false, false);
 
         Set<ConstraintViolation<Config>> violations = validator.validateProperty(config, "keys");
         assertThat(violations).hasSize(1);
@@ -331,7 +331,7 @@ public class ValidationTest {
         DirectKeyPair keyPair = new DirectKeyPair("pub", "priv");
 
         KeyConfiguration keyConfiguration = new KeyConfiguration(null, null, singletonList(keyPair), null, null);
-        Config config = new Config(null, null, null, keyConfiguration, null, false, false);
+        Config config = new Config(null, null, null, keyConfiguration, null, null, false, false);
 
         Set<ConstraintViolation<Config>> violations = validator.validateProperty(config, "keys");
         assertThat(violations).hasSize(0);

--- a/config/src/test/java/com/quorum/tessera/config/constraints/EitherServerConfigsOrServerValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/EitherServerConfigsOrServerValidatorTest.java
@@ -1,0 +1,97 @@
+package com.quorum.tessera.config.constraints;
+
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.DeprecatedServerConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class EitherServerConfigsOrServerValidatorTest {
+
+    private EitherServerConfigsOrServerValidator eitherServerConfigsOrServerValidator;
+
+    private ConstraintValidatorContext constraintContext;
+
+    @Before
+    public void onSetUp() {
+        eitherServerConfigsOrServerValidator = new EitherServerConfigsOrServerValidator();
+
+        constraintContext = mock(ConstraintValidatorContext.class);
+        ConstraintViolationBuilder constraintViolationBuilder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        when(constraintContext.buildConstraintViolationWithTemplate(anyString())).thenReturn(constraintViolationBuilder);
+    }
+
+    @After
+    public void onTearDown() {
+        verifyNoMoreInteractions(constraintContext);
+    }
+
+    @Test
+    public void ignoreNullArg() {
+        boolean outcome = eitherServerConfigsOrServerValidator.isValid(null, constraintContext);
+
+        assertThat(outcome).isTrue();
+    }
+
+    @Test
+    public void nullServerAndServerConfigs() {
+        Config config = new Config();
+
+        boolean outcome = eitherServerConfigsOrServerValidator.isValid(config, constraintContext);
+
+        assertThat(outcome).isFalse();
+
+        verify(constraintContext).disableDefaultConstraintViolation();
+        verify(constraintContext).buildConstraintViolationWithTemplate(anyString());
+    }
+
+    @Test
+    public void cantHaveBoth() {
+        Config config = new Config();
+        config.setServer(new DeprecatedServerConfig());
+        config.setServerConfigs(Collections.emptyList());
+
+        boolean outcome = eitherServerConfigsOrServerValidator.isValid(config, constraintContext);
+
+        assertThat(outcome).isFalse();
+        verify(constraintContext).disableDefaultConstraintViolation();
+        verify(constraintContext).buildConstraintViolationWithTemplate(anyString());
+    }
+
+    @Test
+    public void unixFileRequiredWhenDeprecatedServer() {
+        Config config = new Config();
+        config.setServer(new DeprecatedServerConfig());
+        config.setUnixSocketFile(null);
+
+        boolean outcome = eitherServerConfigsOrServerValidator.isValid(config, constraintContext);
+
+        assertThat(outcome).isFalse();
+        verify(constraintContext).disableDefaultConstraintViolation();
+        verify(constraintContext).buildConstraintViolationWithTemplate(anyString());
+    }
+
+    @Test
+    public void validConfigReturnsTrue() throws IOException {
+        final Path socketPath = Files.createTempFile("socket", ".ipc");
+        Config config = new Config();
+        config.setServer(new DeprecatedServerConfig());
+        config.setUnixSocketFile(socketPath);
+
+        boolean outcome = eitherServerConfigsOrServerValidator.isValid(config, constraintContext);
+
+        assertThat(outcome).isTrue();
+    }
+
+}

--- a/config/src/test/resources/keypassupdate/newLockedKeyAddInline.json
+++ b/config/src/test/resources/keypassupdate/newLockedKeyAddInline.json
@@ -5,23 +5,26 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -29,7 +32,9 @@
     ],
     "keys": {
         "passwords": [],
-        "keyData": []
+        "keyData": [
+        ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/keypassupdate/newLockedKeyAddInlineWithExisting.json
+++ b/config/src/test/resources/keypassupdate/newLockedKeyAddInlineWithExisting.json
@@ -5,33 +5,36 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
         }
     ],
     "keys": {
-        "passwords": [
-            "existing"
-        ],
-        "keyData": []
+        "passwords": ["existing"],
+        "keyData": [
+        ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/keypassupdate/newLockedKeyAddToFile.json
+++ b/config/src/test/resources/keypassupdate/newLockedKeyAddToFile.json
@@ -5,23 +5,26 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -29,7 +32,9 @@
     ],
     "keys": {
         "passwordFile": "newPasses.txt",
-        "keyData": []
+        "keyData": [
+        ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/keypassupdate/newLockedKeyNoPasswordsSet.json
+++ b/config/src/test/resources/keypassupdate/newLockedKeyNoPasswordsSet.json
@@ -5,30 +5,35 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
         }
     ],
     "keys": {
-        "keyData": []
+        "keyData": [
+        ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/keypassupdate/newLockedKeyWithUnlockedPrevious.json
+++ b/config/src/test/resources/keypassupdate/newLockedKeyWithUnlockedPrevious.json
@@ -5,23 +5,26 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -35,5 +38,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/keypassupdate/nullKeys.json
+++ b/config/src/test/resources/keypassupdate/nullKeys.json
@@ -5,27 +5,31 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
         }
     ],
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/mask-fixture-with-private-key-path.json
+++ b/config/src/test/resources/mask-fixture-with-private-key-path.json
@@ -5,36 +5,26 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "STRICT",
-                "generateKeyStoreIfNotExisted": "false",
-                "serverKeyStore": "./ssl/server1-keystore",
-                "serverKeyStorePassword": "quorum",
-                "serverTrustStore": "./ssl/server-truststore",
-                "serverTrustStorePassword": "quorum",
-                "serverTrustMode": "CA",
-                "clientKeyStore": "./ssl/client1-keystore",
-                "clientKeyStorePassword": "quorum",
-                "clientTrustStore": "./ssl/client-truststore",
-                "clientTrustStorePassword": "quorum",
-                "clientTrustMode": "CA",
-                "knownClientsFile": "./ssl/knownClients1",
-                "knownServersFile": "./ssl/knownServers1"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "sslConfig": {
+            "tls": "STRICT",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -52,5 +42,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/mask-fixture.json
+++ b/config/src/test/resources/mask-fixture.json
@@ -5,37 +5,27 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "bindingAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "STRICT",
-                "generateKeyStoreIfNotExisted": "false",
-                "serverKeyStore": "./ssl/server1-keystore",
-                "serverKeyStorePassword": "quorum",
-                "serverTrustStore": "./ssl/server-truststore",
-                "serverTrustStorePassword": "quorum",
-                "serverTrustMode": "CA",
-                "clientKeyStore": "./ssl/client1-keystore",
-                "clientKeyStorePassword": "quorum",
-                "clientTrustStore": "./ssl/client-truststore",
-                "clientTrustStorePassword": "quorum",
-                "clientTrustMode": "CA",
-                "knownClientsFile": "./ssl/knownClients1",
-                "knownServersFile": "./ssl/knownServers1"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "bindingAddress": "http://localhost:9001",
+        "sslConfig": {
+            "tls": "STRICT",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -50,5 +40,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/config/src/test/resources/sample-private-key-file-path.json
+++ b/config/src/test/resources/sample-private-key-file-path.json
@@ -5,23 +5,9 @@
         "password": "tiger",
         "url": "foo:bar"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/bogus.socket",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:99",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
-        }
-    ],
+    "server": {
+        "port": 99
+    },
     "peer": [
         {
             "url": "http://bogus1.com"
@@ -34,5 +20,6 @@
         "passwords": [],
         "keyData": []
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/bogus.socket"
 }

--- a/config/src/test/resources/sample-private-keygen.json
+++ b/config/src/test/resources/sample-private-keygen.json
@@ -15,7 +15,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -53,5 +53,6 @@
         "passwords": [],
         "keyData": []
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/config/src/test/resources/sample.json
+++ b/config/src/test/resources/sample.json
@@ -15,7 +15,7 @@
         {
             "app": "Q2T",
             "enabled": true,
-            "serverAddress": "unix:${unixSocketPath}",
+            "serverAddress": "unix:/tmp/test.ipc",
             "communicationType": "REST"
         },
         {
@@ -73,5 +73,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "${unixSocketPath}"
 }

--- a/config/src/test/resources/sample_bad.json
+++ b/config/src/test/resources/sample_bad.json
@@ -1,0 +1,49 @@
+{
+    "useWhiteList": false,
+
+    "server": {
+        "port": 99,
+        "influxConfig": {
+            "port": 1111,
+            "hostName": "localhost",
+            "dbName": "dummy",
+            "pushIntervalInSecs" : "10"
+        }
+    },
+    "peer": [
+        {
+            "url": "http://bogus1.com"
+        },
+        {
+            "url": "http://bogus2.com"
+        }
+    ],
+    "keys": {
+        "passwords": [
+            "q"
+        ],
+        "keyData": [
+            {
+                "config": {
+                    "data": {
+                        "aopts": {
+                            "variant": "id",
+                            "memory": 1048576,
+                            "iterations": 10,
+                            "parallelism": 4,
+                            "version": "1.3"
+                        },
+                        "snonce": "x3HUNXH6LQldKtEv3q0h0hR4S12Ur9pC",
+                        "asalt": "7Sem2tc6fjEfW3yYUDN/kSslKEW0e1zqKnBCWbZu2Zw=",
+                        "sbox": "d0CmRus0rP0bdc7P7d/wnOyEW14pwFJmcLbdu2W3HmDNRWVJtoNpHrauA/Sr5Vxc"
+                    },
+                    "type": "argon2sbox"
+                },
+                "privateKey": "PRIVATE_KEY",
+                "publicKey": "PUBLIC_KEY"
+            }
+        ]
+    },
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/bogus.socket"
+}

--- a/config/src/test/resources/sample_full.json
+++ b/config/src/test/resources/sample_full.json
@@ -5,24 +5,27 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tessera1"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "bindingAddress": "http://localhost:9001",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "bindingAddress": "http://localhost:9001",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "false",
+            "serverKeyStore": "./ssl/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./ssl/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "CA",
+            "clientKeyStore": "./ssl/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./ssl/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "CA",
+            "knownClientsFile": "./ssl/knownClients1",
+            "knownServersFile": "./ssl/knownServers1"
         }
-    ],
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -37,5 +40,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/jaxrs-service/src/test/java/com/quorum/tessera/jaxrs/JaxrsITConfig.java
+++ b/jaxrs-service/src/test/java/com/quorum/tessera/jaxrs/JaxrsITConfig.java
@@ -1,51 +1,53 @@
+
 package com.quorum.tessera.jaxrs;
 
+import com.quorum.tessera.partyinfo.PartyInfoParser;
+import com.quorum.tessera.partyinfo.PartyInfoService;
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.JdbcConfig;
 import com.quorum.tessera.config.KeyConfiguration;
 import com.quorum.tessera.config.ServerConfig;
-import com.quorum.tessera.partyinfo.PartyInfoParser;
-import com.quorum.tessera.partyinfo.PartyInfoService;
 import com.quorum.tessera.transaction.TransactionManagerImpl;
+import java.nio.file.Path;
+import java.util.Collections;
+import static org.mockito.Mockito.mock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-import java.util.Collections;
-
-import static org.mockito.Mockito.mock;
-
 @Configuration
 @ImportResource(locations = "classpath:tessera-jaxrs-spring.xml")
 public class JaxrsITConfig {
-
-    @Bean(name = "transactionManager")
+    
+    @Bean(name = "transactionManager")    
     public TransactionManagerImpl enclaveMediator() {
         return mock(TransactionManagerImpl.class);
     }
-
+    
     @Bean
     public PartyInfoService partyInfoService() {
         return mock(PartyInfoService.class);
     }
-
+    
     @Bean
     public PartyInfoParser partyInfoParser() {
         return mock(PartyInfoParser.class);
     }
-
+    
     @Bean
     public Config config() {
 
         JdbcConfig jdbcConfig = mock(JdbcConfig.class);
-
+        
         ServerConfig serverConfig = mock(ServerConfig.class);
-
+        
         KeyConfiguration keyConfiguration = mock(KeyConfiguration.class);
-
-        Config config = new Config(jdbcConfig,Collections.singletonList(serverConfig),Collections.EMPTY_LIST,keyConfiguration,Collections.EMPTY_LIST,false,false);
-
+        
+        Path unixSocketFile = mock(Path.class);
+                
+         Config config = new Config(jdbcConfig,Collections.singletonList(serverConfig),Collections.EMPTY_LIST,keyConfiguration,Collections.EMPTY_LIST,unixSocketFile,false,false);
+        
         return config;
     }
-
+    
 }

--- a/tessera-core/src/test/java/com/quorum/tessera/core/CoreIT.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/core/CoreIT.java
@@ -1,0 +1,41 @@
+
+package com.quorum.tessera.core;
+
+import com.quorum.tessera.cli.CliDelegate;
+import com.quorum.tessera.transaction.TransactionManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = "classpath:tessera-core-spring.xml")
+public class CoreIT {
+
+
+    @Inject
+    private TransactionManager transactionManager;
+
+    @PersistenceContext(unitName = "tessera")
+    private EntityManager entityManager;
+
+    @BeforeClass
+    public static void onSetup() throws Exception {
+        String configPath = CoreIT.class.getResource("/config1.json").getPath();
+        CliDelegate.INSTANCE.execute("-configfile",configPath);
+}
+
+    @Test
+    public void doStuff() throws Exception {
+        assertThat(transactionManager).isNotNull();
+        assertThat(entityManager).isNotNull();
+    }
+
+}

--- a/tessera-core/src/test/resources/config-with-relay.json
+++ b/tessera-core/src/test/resources/config-with-relay.json
@@ -1,0 +1,65 @@
+{
+    "useWhiteList": false,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:./target/h2/tessera1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+    },
+    "server": {
+        "port": 8081,
+        "grpcPort": 50501,
+        "communicationType": "REST",
+        "hostName": "http://proxy-address",
+        "bindingAddress": "http://localhost:9001",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "true",
+            "serverKeyStore": "./target/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./target/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "TOFU",
+            "clientKeyStore": "./target/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./target/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "TOFU",
+            "knownClientsFile": "./target/knownClients1",
+            "knownServersFile": "./target/knownServers1"
+        }
+    },
+    "peer": [
+        {
+            "url": "http://proxy-address:8081"
+        },
+        {
+            "url": "http://proxy-address:8082"
+        },
+        {
+            "url": "http://proxy-address:8083"
+        },
+        {
+            "url": "http://proxy-address:8084"
+        },
+        {
+            "url": "http://proxy-address:8085"
+        },
+        {
+            "url": "http://proxy-address:8086"
+        },
+        {
+            "url": "http://proxy-address:8087"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "keyData": [
+            {
+                "publicKey": "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=",
+                "privateKey": "yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM="
+            }
+        ]
+    },
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
+}

--- a/tessera-core/src/test/resources/config1.json
+++ b/tessera-core/src/test/resources/config1.json
@@ -1,0 +1,45 @@
+{
+    "useWhiteList": false,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:./target/h2/tessera1;AUTO_SERVER=TRUE;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+    },
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost",
+        "communicationType" : "REST",
+        "sslConfig": {
+            "tls": "OFF",
+            "generateKeyStoreIfNotExisted": "true",
+            "serverKeyStore": "./target/server1-keystore",
+            "serverKeyStorePassword": "quorum",
+            "serverTrustStore": "./target/server-truststore",
+            "serverTrustStorePassword": "quorum",
+            "serverTrustMode": "TOFU",
+            "clientKeyStore": "./target/client1-keystore",
+            "clientKeyStorePassword": "quorum",
+            "clientTrustStore": "./target/client-truststore",
+            "clientTrustStorePassword": "quorum",
+            "clientTrustMode": "TOFU",
+            "knownClientsFile": "./target/knownClients1",
+            "knownServersFile": "./target/knownServers1"
+        }
+    },
+    "peer": [
+        {
+            "url": "http://localhost:8081"
+        }
+    ],
+    "alwaysSendTo": [],
+    "keys": {
+        "passwords": [],
+        "keyData": [
+            {
+                "publicKey": "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=",
+                "privateKey": "yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM="
+            }
+        ]
+    },
+    "unixSocketFile": "/tmp/tm1.ipc"
+}

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -209,7 +209,7 @@
                         <include>RestSuiteHSQL</include>
                         <include>RestSuiteUnixH2</include>
                         <include>RestSuiteSqlite</include>
-                        <include>ConfigMigrationIT</include>
+<!--                        <include>ConfigMigrationIT</include>-->
                         <include>GrpcSuiteH2</include>
                         <include>GrpcSuiteSqlite</include>
                         <include>GrpcSuiteHSQL</include>
@@ -335,7 +335,7 @@
                                 <include>RestSuiteHSQL</include>
                                 <include>RestSuiteUnixH2</include>
                                 <include>RestSuiteSqlite</include>
-                                <include>ConfigMigrationIT</include>
+<!--                                <include>ConfigMigrationIT</include>-->
                             </includes>
                         </configuration>
                     </plugin>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/migration/config/ConfigMigrationSteps.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/migration/config/ConfigMigrationSteps.java
@@ -103,30 +103,41 @@ public class ConfigMigrationSteps implements En {
             sslConfig.setClientTrustMode(SslTrustMode.CA_OR_TOFU);
             sslConfig.setKnownServersFile(Paths.get("data", "tls-known-servers").toAbsolutePath());
 
+            final DeprecatedServerConfig server = new DeprecatedServerConfig();
+            server.setSslConfig(sslConfig);
+            server.setHostName("http://127.0.0.1");
+            server.setPort(9001);
+            server.setCommunicationType(CommunicationType.REST);
+
             final KeyConfiguration keys = new KeyConfiguration();
-            keys.setKeyData(Collections.singletonList(
+            keys.setKeyData(Arrays.asList(
                 new FilesystemKeyPair(
-                    Paths.get("data", "foo.pub").toAbsolutePath(), Paths.get("data", "foo.key").toAbsolutePath()
-                )
+                    Paths.get("data", "foo.pub").toAbsolutePath(),
+                    Paths.get("data", "foo.key").toAbsolutePath())
             ));
             keys.setPasswordFile(Paths.get("data", "passwords").toAbsolutePath());
 
-            final JdbcConfig jdbcConfig = new JdbcConfig(null, null, "jdbc:h2:mem:tessera");
+            final JdbcConfig jdbcConfig = new JdbcConfig();
+            jdbcConfig.setUrl("jdbc:h2:mem:tessera");
 
-            final ServerConfig q2tConfig = migratedConfig
-                .getServerConfigs()
-                .stream()
-                .filter(ServerConfig::isUnixSocket)
-                .findAny()
-                .get();
+            final Config legacyConfig = new Config();
+            legacyConfig.setServer(server);
+            legacyConfig.setPeers(Arrays.asList(new Peer("http://127.0.0.1:9000/")));
+            legacyConfig.setKeys(keys);
+            legacyConfig.setJdbcConfig(jdbcConfig);
+            legacyConfig.setUnixSocketFile(Paths.get("data", "constellation.ipc").toAbsolutePath());
+            legacyConfig.setAlwaysSendTo(Collections.emptyList());
 
-            assertThat(migratedConfig.getP2PServerConfig().getSslConfig()).isEqualToComparingFieldByField(sslConfig);
-            assertThat(migratedConfig.getP2PServerConfig().getServerAddress()).isEqualTo("http://127.0.0.1:9001");
-            assertThat(q2tConfig.getServerAddress()).isEqualTo("unix:" + Paths.get("data", "constellation.ipc"));
-            assertThat(migratedConfig.getKeys()).isEqualToComparingFieldByFieldRecursively(keys);
-            assertThat(migratedConfig.getJdbcConfig()).isEqualToComparingFieldByField(jdbcConfig);
-            assertThat(migratedConfig.getAlwaysSendTo()).isEqualTo(Collections.emptyList());
-            assertThat(migratedConfig.getPeers()).containsExactlyInAnyOrder(new Peer("http://127.0.0.1:9000/"));
+            assertThat(migratedConfig.getServer()).isEqualToComparingFieldByFieldRecursively(legacyConfig.getServer());
+            assertThat(migratedConfig.getKeys()).isEqualToComparingFieldByFieldRecursively(legacyConfig.getKeys());
+            assertThat(migratedConfig.getUnixSocketFile()).isEqualTo(legacyConfig.getUnixSocketFile());
+            assertThat(migratedConfig.getJdbcConfig()).isEqualToComparingFieldByField(legacyConfig.getJdbcConfig());
+            assertThat(migratedConfig.getP2PServerConfig()).isEqualToComparingFieldByFieldRecursively(legacyConfig.getP2PServerConfig());
+            assertThat(migratedConfig.getAlwaysSendTo()).isEqualTo(legacyConfig.getAlwaysSendTo());
+            assertThat(migratedConfig.getServerConfigs().size()).isEqualTo(legacyConfig.getServerConfigs().size());
+            assertThat(migratedConfig.getServerConfigs()).hasSize(2);
+            assertThat(migratedConfig.getServerConfigs()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(legacyConfig.getServerConfigs().get(0), legacyConfig.getServerConfigs().get(1));
+            assertThat(migratedConfig.getPeers()).isEqualTo(legacyConfig.getPeers());
         });
 
     }

--- a/tests/acceptance-test/src/test/resources/empty-keys-config.json
+++ b/tests/acceptance-test/src/test/resources/empty-keys-config.json
@@ -5,23 +5,10 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/rest1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9090"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/empty-keys.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8989",
-            "sslConfig": {
-                "tls": "OFF"
-            },
-            "communicationType": "REST"
-        }
-    ],
+    "server": {
+        "port": 8989,
+        "hostName": "http://localhost"
+    },
     "peer": [
         {
             "url": "http://localhost:8990/"
@@ -36,5 +23,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/empty-keys.ipc"
 }

--- a/tests/acceptance-test/src/test/resources/empty-keyspath-config.json
+++ b/tests/acceptance-test/src/test/resources/empty-keyspath-config.json
@@ -5,23 +5,10 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/rest1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9090"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/empty-keyspath.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8989",
-            "sslConfig": {
-                "tls": "OFF"
-            },
-            "communicationType": "REST"
-        }
-    ],
+    "server": {
+        "port": 8989,
+        "hostName": "http://localhost"
+    },
     "peer": [
         {
             "url": "http://localhost:8990/"
@@ -36,5 +23,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/empty-keyspath.ipc"
 }

--- a/tests/jmeter-test/src/test/resources/config1.json
+++ b/tests/jmeter-test/src/test/resources/config1.json
@@ -5,23 +5,10 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tess1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm1.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8080",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
-        }
-    ],
+    "server": {
+        "port": 8080,
+        "hostName": "http://localhost"
+    },
     "peer": [
         {
             "url": "http://localhost:8081"
@@ -36,5 +23,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm1.ipc"
 }

--- a/tests/jmeter-test/src/test/resources/config2.json
+++ b/tests/jmeter-test/src/test/resources/config2.json
@@ -5,23 +5,10 @@
         "password": "",
         "url": "jdbc:h2:./target/h2/tess2;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
-    "serverConfigs": [
-        {
-            "app": "Q2T",
-            "enabled": true,
-            "serverAddress": "unix:/tmp/tm2.ipc",
-            "communicationType": "REST"
-        },
-        {
-            "app": "P2P",
-            "enabled": true,
-            "serverAddress": "http://localhost:8081",
-            "communicationType": "REST",
-            "sslConfig": {
-                "tls": "OFF"
-            }
-        }
-    ],
+    "server": {
+        "port": 8081,
+        "hostName": "http://localhost"
+    },
     "peer": [
         {
             "url": "http://localhost:8080"
@@ -36,5 +23,6 @@
             }
         ]
     },
-    "alwaysSendTo": []
+    "alwaysSendTo": [],
+    "unixSocketFile": "/tmp/tm2.ipc"
 }


### PR DESCRIPTION
The removal of the deprecated config is a breaking change, and should only have been merged when we are ready to do a breaking release.

Until such time, the config should remain as is.

This is a direct reversal of https://github.com/jpmorganchase/tessera/pull/788