### PR TITLE
Print more useful error msgs to syserr for service provider errors

### DIFF
--- a/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
+++ b/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
@@ -69,8 +69,17 @@ public class Main {
             System.err.println(ex.getMessage());
             System.exit(4);
         } catch (final ServiceConfigurationError ex) {
-            Optional.ofNullable(ex.getMessage()).ifPresent(System.err::println);
-            Optional.ofNullable(ex.getCause()).map(Throwable::getMessage).ifPresent(System.err::println);
+            Optional<Throwable> e = Optional.of(ex);
+
+            e.map(Throwable::getMessage).ifPresent(System.err::println);
+
+            // get root cause
+            while (e.map(Throwable::getCause).isPresent()) {
+                e = e.map(Throwable::getCause);
+            }
+
+            e.map(Throwable::toString).ifPresent(System.err::println);
+
             System.exit(5);
         } catch (final Throwable ex) {
             Optional.ofNullable(ex.getMessage()).ifPresent(System.err::println);

--- a/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
+++ b/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
@@ -68,6 +68,11 @@ public class Main {
         } catch (final CliException ex) {
             System.err.println(ex.getMessage());
             System.exit(4);
+        } catch (final ServiceConfigurationError ex) {
+            Optional.ofNullable(ex.getMessage()).ifPresent(System.err::println);
+            Optional.ofNullable(ex.getCause()).map(Throwable::getMessage).ifPresent(System.err::println);
+            ex.printStackTrace();
+            System.exit(5);
         } catch (final Throwable ex) {
             Optional.ofNullable(ex.getMessage()).ifPresent(System.err::println);
             System.exit(2);

--- a/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
+++ b/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
@@ -71,7 +71,6 @@ public class Main {
         } catch (final ServiceConfigurationError ex) {
             Optional.ofNullable(ex.getMessage()).ifPresent(System.err::println);
             Optional.ofNullable(ex.getCause()).map(Throwable::getMessage).ifPresent(System.err::println);
-            ex.printStackTrace();
             System.exit(5);
         } catch (final Throwable ex) {
             Optional.ofNullable(ex.getMessage()).ifPresent(System.err::println);


### PR DESCRIPTION
Fixes #859 

By also printing the root cause exception, additional useful information will be presented to the user.

Before
```
com.quorum.tessera.config.apps.TesseraApp: Provider com.quorum.tessera.p2p.P2PRestApp could not be instantiated
```

After
```
com.quorum.tessera.config.apps.TesseraApp: Provider com.quorum.tessera.p2p.P2PRestApp could not be instantiated
com.quorum.tessera.key.vault.hashicorp.HashicorpCredentialNotSetException: Only one of the HASHICORP_ROLE_ID and HASHICORP_SECRET_ID environment variables to authenticate with Hashicorp Vault using the AppRole method has been set
```