### PR TITLE
Stop throwing on network sync calls

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/threading/TesseraScheduledExecutor.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/threading/TesseraScheduledExecutor.java
@@ -10,10 +10,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Schedules a continuous running task as an alternative to
- * a {@link Thread} running a {@code while(true)} loop
+ * Schedules a continuous running task as an alternative to a {@link Thread} running a {@code while(true)} loop
  *
- * Also allows delays if required between each execution of the loop
+ * <p>Also allows delays if required between each execution of the loop
  */
 public class TesseraScheduledExecutor {
 
@@ -24,13 +23,11 @@ public class TesseraScheduledExecutor {
     private final Runnable action;
 
     private final long rate;
-    
+
     private final long initialDelay;
 
-    public TesseraScheduledExecutor(final ScheduledExecutorService executor,
-                                    final Runnable action,
-                                    final long rate,
-                                    final long delay) {
+    public TesseraScheduledExecutor(
+            final ScheduledExecutorService executor, final Runnable action, final long rate, final long delay) {
         this.executor = Objects.requireNonNull(executor);
         this.action = Objects.requireNonNull(action);
         this.rate = rate;
@@ -38,21 +35,26 @@ public class TesseraScheduledExecutor {
     }
 
     /**
-     * Starts the submitted task and schedules it to run every given time frame
-     * Catches any Throwable and logs it so that the scheduling doesn't break
+     * Starts the submitted task and schedules it to run every given time frame. Catches any Throwable and logs it so
+     * that the scheduling doesn't break
      */
     @PostConstruct
     public void start() {
         LOGGER.info("Starting {}", this.action.getClass().getSimpleName());
 
-        final Runnable exceptionSafeRunnable = () -> {
-            try {
-                this.action.run();
-            } catch (final Throwable ex) {
-                LOGGER.error("Error when executing action {}", action.getClass().getSimpleName());
-                LOGGER.error("Error when executing action", ex);
-            }
-        };
+        final Runnable exceptionSafeRunnable =
+                () -> {
+                    try {
+                        LOGGER.debug("{} has started running", getClass().getSimpleName());
+
+                        this.action.run();
+                    } catch (final Throwable ex) {
+                        LOGGER.error("Error when executing action {}", action.getClass().getSimpleName());
+                        LOGGER.error("Error when executing action", ex);
+                    } finally {
+                        LOGGER.debug("{} has finished running", getClass().getSimpleName());
+                    }
+                };
 
         this.executor.scheduleWithFixedDelay(exceptionSafeRunnable, initialDelay, rate, TimeUnit.MILLISECONDS);
 
@@ -60,8 +62,8 @@ public class TesseraScheduledExecutor {
     }
 
     /**
-     * Stops any more executions of the submitted task from running
-     * Does not cancel the currently running task, which may be blocking
+     * Stops any more executions of the submitted task from running. Does not cancel the currently running task, which
+     * may be blocking
      */
     @PreDestroy
     public void stop() {
@@ -71,5 +73,4 @@ public class TesseraScheduledExecutor {
 
         LOGGER.info("Stopped {}", this.action.getClass().getSimpleName());
     }
-
 }

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoPollerTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoPollerTest.java
@@ -6,7 +6,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.ConnectException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -19,6 +21,8 @@ public class PartyInfoPollerTest {
     private static final String OWN_URL = "http://own.com:8080/";
 
     private static final String TARGET_URL = "http://bogus.com:9878/";
+
+    private static final String TARGET_URL_2 = "http://otherwebsite.com:9878/";
 
     private static final byte[] DATA = "BOGUS".getBytes();
 
@@ -35,6 +39,9 @@ public class PartyInfoPollerTest {
         this.partyInfoService = mock(PartyInfoService.class);
         this.partyInfoParser = mock(PartyInfoParser.class);
         this.p2pClient = mock(P2pClient.class);
+
+        when(partyInfoParser.to(any(PartyInfo.class))).thenReturn(DATA);
+
         this.partyInfoPoller = new PartyInfoPoller(partyInfoService, partyInfoParser, p2pClient);
     }
 
@@ -45,37 +52,23 @@ public class PartyInfoPollerTest {
 
     @Test
     public void run() {
-
-        doReturn(true).when(p2pClient).sendPartyInfo(TARGET_URL, DATA);
-
         final PartyInfo partyInfo = new PartyInfo(OWN_URL, emptySet(), singleton(new Party(TARGET_URL)));
         doReturn(partyInfo).when(partyInfoService).getPartyInfo();
-
-        doReturn(DATA).when(partyInfoParser).to(partyInfo);
-
-        final PartyInfo updatedPartyInfo = new PartyInfo(OWN_URL, emptySet(), singleton(new Party(TARGET_URL)));
-        doReturn(updatedPartyInfo).when(partyInfoParser).from(DATA);
+        doReturn(true).when(p2pClient).sendPartyInfo(TARGET_URL, DATA);
 
         partyInfoPoller.run();
 
         verify(partyInfoService).getPartyInfo();
-
         verify(partyInfoParser).to(partyInfo);
-
         verify(p2pClient).sendPartyInfo(TARGET_URL, DATA);
     }
 
     @Test
     public void testWhenURLIsOwn() {
-
-        doReturn(true).when(p2pClient).sendPartyInfo(OWN_URL, DATA);
-
         final PartyInfo partyInfo = new PartyInfo(OWN_URL, emptySet(), singleton(new Party(OWN_URL)));
         doReturn(partyInfo).when(partyInfoService).getPartyInfo();
         doReturn(DATA).when(partyInfoParser).to(partyInfo);
-
-        final PartyInfo updatedPartyInfo = mock(PartyInfo.class);
-        doReturn(updatedPartyInfo).when(partyInfoParser).from(DATA);
+        doReturn(true).when(p2pClient).sendPartyInfo(OWN_URL, DATA);
 
         partyInfoPoller.run();
 
@@ -84,70 +77,18 @@ public class PartyInfoPollerTest {
     }
 
     @Test
-    public void testWhenPostFails() {
-
-        doReturn(false).when(p2pClient).sendPartyInfo(TARGET_URL, DATA);
-
-        final PartyInfo partyInfo = new PartyInfo(OWN_URL, emptySet(), singleton(new Party(TARGET_URL)));
-
+    public void exceptionThrowByPostDoesntBubble() {
+        final Set<Party> parties = new HashSet<>(Arrays.asList(new Party(TARGET_URL), new Party(TARGET_URL_2)));
+        final PartyInfo partyInfo = new PartyInfo(OWN_URL, emptySet(), parties);
         doReturn(partyInfo).when(partyInfoService).getPartyInfo();
-        doReturn(DATA).when(partyInfoParser).to(partyInfo);
-
-        final PartyInfo updatedPartyInfo = mock(PartyInfo.class);
-        doReturn(updatedPartyInfo).when(partyInfoParser).from(DATA);
-
-        partyInfoPoller.run();
-
-        verify(partyInfoParser, never()).from(DATA);
-        verify(partyInfoParser).to(partyInfo);
-        verify(partyInfoService).getPartyInfo();
-        verify(p2pClient).sendPartyInfo(TARGET_URL, DATA);
-    }
-
-    @Test
-    public void runThrowsException() {
-
-        final PartyInfo partyInfo = new PartyInfo(OWN_URL, emptySet(), singleton(new Party(TARGET_URL)));
-
-        doReturn(partyInfo).when(partyInfoService).getPartyInfo();
-        doReturn(DATA).when(partyInfoParser).to(partyInfo);
-
-        PartyInfo updatedPartyInfo = mock(PartyInfo.class);
-        doReturn(updatedPartyInfo).when(partyInfoParser).from(DATA);
-
         doThrow(UnsupportedOperationException.class).when(p2pClient).sendPartyInfo(TARGET_URL, DATA);
 
         final Throwable throwable = catchThrowable(partyInfoPoller::run);
-        assertThat(throwable).isInstanceOf(UnsupportedOperationException.class);
 
+        assertThat(throwable).isNull();
         verify(p2pClient).sendPartyInfo(TARGET_URL, DATA);
-
+        verify(p2pClient).sendPartyInfo(TARGET_URL_2, DATA);
         verify(partyInfoService).getPartyInfo();
-        verify(partyInfoService, never()).updatePartyInfo(updatedPartyInfo);
-        verify(partyInfoParser, never()).from(DATA);
-        verify(partyInfoParser).to(partyInfo);
-    }
-
-    @Test
-    public void runThrowsConnectionExceptionAndDoesNotThrow() {
-
-        final PartyInfo partyInfo = new PartyInfo(OWN_URL, emptySet(), singleton(new Party(TARGET_URL)));
-
-        doReturn(partyInfo).when(partyInfoService).getPartyInfo();
-        doReturn(DATA).when(partyInfoParser).to(partyInfo);
-
-        final PartyInfo updatedPartyInfo = mock(PartyInfo.class);
-        doReturn(updatedPartyInfo).when(partyInfoParser).from(DATA);
-
-        final RuntimeException connectionException = new RuntimeException(new ConnectException("OUCH"));
-        doThrow(connectionException).when(p2pClient).sendPartyInfo(TARGET_URL, DATA);
-
-        partyInfoPoller.run();
-
-        verify(p2pClient).sendPartyInfo(TARGET_URL, DATA);
-
-        verify(partyInfoService).getPartyInfo();
-        verify(partyInfoParser, never()).from(DATA);
         verify(partyInfoParser).to(partyInfo);
     }
 


### PR DESCRIPTION
Make all exceptions from sending out our `PartyInfo` report the error to the log, but not throw the error up the call stack, so as to not stop subsequent calls. 
This means that the `forEach` loop will not stop if an error occurred on any of the requests.

Move run messages to the general executor so they work for all polling actions. The only "useful" logging was the `PartyInfo` object, but this was only a reference to the object, so nothing to be gained from it.

Fixes https://github.com/jpmorganchase/tessera/issues/842