### PR TITLE
Reduce the logging of the dependency caching/checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B dependency:go-offline
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B dependency:go-offline
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 


### PR DESCRIPTION
https://github.com/jpmorganchase/tessera/issues/738

Currently some of the CI builds fail since the logs are too long.

The command `mvn dependency:go-offline` seems to contribute a large chunk of this.
Add the parameter `-Dsilent=true` will quieten the output.

For comparison, this is the difference in number of lines on my local machine:
master:   30241 lines
This PR:  879 lines