### PR TITLE
Poll (remote) enclave for local public keys

### DIFF
--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/EnclaveKeySynchroniser.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/EnclaveKeySynchroniser.java
@@ -1,0 +1,44 @@
+package com.quorum.tessera.partyinfo;
+
+import com.quorum.tessera.admin.ConfigService;
+import com.quorum.tessera.enclave.Enclave;
+import com.quorum.tessera.partyinfo.model.PartyInfo;
+import com.quorum.tessera.partyinfo.model.Recipient;
+
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Fetches local public keys from the Enclave and adds them to the local store. This is useful when the Enclave is
+ * remote and can restart with new keys independently of the Transaction Manager
+ */
+public class EnclaveKeySynchroniser implements Runnable {
+
+    private final Enclave enclave;
+
+    private PartyInfoStore partyInfoStore;
+
+    private final String advertisedUrl;
+
+    public EnclaveKeySynchroniser(
+            final Enclave enclave, final PartyInfoStore partyInfoStore, final ConfigService configService) {
+        this.enclave = Objects.requireNonNull(enclave);
+        this.partyInfoStore = Objects.requireNonNull(partyInfoStore);
+        this.advertisedUrl = URLNormalizer.create().normalize(configService.getServerUri().toString());
+    }
+
+    @Override
+    public void run() {
+        // fetch keys and create recipients
+        final Set<Recipient> ourKeys =
+                this.enclave.getPublicKeys().stream()
+                        .map(key -> new Recipient(key, this.advertisedUrl))
+                        .collect(toSet());
+
+        // add to store
+        this.partyInfoStore.store(new PartyInfo(this.advertisedUrl, ourKeys, emptySet()));
+    }
+}

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceFactory.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceFactory.java
@@ -15,6 +15,8 @@ public interface PartyInfoServiceFactory {
 
     PayloadPublisher payloadPublisher();
 
+    PartyInfoStore partyInfoStore();
+
     static PartyInfoServiceFactory create() {
         return new PartyInfoServiceFactoryImpl();
     }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceFactoryImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceFactoryImpl.java
@@ -8,12 +8,12 @@ public class PartyInfoServiceFactoryImpl implements PartyInfoServiceFactory {
 
     private final ServiceLocator serviceLocator = ServiceLocator.create();
 
-    public <T> T find(Class<T> type) {
+    public <T> T find(final Class<T> type) {
         return serviceLocator.getServices().stream()
                 .filter(type::isInstance)
                 .map(type::cast)
                 .findAny()
-                .orElseThrow(() -> new IllegalStateException("Unable to find service type :" + type));
+                .orElseThrow(() -> new IllegalStateException("Unable to find service type: " + type));
     }
 
     @Override
@@ -39,5 +39,10 @@ public class PartyInfoServiceFactoryImpl implements PartyInfoServiceFactory {
     @Override
     public PayloadPublisher payloadPublisher() {
         return find(PayloadPublisher.class);
+    }
+
+    @Override
+    public PartyInfoStore partyInfoStore() {
+        return find(PartyInfoStore.class);
     }
 }

--- a/tessera-partyinfo/src/main/resources/tessera-partyinfo-spring.xml
+++ b/tessera-partyinfo/src/main/resources/tessera-partyinfo-spring.xml
@@ -22,7 +22,12 @@
 
     <!-- Party Info management -->
 
+    <bean name="partyInfoStore" class="com.quorum.tessera.partyinfo.PartyInfoStore">
+        <constructor-arg ref="configService"/>
+    </bean>
+
     <bean name="partyInfoService" class="com.quorum.tessera.partyinfo.PartyInfoServiceImpl">
+        <constructor-arg ref="partyInfoStore"/>
         <constructor-arg ref="configService"/>
         <constructor-arg ref="enclave"/>
         <constructor-arg ref="payloadPublisher"/>
@@ -45,6 +50,23 @@
     <bean id="resendManager" class="com.quorum.tessera.partyinfo.ResendManagerImpl">
         <constructor-arg ref="encryptedTransactionDAO" />
         <constructor-arg ref="enclave" />
+    </bean>
+
+    <!-- Local key sync -->
+    <bean name="enclaveKeySynchroniser" class="com.quorum.tessera.partyinfo.EnclaveKeySynchroniser">
+        <constructor-arg ref="enclave" />
+        <constructor-arg ref="partyInfoStore" />
+        <constructor-arg ref="configService" />
+
+    </bean>
+
+    <bean name="enclaveKeySynchroniserExecutor" class="com.quorum.tessera.threading.TesseraScheduledExecutor">
+        <constructor-arg>
+            <bean class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
+        </constructor-arg>
+        <constructor-arg ref="enclaveKeySynchroniser"/>
+        <constructor-arg value="2000"/>
+        <constructor-arg value="5000"/>
     </bean>
 
     <!-- Node synchronization management-->

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/EnclaveKeySynchroniserTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/EnclaveKeySynchroniserTest.java
@@ -1,0 +1,86 @@
+package com.quorum.tessera.partyinfo;
+
+import com.quorum.tessera.admin.ConfigService;
+import com.quorum.tessera.enclave.Enclave;
+import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.partyinfo.model.Party;
+import com.quorum.tessera.partyinfo.model.PartyInfo;
+import com.quorum.tessera.partyinfo.model.Recipient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.*;
+
+public class EnclaveKeySynchroniserTest {
+
+    private static final String URL = "myurl.com/";
+
+    private Enclave enclave;
+
+    private PartyInfoStore partyInfoStore;
+
+    private ConfigService configService;
+
+    private EnclaveKeySynchroniser enclaveKeySynchroniser;
+
+    @Before
+    public void init() throws URISyntaxException {
+        this.configService = mock(ConfigService.class);
+        when(configService.getServerUri()).thenReturn(new URI(URL));
+
+        this.enclave = mock(Enclave.class);
+        this.partyInfoStore = new PartyInfoStore(new URI(URL));
+
+        this.enclaveKeySynchroniser = new EnclaveKeySynchroniser(enclave, partyInfoStore, configService);
+    }
+
+    @After
+    public void after() {
+        verifyNoMoreInteractions(enclave, configService);
+    }
+
+    @Test
+    public void fetchedKeysAreAddedToStore() {
+        final PartyInfo initialStore = this.partyInfoStore.getPartyInfo();
+        assertThat(initialStore.getRecipients()).isEmpty();
+        assertThat(initialStore.getParties()).containsExactlyInAnyOrder(new Party(URL));
+
+        final PublicKey keyOne = PublicKey.from("KeyOne".getBytes());
+        final PublicKey keyTwo = PublicKey.from("KeyTwo".getBytes());
+
+        when(enclave.getPublicKeys()).thenReturn(new HashSet<>(Arrays.asList(keyOne, keyTwo)));
+
+        this.enclaveKeySynchroniser.run();
+
+        final PartyInfo updatedStore = this.partyInfoStore.getPartyInfo();
+        assertThat(updatedStore.getRecipients())
+                .containsExactlyInAnyOrder(new Recipient(keyOne, URL), new Recipient(keyTwo, URL));
+
+        verify(enclave).getPublicKeys();
+        verify(configService).getServerUri();
+    }
+
+    @Test
+    public void connectionIssuesBubbleUp() {
+        when(enclave.getPublicKeys()).thenThrow(UncheckedIOException.class);
+
+        final Throwable throwable = catchThrowable(this.enclaveKeySynchroniser::run);
+        assertThat(throwable).isInstanceOf(UncheckedIOException.class);
+
+        final PartyInfo store = this.partyInfoStore.getPartyInfo();
+        assertThat(store.getRecipients()).isEmpty();
+        assertThat(store.getParties()).containsExactlyInAnyOrder(new Party(URL));
+
+        verify(enclave).getPublicKeys();
+        verify(configService).getServerUri();
+    }
+}

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoServiceFactoryTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoServiceFactoryTest.java
@@ -3,58 +3,53 @@ package com.quorum.tessera.partyinfo;
 import com.jpmorgan.quorum.mock.servicelocator.MockServiceLocator;
 import com.quorum.tessera.admin.ConfigService;
 import com.quorum.tessera.enclave.Enclave;
+import org.junit.Test;
+
 import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import static org.assertj.core.api.Assertions.*;
-import org.junit.Before;
-import org.junit.Test;
-import static org.mockito.Mockito.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PartyInfoServiceFactoryTest {
-
-    private PartyInfoServiceFactory partyInfoServiceFactory;
-
-    @Before
-    public void onSetUp() {
-        partyInfoServiceFactory = PartyInfoServiceFactory.create();
-    }
 
     @Test
     public void loadServicesFromLocator() throws Exception {
 
         ResendManager resendManager = mock(ResendManager.class);
-
         PayloadPublisher payloadPublisher = mock(PayloadPublisher.class);
         ConfigService configService = mock(ConfigService.class);
         when(configService.getServerUri()).thenReturn(new URI("http://bogus.com"));
         Enclave enclave = mock(Enclave.class);
-
         PartyInfoService partyInfoService = mock(PartyInfoService.class);
+        PartyInfoStore store = mock(PartyInfoStore.class);
 
-        Set services =
-                Stream.of(payloadPublisher, configService, enclave, partyInfoService, resendManager)
+        Set<Object> services =
+                Stream.of(payloadPublisher, configService, enclave, partyInfoService, resendManager, store)
                         .collect(Collectors.toSet());
 
-        MockServiceLocator mockServiceLocator = MockServiceLocator.createMockServiceLocator();
-
+        final MockServiceLocator mockServiceLocator = MockServiceLocator.createMockServiceLocator();
         mockServiceLocator.setServices(services);
+
+        final PartyInfoServiceFactory partyInfoServiceFactory = PartyInfoServiceFactory.create();
 
         assertThat(partyInfoServiceFactory.partyInfoService()).isSameAs(partyInfoService);
         assertThat(partyInfoServiceFactory.enclave()).isSameAs(enclave);
         assertThat(partyInfoServiceFactory.configService()).isSameAs(configService);
         assertThat(partyInfoServiceFactory.payloadPublisher()).isSameAs(payloadPublisher);
         assertThat(partyInfoServiceFactory.resendManager()).isSameAs(resendManager);
+        assertThat(partyInfoServiceFactory.partyInfoStore()).isSameAs(store);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void loadServicesFromLocatorServiceNotFoundThrowsIllegalStateException() throws Exception {
+    public void loadServicesFromLocatorServiceNotFoundThrowsIllegalStateException() {
+        MockServiceLocator.createMockServiceLocator().setServices(Collections.emptySet());
 
-        MockServiceLocator mockServiceLocator = MockServiceLocator.createMockServiceLocator();
-
-        mockServiceLocator.setServices(Collections.emptySet());
+        final PartyInfoServiceFactory partyInfoServiceFactory = PartyInfoServiceFactory.create();
 
         partyInfoServiceFactory.partyInfoService();
     }

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoServiceTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoServiceTest.java
@@ -259,18 +259,20 @@ public class PartyInfoServiceTest {
     }
 
     @Test
-    public void createWithDefaultConstructor() throws Exception {
+    public void createWithFactoryConstructor() throws Exception {
 
-        ConfigService configService = mock(ConfigService.class);
+        final ConfigService configService = mock(ConfigService.class);
         when(configService.getServerUri()).thenReturn(new URI("bogus.com"));
 
         Set<Object> services =
-                Stream.of(configService, mock(Enclave.class), mock(PayloadPublisher.class)).collect(Collectors.toSet());
+                Stream.of(configService, mock(Enclave.class), mock(PayloadPublisher.class), mock(PartyInfoStore.class))
+                        .collect(Collectors.toSet());
 
-        MockServiceLocator mockServiceLocator = MockServiceLocator.createMockServiceLocator();
-        mockServiceLocator.setServices(services);
+        MockServiceLocator.createMockServiceLocator().setServices(services);
 
-        assertThat(new PartyInfoServiceImpl()).isNotNull();
+        final PartyInfoServiceFactory factory = PartyInfoServiceFactory.create();
+
+        assertThat(new PartyInfoServiceImpl(factory)).isNotNull();
     }
 
     @Test

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -205,6 +205,7 @@
                         <include>ConfigMigrationIT</include>
                         <include>P2pTestSuite</include>
                         <include>GrpcSuite</include>
+                        <include>SendWithRemoteEnclaveReconnectIT</include>
                     </includes>
                 </configuration>
                 <executions>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendWithRemoteEnclaveReconnectIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendWithRemoteEnclaveReconnectIT.java
@@ -1,13 +1,7 @@
 package com.quorum.tessera.test.rest;
 
 import com.quorum.tessera.api.model.SendRequest;
-import com.quorum.tessera.config.AppType;
-import com.quorum.tessera.config.CommunicationType;
-import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.JdbcConfig;
-import com.quorum.tessera.config.KeyConfiguration;
-import com.quorum.tessera.config.Peer;
-import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.config.*;
 import com.quorum.tessera.config.keypairs.DirectKeyPair;
 import com.quorum.tessera.config.util.JaxbUtil;
 import com.quorum.tessera.test.DBType;
@@ -15,67 +9,56 @@ import com.quorum.tessera.test.Party;
 import config.ConfigDescriptor;
 import exec.EnclaveExecManager;
 import exec.NodeExecManager;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import suite.*;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import suite.EnclaveType;
-import suite.ExecutionContext;
-import suite.NodeAlias;
-import suite.SocketType;
-import suite.Utils;
 
 public class SendWithRemoteEnclaveReconnectIT {
 
-  
-    
     private EnclaveExecManager enclaveExecManager;
 
     private NodeExecManager nodeExecManager;
 
-    private Party party;
+    private ConfigDescriptor configDescriptor;
 
-//    static {
-//        System.setProperty("application.jar", "../../tessera-dist/tessera-app/target/tessera-app-0.9-SNAPSHOT-app.jar");
-//        System.setProperty("enclave.jaxrs.server.jar", "../../enclave/enclave-jaxrs/target/enclave-jaxrs-0.9-SNAPSHOT-server.jar");
-//        System.setProperty("javax.xml.bind.JAXBContextFactory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
-//        System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
-//
-//    }
+    private Party party;
 
     @Before
     public void onSetup() throws IOException {
 
-       ExecutionContext.Builder.create()
-            .with(CommunicationType.REST)
-            .with(DBType.H2)
-            .with(SocketType.HTTP)
-            .with(EnclaveType.REMOTE)
-            .buildAndStoreContext();
+        ExecutionContext.Builder.create()
+                .with(CommunicationType.REST)
+                .with(DBType.H2)
+                .with(SocketType.HTTP)
+                .with(EnclaveType.REMOTE)
+                .buildAndStoreContext();
 
         final AtomicInteger portGenerator = new AtomicInteger(50100);
 
         final String serverUriTemplate = "http://localhost:%d";
 
         final Config nodeConfig = new Config();
-        JdbcConfig jdbcConfig = new JdbcConfig();
-        jdbcConfig.setUrl("jdbc:h2:mem:junit");
-        jdbcConfig.setUsername("sa");
-        jdbcConfig.setPassword("");
+
+        final JdbcConfig jdbcConfig = new JdbcConfig("sa", "", "jdbc:h2:mem:junit");
+        jdbcConfig.setAutoCreateTables(true);
         nodeConfig.setJdbcConfig(jdbcConfig);
 
         ServerConfig p2pServerConfig = new ServerConfig();
@@ -100,32 +83,25 @@ public class SendWithRemoteEnclaveReconnectIT {
 
         nodeConfig.setServerConfigs(Arrays.asList(p2pServerConfig, q2tServerConfig, enclaveServerConfig));
 
-        DirectKeyPair keyPair = new DirectKeyPair("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=", "yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=");
+        DirectKeyPair keyPair =
+                new DirectKeyPair(
+                        "/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=", "yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=");
 
         enclaveConfig.setKeys(new KeyConfiguration());
-        enclaveConfig.getKeys().setKeyData(Arrays.asList(keyPair));
+        enclaveConfig.getKeys().setKeyData(new ArrayList<>(Arrays.asList(keyPair)));
 
         nodeConfig.setPeers(Arrays.asList(new Peer(p2pServerConfig.getServerAddress())));
 
         enclaveConfig.setServerConfigs(Arrays.asList(enclaveServerConfig));
 
-        Path configPath = Files.createFile(Paths.get(UUID.randomUUID().toString()));
-        configPath.toFile().deleteOnExit();
+        Path configPath = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
+        Path enclaveConfigPath = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
 
-        Path enclaveConfigPath = Files.createFile(Paths.get(UUID.randomUUID().toString()));
-        enclaveConfigPath.toFile().deleteOnExit();
+        this.writeConfig(nodeConfig, configPath);
+        this.writeConfig(enclaveConfig, enclaveConfigPath);
 
-        try (OutputStream out = Files.newOutputStream(configPath)) {
-            JaxbUtil.marshalWithNoValidation(nodeConfig, out);
-            out.flush();
-        }
-
-        JaxbUtil.marshalWithNoValidation(enclaveConfig, System.out);
-        try (OutputStream out = Files.newOutputStream(enclaveConfigPath)) {
-            JaxbUtil.marshalWithNoValidation(enclaveConfig, out);
-            out.flush();
-        }
-        ConfigDescriptor configDescriptor = new ConfigDescriptor(NodeAlias.A, configPath, nodeConfig, enclaveConfig, enclaveConfigPath);
+        this.configDescriptor =
+                new ConfigDescriptor(NodeAlias.A, configPath, nodeConfig, enclaveConfig, enclaveConfigPath);
 
         String key = configDescriptor.getKey().getPublicKey();
         URL file = Utils.toUrl(configDescriptor.getPath());
@@ -137,23 +113,18 @@ public class SendWithRemoteEnclaveReconnectIT {
         enclaveExecManager = new EnclaveExecManager(configDescriptor);
 
         enclaveExecManager.start();
-
         nodeExecManager.start();
     }
 
     @After
     public void onTearDown() {
-        
-        
         nodeExecManager.stop();
-
         enclaveExecManager.stop();
-        
         ExecutionContext.destroyContext();
     }
 
     @Test
-    public void sendTransactiuonToSelfWhenEnclaveIsDown() throws InterruptedException {
+    public void sendTransactionToSelfWhenEnclaveIsDown() {
 
         enclaveExecManager.stop();
 
@@ -165,22 +136,52 @@ public class SendWithRemoteEnclaveReconnectIT {
 
         Client client = ClientBuilder.newClient();
 
-        final Response response = client.target(party.getQ2TUri())
-            .path("send")
-            .request()
-            .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
+        final Response response =
+                client.target(party.getQ2TUri())
+                        .path("send")
+                        .request()
+                        .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(503);
 
+        this.enclaveExecManager = new EnclaveExecManager(this.configDescriptor);
         enclaveExecManager.start();
 
-        final Response secondresponse = client.target(party.getQ2TUri())
-            .path("send")
-            .request()
-            .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
+        final Response secondresponse =
+                client.target(party.getQ2TUri())
+                        .path("send")
+                        .request()
+                        .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
 
         assertThat(secondresponse.getStatus()).isEqualTo(201);
-
     }
 
+    @Test
+    public void reconnectingToEnclaveUpdatesKeys() throws IOException {
+        enclaveExecManager.stop();
+
+        final DirectKeyPair addedKeypair =
+                new DirectKeyPair(
+                        "sL/prFZhfUNhbL+7Ky7bHA+OEBhqty0L+PaOuA0bj1M=", "JIQ3a2udSn+xxfhM5pQP+sn3u9BblC84Clpk5tsYmg4=");
+
+        final Config enclaveConfig = this.configDescriptor.getEnclaveConfig().get();
+        enclaveConfig.getKeys().getKeyData().add(addedKeypair);
+        this.writeConfig(enclaveConfig, this.configDescriptor.getEnclavePath());
+
+        this.enclaveExecManager = new EnclaveExecManager(this.configDescriptor);
+        enclaveExecManager.start();
+
+        Client client = ClientBuilder.newClient();
+
+        final Response response = client.target(party.getP2PUri()).path("partyinfo").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    private void writeConfig(final Config config, final Path outputPath) throws IOException {
+        try (OutputStream out = Files.newOutputStream(outputPath)) {
+            JaxbUtil.marshalWithNoValidation(config, out);
+            out.flush();
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a poller that will fetch public keys from the Enclave and add them to the local store.
This means that if a remote enclave is restarted with different keys, then they will get picked up by the transaction manager without having to restart, which then propagates across the network.

This is essentially a no-op for local enclaves for now, although after https://github.com/jpmorganchase/tessera/issues/703 is implemented, it would be picked up automatically (although whether this is worth the cost is arguable, tending towards not).

A poller was chosen so that we can keep the 1-way communication of TM->Enclave.
A polling time of `5000ms` was chosen arbitrarily, which keep the amount of time a user must wait before the key is accessible down, if we want to increase the time to reduce strain then please do suggest.

Fixes https://github.com/jpmorganchase/tessera/issues/702

Supersedes https://github.com/jpmorganchase/tessera/pull/853

---

Although this PR creates more spring beans, which is the opposite direction of where we want to go, I have raised the ticket https://github.com/jpmorganchase/tessera/issues/860 to capture a  removing all the possible `tessera-partyinfo` beans as its own change.