### PR TITLE
Disable mvn deploy when merging in to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o -Dmaven.repo.local=$HOME/.m2/repository
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
@@ -116,8 +116,8 @@ notifications:
     secure: TeWK06kSrpdvMY/TNocbNYy0gJ9+jP9ygjzBtgsMRmm0kbBpzg34eZJyWMU/sf5x6taWAVOGW1jfG4+kfLUqG7CrqcRUihqK3x1DOJQS/BlT2IhJkED4dtwEw7xTkRTxPkghwMAXjJZImnh7ORS1HCJByEs5kedThh/Vr1HDaWJ+KctGLhE3LudyYikxZEWYVbexHZ5o8QbFGwmTYNHLaKAIGZbvt8wDoE+yJOftCqmCh2aJ4YBzYSW9wmxxf3tu75Azni9Am1wiCu+Q5NhljtZwbx6QopkHxbM0DdohOwQQ1g2lPni8dZYdw/obvVQOKLNjkTWU3LvtiWrwiAKp/w5czeL5nkQiFxcAcyTqCRXNh3J1RD1k9H4OBLo2N+5o6dhnNUZt24PZFsNMzR+ygmNq7WvAqQpC5ixppND//8tg25234dXafdL8KmWMFuTepQem2H9Yo8zr16v+VC7MEUyh5ta67xqhFGluIDEySgxMX389r0bU1dXsqhc/K131ty6AcV8FWEGToguvxL+Sj8RhBk5F2B+QOtUzl/5iqlGhqpWcVkoQjiCPJbcLHlHbt6fiUNEpVVjxa2kNrTNZ/5GS6eZoVr5OT1tc3lY5ZUA40yk0Pk63mYB30yMl/wtbbQl/g/0OpcJW20+ZT3971dIt6PMFg3b+n1xSZgTNvIY=
 
 before_cache:
+- mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true dependency:go-offline
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn dependency:go-offline -B -Dmaven.repo.local=$HOME/.m2/repository
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
@@ -118,9 +118,7 @@ notifications:
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
 - mvn package dependency:go-offline -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
-
 cache:
-  timeout: 100000
   directories:
     - $HOME/.m2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o -Dmaven.repo.local=$HOME/.m2/repository
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
@@ -117,7 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn dependency:go-offline -B
+- mvn dependency:go-offline -B -Dmaven.repo.local=$HOME/.m2/repository
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn dependency:go-offline -B -DexcludeGroupIds=com.jpmorgan.quorum
+- mvn dependency:resolve-plugins dependency:resolve
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true dependency:go-offline -B
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
@@ -117,7 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn package dependency:go-offline -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
+
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn dependency:resolve-plugins dependency:resolve
+- mvn package dependency:go-offline -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn dependency:go-offline -B
+- mvn dependency:go-offline -B -DexcludeGroupIds=com.jpmorgan.quorum
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,8 +116,8 @@ notifications:
     secure: TeWK06kSrpdvMY/TNocbNYy0gJ9+jP9ygjzBtgsMRmm0kbBpzg34eZJyWMU/sf5x6taWAVOGW1jfG4+kfLUqG7CrqcRUihqK3x1DOJQS/BlT2IhJkED4dtwEw7xTkRTxPkghwMAXjJZImnh7ORS1HCJByEs5kedThh/Vr1HDaWJ+KctGLhE3LudyYikxZEWYVbexHZ5o8QbFGwmTYNHLaKAIGZbvt8wDoE+yJOftCqmCh2aJ4YBzYSW9wmxxf3tu75Azni9Am1wiCu+Q5NhljtZwbx6QopkHxbM0DdohOwQQ1g2lPni8dZYdw/obvVQOKLNjkTWU3LvtiWrwiAKp/w5czeL5nkQiFxcAcyTqCRXNh3J1RD1k9H4OBLo2N+5o6dhnNUZt24PZFsNMzR+ygmNq7WvAqQpC5ixppND//8tg25234dXafdL8KmWMFuTepQem2H9Yo8zr16v+VC7MEUyh5ta67xqhFGluIDEySgxMX389r0bU1dXsqhc/K131ty6AcV8FWEGToguvxL+Sj8RhBk5F2B+QOtUzl/5iqlGhqpWcVkoQjiCPJbcLHlHbt6fiUNEpVVjxa2kNrTNZ/5GS6eZoVr5OT1tc3lY5ZUA40yk0Pk63mYB30yMl/wtbbQl/g/0OpcJW20+ZT3971dIt6PMFg3b+n1xSZgTNvIY=
 
 before_cache:
-- mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true dependency:go-offline
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
+- mvn dependency:go-offline -B
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true dependency:go-offline -B
+        - mvn install -o -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
@@ -117,7 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-
+- mvn package dependency:go-offline -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ install: true
 
 stages:
   - name: test
-    if: type = pull_request OR type = api
-  - name: deploy only
-    if: branch = master AND type = push
+    if: type = pull_request OR type = api OR (branch = master AND type = push)
+#  - name: deploy only
+#    if: branch = master AND type = push
   - name: tag and deploy
     if: type = api
 
@@ -65,13 +65,13 @@ jobs:
       install: *build_no_checks
       script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1
 
-    - stage: deploy only
-      name: "Deploy to OSSRH"
-      jdk:  oraclejdk8
-      script:
-        - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
-        - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
-        - travis_wait 60 mvn deploy --settings .maven.xml -B -P release,reduce-logging -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djavadoc.skip=true || travis_terminate 1
+#    - stage: deploy only
+#      name: "Deploy to OSSRH"
+#      jdk:  oraclejdk8
+#      script:
+#        - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
+#        - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
+#        - travis_wait 60 mvn deploy --settings .maven.xml -B -P release,reduce-logging -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Djavadoc.skip=true || travis_terminate 1
 
     - stage: tag and deploy
       name: "Tag on GitHub and deploy to OSSRH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B dependency:go-offline
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o
       script: &build_with_unittests
-        - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
+        - mvn install -pl \!tests/acceptance-test -o -P reduce-logging -o || travis_terminate 1
 
     - name: "Unit Tests Java 11"
       jdk:  oraclejdk11
@@ -34,7 +34,7 @@ jobs:
     - name: "Acceptance Tests Java 8"
       jdk:  oraclejdk8
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P reduce-logging -o || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -o -P reduce-logging -o || travis_terminate 1
 
     - name: "Acceptance Tests Java 11"
       jdk:  oraclejdk11
@@ -42,7 +42,7 @@ jobs:
 #        - rm "${JAVA_HOME}/lib/security/cacerts"
 #        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -o -P reduce-logging || travis_terminate 1
 
     - name: "Simple Only Acceptance Tests"
       jdk:  oraclejdk8
@@ -117,6 +117,7 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
+- mvn dependency:go-offline -B
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,7 @@ before_cache:
 - mvn package dependency:go-offline -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
 
 cache:
+  timeout: 100000
   directories:
     - $HOME/.m2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,8 +116,7 @@ notifications:
     secure: TeWK06kSrpdvMY/TNocbNYy0gJ9+jP9ygjzBtgsMRmm0kbBpzg34eZJyWMU/sf5x6taWAVOGW1jfG4+kfLUqG7CrqcRUihqK3x1DOJQS/BlT2IhJkED4dtwEw7xTkRTxPkghwMAXjJZImnh7ORS1HCJByEs5kedThh/Vr1HDaWJ+KctGLhE3LudyYikxZEWYVbexHZ5o8QbFGwmTYNHLaKAIGZbvt8wDoE+yJOftCqmCh2aJ4YBzYSW9wmxxf3tu75Azni9Am1wiCu+Q5NhljtZwbx6QopkHxbM0DdohOwQQ1g2lPni8dZYdw/obvVQOKLNjkTWU3LvtiWrwiAKp/w5czeL5nkQiFxcAcyTqCRXNh3J1RD1k9H4OBLo2N+5o6dhnNUZt24PZFsNMzR+ygmNq7WvAqQpC5ixppND//8tg25234dXafdL8KmWMFuTepQem2H9Yo8zr16v+VC7MEUyh5ta67xqhFGluIDEySgxMX389r0bU1dXsqhc/K131ty6AcV8FWEGToguvxL+Sj8RhBk5F2B+QOtUzl/5iqlGhqpWcVkoQjiCPJbcLHlHbt6fiUNEpVVjxa2kNrTNZ/5GS6eZoVr5OT1tc3lY5ZUA40yk0Pk63mYB30yMl/wtbbQl/g/0OpcJW20+ZT3971dIt6PMFg3b+n1xSZgTNvIY=
 
 before_cache:
-- mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn dependency:go-offline -B
+- mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false dependency:go-offline -B
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Unit Tests Java 8"
       jdk:  oraclejdk8
       install: &build_no_checks
-        - mvn install -o -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
+        - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B dependency:go-offline
       script: &build_with_unittests
         - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
@@ -42,7 +42,7 @@ jobs:
 #        - rm "${JAVA_HOME}/lib/security/cacerts"
 #        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P reduce-logging -o || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -P reduce-logging || travis_terminate 1
 
     - name: "Simple Only Acceptance Tests"
       jdk:  oraclejdk8
@@ -117,11 +117,10 @@ notifications:
 
 before_cache:
 - mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
-- mvn package dependency:go-offline -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B
+
 cache:
   directories:
-    - $HOME/.m2
+    - "$HOME/.m2"
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       install: &build_no_checks
         - mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -o
       script: &build_with_unittests
-        - mvn install -pl \!tests/acceptance-test -o -P reduce-logging -o || travis_terminate 1
+        - mvn install -pl \!tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
     - name: "Unit Tests Java 11"
       jdk:  oraclejdk11
@@ -34,7 +34,7 @@ jobs:
     - name: "Acceptance Tests Java 8"
       jdk:  oraclejdk8
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -o -P reduce-logging -o || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
     - name: "Acceptance Tests Java 11"
       jdk:  oraclejdk11
@@ -42,7 +42,7 @@ jobs:
 #        - rm "${JAVA_HOME}/lib/security/cacerts"
 #        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -o -P reduce-logging || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -P reduce-logging -o || travis_terminate 1
 
     - name: "Simple Only Acceptance Tests"
       jdk:  oraclejdk8
@@ -116,11 +116,12 @@ notifications:
     secure: TeWK06kSrpdvMY/TNocbNYy0gJ9+jP9ygjzBtgsMRmm0kbBpzg34eZJyWMU/sf5x6taWAVOGW1jfG4+kfLUqG7CrqcRUihqK3x1DOJQS/BlT2IhJkED4dtwEw7xTkRTxPkghwMAXjJZImnh7ORS1HCJByEs5kedThh/Vr1HDaWJ+KctGLhE3LudyYikxZEWYVbexHZ5o8QbFGwmTYNHLaKAIGZbvt8wDoE+yJOftCqmCh2aJ4YBzYSW9wmxxf3tu75Azni9Am1wiCu+Q5NhljtZwbx6QopkHxbM0DdohOwQQ1g2lPni8dZYdw/obvVQOKLNjkTWU3LvtiWrwiAKp/w5czeL5nkQiFxcAcyTqCRXNh3J1RD1k9H4OBLo2N+5o6dhnNUZt24PZFsNMzR+ygmNq7WvAqQpC5ixppND//8tg25234dXafdL8KmWMFuTepQem2H9Yo8zr16v+VC7MEUyh5ta67xqhFGluIDEySgxMX389r0bU1dXsqhc/K131ty6AcV8FWEGToguvxL+Sj8RhBk5F2B+QOtUzl/5iqlGhqpWcVkoQjiCPJbcLHlHbt6fiUNEpVVjxa2kNrTNZ/5GS6eZoVr5OT1tc3lY5ZUA40yk0Pk63mYB30yMl/wtbbQl/g/0OpcJW20+ZT3971dIt6PMFg3b+n1xSZgTNvIY=
 
 before_cache:
-- mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false dependency:go-offline -B
+- mvn dependency:purge-local-repository -Dinclude=com.jpmorgan.quorum -DresolutionFuzziness=groupId -Dverbose=true -DreResolve=false
+- mvn dependency:go-offline -B
 
 cache:
   directories:
-    - "$HOME/.m2"
+    - $HOME/.m2
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Fixes #850 

Replacing master builds to only run the test suite should prevent this.

However, this will require doing manual deploys if we want to make the latest snapshot available to users from maven central.  We could look at creating an automated deploy process separate to the master builds if desired.