### PR TITLE
Downgrade okhttp to 3.12.3 as required by Azure key vault SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1254,7 +1254,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>3.14.0</version>
+                <version>3.12.3</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Related PR: #753 upgraded version past 3.12.0 to resolve nist vulnerability.  Downgrade to 3.12.3 which still resolves vulnerability but also ensures compatibility with Azure key vault functionality.