### PR TITLE
Update Jackson Databinding dependency to newer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1229,7 +1229,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}.1</version>
+                <version>${jackson.version}.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Updates the Jackson Databind version to one that is accepted by the Enforcer plugin.

Fixes #855