### PR TITLE
Update own keys on remote Enclave restart

### DIFF
--- a/tessera-grpc/grpc/src/main/proto/p2p.proto
+++ b/tessera-grpc/grpc/src/main/proto/p2p.proto
@@ -21,8 +21,6 @@ service PartyInfo {
 
     rpc GetPartyInfo (PartyInfoMessage) returns (PartyInfoMessage) { }
 
-    rpc GetPartyInfoStream (stream PartyInfoMessage) returns (stream PartyInfoMessage) { }
-
     rpc GetPartyInfoMessage (google.protobuf.Empty) returns (PartyInfoJson) { }
 
 }

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -205,6 +205,7 @@
                         <include>ConfigMigrationIT</include>
                         <include>P2pTestSuite</include>
                         <include>GrpcSuite</include>
+                        <include>SendWithRemoteEnclaveReconnectIT</include>
                     </includes>
                 </configuration>
                 <executions>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendWithRemoteEnclaveReconnectIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendWithRemoteEnclaveReconnectIT.java
@@ -1,13 +1,7 @@
 package com.quorum.tessera.test.rest;
 
 import com.quorum.tessera.api.model.SendRequest;
-import com.quorum.tessera.config.AppType;
-import com.quorum.tessera.config.CommunicationType;
-import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.JdbcConfig;
-import com.quorum.tessera.config.KeyConfiguration;
-import com.quorum.tessera.config.Peer;
-import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.config.*;
 import com.quorum.tessera.config.keypairs.DirectKeyPair;
 import com.quorum.tessera.config.util.JaxbUtil;
 import com.quorum.tessera.test.DBType;
@@ -15,67 +9,56 @@ import com.quorum.tessera.test.Party;
 import config.ConfigDescriptor;
 import exec.EnclaveExecManager;
 import exec.NodeExecManager;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import suite.*;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import suite.EnclaveType;
-import suite.ExecutionContext;
-import suite.NodeAlias;
-import suite.SocketType;
-import suite.Utils;
 
 public class SendWithRemoteEnclaveReconnectIT {
 
-  
-    
     private EnclaveExecManager enclaveExecManager;
 
     private NodeExecManager nodeExecManager;
 
-    private Party party;
+    private ConfigDescriptor configDescriptor;
 
-//    static {
-//        System.setProperty("application.jar", "../../tessera-dist/tessera-app/target/tessera-app-0.9-SNAPSHOT-app.jar");
-//        System.setProperty("enclave.jaxrs.server.jar", "../../enclave/enclave-jaxrs/target/enclave-jaxrs-0.9-SNAPSHOT-server.jar");
-//        System.setProperty("javax.xml.bind.JAXBContextFactory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
-//        System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
-//
-//    }
+    private Party party;
 
     @Before
     public void onSetup() throws IOException {
 
-       ExecutionContext.Builder.create()
-            .with(CommunicationType.REST)
-            .with(DBType.H2)
-            .with(SocketType.HTTP)
-            .with(EnclaveType.REMOTE)
-            .buildAndStoreContext();
+        ExecutionContext.Builder.create()
+                .with(CommunicationType.REST)
+                .with(DBType.H2)
+                .with(SocketType.HTTP)
+                .with(EnclaveType.REMOTE)
+                .buildAndStoreContext();
 
         final AtomicInteger portGenerator = new AtomicInteger(50100);
 
         final String serverUriTemplate = "http://localhost:%d";
 
         final Config nodeConfig = new Config();
-        JdbcConfig jdbcConfig = new JdbcConfig();
-        jdbcConfig.setUrl("jdbc:h2:mem:junit");
-        jdbcConfig.setUsername("sa");
-        jdbcConfig.setPassword("");
+
+        final JdbcConfig jdbcConfig = new JdbcConfig("sa", "", "jdbc:h2:mem:junit");
+        jdbcConfig.setAutoCreateTables(true);
         nodeConfig.setJdbcConfig(jdbcConfig);
 
         ServerConfig p2pServerConfig = new ServerConfig();
@@ -100,32 +83,25 @@ public class SendWithRemoteEnclaveReconnectIT {
 
         nodeConfig.setServerConfigs(Arrays.asList(p2pServerConfig, q2tServerConfig, enclaveServerConfig));
 
-        DirectKeyPair keyPair = new DirectKeyPair("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=", "yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=");
+        DirectKeyPair keyPair =
+                new DirectKeyPair(
+                        "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=", "yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=");
 
         enclaveConfig.setKeys(new KeyConfiguration());
-        enclaveConfig.getKeys().setKeyData(Arrays.asList(keyPair));
+        enclaveConfig.getKeys().setKeyData(new ArrayList<>(Arrays.asList(keyPair)));
 
         nodeConfig.setPeers(Arrays.asList(new Peer(p2pServerConfig.getServerAddress())));
 
         enclaveConfig.setServerConfigs(Arrays.asList(enclaveServerConfig));
 
-        Path configPath = Files.createFile(Paths.get(UUID.randomUUID().toString()));
-        configPath.toFile().deleteOnExit();
+        Path configPath = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
+        Path enclaveConfigPath = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
 
-        Path enclaveConfigPath = Files.createFile(Paths.get(UUID.randomUUID().toString()));
-        enclaveConfigPath.toFile().deleteOnExit();
+        this.writeConfig(nodeConfig, configPath);
+        this.writeConfig(enclaveConfig, enclaveConfigPath);
 
-        try (OutputStream out = Files.newOutputStream(configPath)) {
-            JaxbUtil.marshalWithNoValidation(nodeConfig, out);
-            out.flush();
-        }
-
-        JaxbUtil.marshalWithNoValidation(enclaveConfig, System.out);
-        try (OutputStream out = Files.newOutputStream(enclaveConfigPath)) {
-            JaxbUtil.marshalWithNoValidation(enclaveConfig, out);
-            out.flush();
-        }
-        ConfigDescriptor configDescriptor = new ConfigDescriptor(NodeAlias.A, configPath, nodeConfig, enclaveConfig, enclaveConfigPath);
+        this.configDescriptor =
+                new ConfigDescriptor(NodeAlias.A, configPath, nodeConfig, enclaveConfig, enclaveConfigPath);
 
         String key = configDescriptor.getKey().getPublicKey();
         URL file = Utils.toUrl(configDescriptor.getPath());
@@ -137,23 +113,18 @@ public class SendWithRemoteEnclaveReconnectIT {
         enclaveExecManager = new EnclaveExecManager(configDescriptor);
 
         enclaveExecManager.start();
-
         nodeExecManager.start();
     }
 
     @After
     public void onTearDown() {
-        
-        
         nodeExecManager.stop();
-
         enclaveExecManager.stop();
-        
         ExecutionContext.destroyContext();
     }
 
     @Test
-    public void sendTransactiuonToSelfWhenEnclaveIsDown() throws InterruptedException {
+    public void sendTransactionToSelfWhenEnclaveIsDown() {
 
         enclaveExecManager.stop();
 
@@ -165,22 +136,52 @@ public class SendWithRemoteEnclaveReconnectIT {
 
         Client client = ClientBuilder.newClient();
 
-        final Response response = client.target(party.getQ2TUri())
-            .path("send")
-            .request()
-            .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
+        final Response response =
+                client.target(party.getQ2TUri())
+                        .path("send")
+                        .request()
+                        .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(503);
 
+        this.enclaveExecManager = new EnclaveExecManager(this.configDescriptor);
         enclaveExecManager.start();
 
-        final Response secondresponse = client.target(party.getQ2TUri())
-            .path("send")
-            .request()
-            .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
+        final Response secondresponse =
+                client.target(party.getQ2TUri())
+                        .path("send")
+                        .request()
+                        .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
 
         assertThat(secondresponse.getStatus()).isEqualTo(201);
-
     }
 
+    @Test
+    public void reconnectingToEnclaveUpdatesKeys() throws IOException {
+        enclaveExecManager.stop();
+
+        final DirectKeyPair addedKeypair =
+                new DirectKeyPair(
+                        "sL/prFZhfUNhbL+7Ky7bHA+OEBhqty0L+PaOuA0bj1M=", "JIQ3a2udSn+xxfhM5pQP+sn3u9BblC84Clpk5tsYmg4=");
+
+        final Config enclaveConfig = this.configDescriptor.getEnclaveConfig().get();
+        enclaveConfig.getKeys().getKeyData().add(addedKeypair);
+        this.writeConfig(enclaveConfig, this.configDescriptor.getEnclavePath());
+
+        this.enclaveExecManager = new EnclaveExecManager(this.configDescriptor);
+        enclaveExecManager.start();
+
+        Client client = ClientBuilder.newClient();
+
+        final Response response = client.target(party.getP2PUri()).path("partyinfo").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    private void writeConfig(final Config config, final Path outputPath) throws IOException {
+        try (OutputStream out = Files.newOutputStream(outputPath)) {
+            JaxbUtil.marshalWithNoValidation(config, out);
+            out.flush();
+        }
+    }
 }


### PR DESCRIPTION
When we fetch our local network information, check for any new keys that may be available what we own. These then get added the outgoing network information.

This can happen when a remote enclave is restarted with different keys. Since we only populate our local keys on startup in the Transaction Manager, it was not aware of the changed configuration of the Enclave.

Whilst digging around the PartyInfo area, I found an unused and unimplemented GRPC method that should be removed too.

Fixes https://github.com/jpmorganchase/tessera/issues/702

---

This can be quite intensive, as when running a local enclave this is not needed, and when running a remote enclave, the extra (hopefully TLS-enabled) call will add latency.

**Open questions**:

- [ ] Is it better to make this only occur 1 in X calls to `getPartyInfo()`? (Probably not)
- [ ] Is this the correct place to put it? Doesn't look ideal but logically it makes sense.
- [ ] Would it be better to have a background updating thread to perform this for us, to keep it separate?
- [ ] Is it better to have the Enclave notify us of this event? This breaks the current one way communication idea.