### PR TITLE
Add generics to Key Vaults

### DIFF
--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/AzureVaultKeyGenerator.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/AzureVaultKeyGenerator.java
@@ -2,8 +2,8 @@ package com.quorum.tessera.key.generation;
 
 import com.quorum.tessera.config.ArgonOptions;
 import com.quorum.tessera.config.keypairs.AzureVaultKeyPair;
+import com.quorum.tessera.config.vault.data.AzureGetSecretData;
 import com.quorum.tessera.config.vault.data.AzureSetSecretData;
-import com.quorum.tessera.config.vault.data.SetSecretData;
 import com.quorum.tessera.encryption.Key;
 import com.quorum.tessera.encryption.KeyPair;
 import com.quorum.tessera.key.vault.KeyVaultService;
@@ -20,9 +20,11 @@ public class AzureVaultKeyGenerator implements KeyGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureVaultKeyGenerator.class);
 
     private final NaclFacade nacl;
-    private final KeyVaultService keyVaultService;
 
-    public AzureVaultKeyGenerator(final NaclFacade nacl, KeyVaultService keyVaultService) {
+    private final KeyVaultService<AzureSetSecretData, AzureGetSecretData> keyVaultService;
+
+    public AzureVaultKeyGenerator(
+            final NaclFacade nacl, KeyVaultService<AzureSetSecretData, AzureGetSecretData> keyVaultService) {
         this.nacl = nacl;
         this.keyVaultService = keyVaultService;
     }
@@ -34,17 +36,16 @@ public class AzureVaultKeyGenerator implements KeyGenerator {
         final StringBuilder publicId = new StringBuilder();
         final StringBuilder privateId = new StringBuilder();
 
-        if(filename != null) {
+        if (filename != null) {
             final Path path = Paths.get(filename);
             final String keyVaultId = path.getFileName().toString();
 
-            if(!keyVaultId.matches("^[0-9a-zA-Z\\-]*$")) {
+            if (!keyVaultId.matches("^[0-9a-zA-Z\\-]*$")) {
                 throw new UnsupportedCharsetException("Generated key ID for Azure Key Vault can contain only 0-9, a-z, A-Z and - characters");
             }
 
             publicId.append(keyVaultId);
             privateId.append(keyVaultId);
-
         }
 
         publicId.append("Pub");
@@ -57,9 +58,7 @@ public class AzureVaultKeyGenerator implements KeyGenerator {
     }
 
     private void saveKeyInVault(String id, Key key) {
-        SetSecretData setSecretData = new AzureSetSecretData(id, key.encodeToBase64());
-
-        keyVaultService.setSecret(setSecretData);
+        keyVaultService.setSecret(new AzureSetSecretData(id, key.encodeToBase64()));
         LOGGER.debug("Key {} saved to vault with id {}", key.encodeToBase64(), id);
         LOGGER.info("Key saved to vault with id {}", id);
     }

--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/DefaultKeyGeneratorFactory.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/DefaultKeyGeneratorFactory.java
@@ -3,6 +3,10 @@ package com.quorum.tessera.key.generation;
 import com.quorum.tessera.config.*;
 import com.quorum.tessera.config.keys.KeyEncryptorFactory;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
+import com.quorum.tessera.config.vault.data.AzureGetSecretData;
+import com.quorum.tessera.config.vault.data.AzureSetSecretData;
+import com.quorum.tessera.config.vault.data.HashicorpGetSecretData;
+import com.quorum.tessera.config.vault.data.HashicorpSetSecretData;
 import com.quorum.tessera.key.vault.KeyVaultService;
 import com.quorum.tessera.key.vault.KeyVaultServiceFactory;
 import com.quorum.tessera.nacl.NaclFacadeFactory;
@@ -13,18 +17,19 @@ public class DefaultKeyGeneratorFactory implements KeyGeneratorFactory {
     @Override
     public KeyGenerator create(KeyVaultConfig keyVaultConfig) {
 
-        if(keyVaultConfig != null) {
+        if (keyVaultConfig != null) {
             final KeyVaultServiceFactory keyVaultServiceFactory = KeyVaultServiceFactory.getInstance(keyVaultConfig.getKeyVaultType());
 
             final Config config = new Config();
             final KeyConfiguration keyConfiguration = new KeyConfiguration();
 
-            if(keyVaultConfig.getKeyVaultType().equals(KeyVaultType.AZURE)) {
+            if (keyVaultConfig.getKeyVaultType().equals(KeyVaultType.AZURE)) {
                 keyConfiguration.setAzureKeyVaultConfig((AzureKeyVaultConfig) keyVaultConfig);
 
                 config.setKeys(keyConfiguration);
 
-                final KeyVaultService keyVaultService = keyVaultServiceFactory.create(config, new EnvironmentVariableProvider());
+                final KeyVaultService<AzureSetSecretData, AzureGetSecretData> keyVaultService =
+                        keyVaultServiceFactory.create(config, new EnvironmentVariableProvider());
 
                 return new AzureVaultKeyGenerator(NaclFacadeFactory.newFactory().create(), keyVaultService);
 
@@ -33,7 +38,8 @@ public class DefaultKeyGeneratorFactory implements KeyGeneratorFactory {
 
                 config.setKeys(keyConfiguration);
 
-                final KeyVaultService keyVaultService = keyVaultServiceFactory.create(config, new EnvironmentVariableProvider());
+                final KeyVaultService<HashicorpSetSecretData, HashicorpGetSecretData> keyVaultService =
+                        keyVaultServiceFactory.create(config, new EnvironmentVariableProvider());
 
                 return new HashicorpVaultKeyGenerator(NaclFacadeFactory.newFactory().create(), keyVaultService);
             }

--- a/key-generation/src/main/java/com/quorum/tessera/key/generation/HashicorpVaultKeyGenerator.java
+++ b/key-generation/src/main/java/com/quorum/tessera/key/generation/HashicorpVaultKeyGenerator.java
@@ -2,8 +2,8 @@ package com.quorum.tessera.key.generation;
 
 import com.quorum.tessera.config.ArgonOptions;
 import com.quorum.tessera.config.keypairs.HashicorpVaultKeyPair;
+import com.quorum.tessera.config.vault.data.HashicorpGetSecretData;
 import com.quorum.tessera.config.vault.data.HashicorpSetSecretData;
-import com.quorum.tessera.config.vault.data.SetSecretData;
 import com.quorum.tessera.encryption.KeyPair;
 import com.quorum.tessera.key.vault.KeyVaultService;
 import com.quorum.tessera.nacl.NaclFacade;
@@ -15,12 +15,15 @@ import java.util.Map;
 import java.util.Objects;
 
 public class HashicorpVaultKeyGenerator implements KeyGenerator {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(HashicorpVaultKeyGenerator.class);
 
     private final NaclFacade nacl;
-    private final KeyVaultService keyVaultService;
 
-    public HashicorpVaultKeyGenerator(final NaclFacade nacl, KeyVaultService keyVaultService) {
+    private final KeyVaultService<HashicorpSetSecretData, HashicorpGetSecretData> keyVaultService;
+
+    public HashicorpVaultKeyGenerator(
+            final NaclFacade nacl, KeyVaultService<HashicorpSetSecretData, HashicorpGetSecretData> keyVaultService) {
         this.nacl = nacl;
         this.keyVaultService = keyVaultService;
     }
@@ -39,9 +42,7 @@ public class HashicorpVaultKeyGenerator implements KeyGenerator {
         keyPairData.put(pubId, keys.getPublicKey().encodeToBase64());
         keyPairData.put(privId, keys.getPrivateKey().encodeToBase64());
 
-        SetSecretData setSecretData = new HashicorpSetSecretData(keyVaultOptions.getSecretEngineName(), filename, keyPairData);
-
-        keyVaultService.setSecret(setSecretData);
+        keyVaultService.setSecret(new HashicorpSetSecretData(keyVaultOptions.getSecretEngineName(), filename, keyPairData));
         LOGGER.debug("Key {} saved to vault secret engine {} with name {} and id {}", keyPairData.get(pubId), keyVaultOptions.getSecretEngineName(), filename, pubId);
         LOGGER.info("Key saved to vault secret engine {} with name {} and id {}", keyVaultOptions.getSecretEngineName(), filename, pubId);
         LOGGER.debug("Key {} saved to vault secret engine {} with name {} and id {}", keyPairData.get(privId), keyVaultOptions.getSecretEngineName(), filename, privId);

--- a/key-vault/azure-key-vault/src/main/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultService.java
+++ b/key-vault/azure-key-vault/src/main/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultService.java
@@ -5,44 +5,33 @@ import com.microsoft.azure.keyvault.requests.SetSecretRequest;
 import com.quorum.tessera.config.AzureKeyVaultConfig;
 import com.quorum.tessera.config.vault.data.AzureGetSecretData;
 import com.quorum.tessera.config.vault.data.AzureSetSecretData;
-import com.quorum.tessera.config.vault.data.GetSecretData;
-import com.quorum.tessera.config.vault.data.SetSecretData;
-import com.quorum.tessera.key.vault.KeyVaultException;
 import com.quorum.tessera.key.vault.KeyVaultService;
 import com.quorum.tessera.key.vault.VaultSecretNotFoundException;
 
 import java.util.Objects;
 
-public class AzureKeyVaultService implements KeyVaultService {
+public class AzureKeyVaultService implements KeyVaultService<AzureSetSecretData, AzureGetSecretData> {
+
     private String vaultUrl;
+
     private AzureKeyVaultClientDelegate azureKeyVaultClientDelegate;
 
     AzureKeyVaultService(AzureKeyVaultConfig keyVaultConfig, AzureKeyVaultClientDelegate azureKeyVaultClientDelegate) {
-        Objects.requireNonNull(keyVaultConfig);
-        Objects.requireNonNull(azureKeyVaultClientDelegate);
-
-        this.vaultUrl = keyVaultConfig.getUrl();
-        this.azureKeyVaultClientDelegate = azureKeyVaultClientDelegate;
+        this.vaultUrl = Objects.requireNonNull(keyVaultConfig).getUrl();
+        this.azureKeyVaultClientDelegate = Objects.requireNonNull(azureKeyVaultClientDelegate);
     }
 
     @Override
-    public String getSecret(GetSecretData getSecretData) {
-        if(!(getSecretData instanceof AzureGetSecretData)) {
-            throw new KeyVaultException("Incorrect data type passed to AzureKeyVaultService.  Type was " + getSecretData.getType());
-        }
-
-        AzureGetSecretData azureGetSecretData = (AzureGetSecretData) getSecretData;
-
+    public String getSecret(AzureGetSecretData azureGetSecretData) {
         SecretBundle secretBundle;
 
-        if(azureGetSecretData.getSecretVersion() != null) {
+        if (azureGetSecretData.getSecretVersion() != null) {
             secretBundle = azureKeyVaultClientDelegate.getSecret(vaultUrl, azureGetSecretData.getSecretName(), azureGetSecretData.getSecretVersion());
-        }
-        else {
+        } else {
             secretBundle = azureKeyVaultClientDelegate.getSecret(vaultUrl, azureGetSecretData.getSecretName());
         }
 
-        if(secretBundle == null) {
+        if (secretBundle == null) {
             throw new VaultSecretNotFoundException("Azure Key Vault secret " + azureGetSecretData.getSecretName() + " was not found in vault " + vaultUrl);
         }
 
@@ -50,13 +39,7 @@ public class AzureKeyVaultService implements KeyVaultService {
     }
 
     @Override
-    public Object setSecret(SetSecretData setSecretData) {
-        if(!(setSecretData instanceof AzureSetSecretData)) {
-            throw new KeyVaultException("Incorrect data type passed to AzureKeyVaultService.  Type was " + setSecretData.getType());
-        }
-
-        AzureSetSecretData azureSetSecretData = (AzureSetSecretData) setSecretData;
-
+    public Object setSecret(AzureSetSecretData azureSetSecretData) {
         SetSecretRequest setSecretRequest = new SetSecretRequest.Builder(vaultUrl, azureSetSecretData.getSecretName(), azureSetSecretData.getSecret()).build();
 
         return this.azureKeyVaultClientDelegate.setSecret(setSecretRequest);

--- a/key-vault/azure-key-vault/src/test/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultServiceTest.java
+++ b/key-vault/azure-key-vault/src/test/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultServiceTest.java
@@ -5,9 +5,6 @@ import com.microsoft.azure.keyvault.requests.SetSecretRequest;
 import com.quorum.tessera.config.AzureKeyVaultConfig;
 import com.quorum.tessera.config.vault.data.AzureGetSecretData;
 import com.quorum.tessera.config.vault.data.AzureSetSecretData;
-import com.quorum.tessera.config.vault.data.GetSecretData;
-import com.quorum.tessera.config.vault.data.SetSecretData;
-import com.quorum.tessera.key.vault.KeyVaultException;
 import com.quorum.tessera.key.vault.VaultSecretNotFoundException;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,16 +86,6 @@ public class AzureKeyVaultServiceTest {
     }
 
     @Test
-    public void getSecretThrowsExceptionIfWrongDataImplProvided() {
-        GetSecretData wrongImpl = mock(GetSecretData.class);
-
-        Throwable ex = catchThrowable(() -> keyVaultService.getSecret(wrongImpl));
-
-        assertThat(ex).isInstanceOf(KeyVaultException.class);
-        assertThat(ex.getMessage()).isEqualTo("Incorrect data type passed to AzureKeyVaultService.  Type was null");
-    }
-
-    @Test
     public void setSecret() {
         AzureSetSecretData setSecretData = mock(AzureSetSecretData.class);
         String secretName = "id";
@@ -114,15 +101,5 @@ public class AzureKeyVaultServiceTest {
         verify(azureKeyVaultClientDelegate).setSecret(argument.capture());
 
         assertThat(argument.getValue()).isEqualToComparingFieldByField(expected);
-    }
-
-    @Test
-    public void setSecretThrowsExceptionIfWrongDataImplProvided() {
-        SetSecretData wrongImpl = mock(SetSecretData.class);
-
-        Throwable ex = catchThrowable(() -> keyVaultService.setSecret(wrongImpl));
-
-        assertThat(ex).isInstanceOf(KeyVaultException.class);
-        assertThat(ex.getMessage()).isEqualTo("Incorrect data type passed to AzureKeyVaultService.  Type was null");
     }
 }

--- a/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
+++ b/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
@@ -1,10 +1,7 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
-import com.quorum.tessera.config.vault.data.GetSecretData;
 import com.quorum.tessera.config.vault.data.HashicorpGetSecretData;
 import com.quorum.tessera.config.vault.data.HashicorpSetSecretData;
-import com.quorum.tessera.config.vault.data.SetSecretData;
-import com.quorum.tessera.key.vault.KeyVaultException;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.vault.support.Versioned;
@@ -62,17 +59,6 @@ public class HashicorpKeyVaultServiceTest {
     }
 
     @Test
-    public void getSecretThrowsExceptionIfProvidedDataIsNotCorrectType() {
-        GetSecretData getSecretData = mock(GetSecretData.class);
-        when(getSecretData.getType()).thenReturn(null);
-
-        Throwable ex = catchThrowable(() -> keyVaultService.getSecret(getSecretData));
-
-        assertThat(ex).isExactlyInstanceOf(KeyVaultException.class);
-        assertThat(ex).hasMessage("Incorrect data type passed to HashicorpKeyVaultService.  Type was null");
-    }
-
-    @Test
     public void getSecretThrowsExceptionIfNullRetrievedFromVault() {
         HashicorpGetSecretData getSecretData = new HashicorpGetSecretData("engine", "secretName", "id", 0);
 
@@ -99,7 +85,6 @@ public class HashicorpKeyVaultServiceTest {
         assertThat(ex).hasMessage("No data found at engine/secretName");
     }
 
-
     @Test
     public void getSecretThrowsExceptionIfValueNotFoundForGivenId() {
         HashicorpGetSecretData getSecretData = new HashicorpGetSecretData("engine", "secretName", "id", 0);
@@ -118,19 +103,6 @@ public class HashicorpKeyVaultServiceTest {
         assertThat(ex).isExactlyInstanceOf(HashicorpVaultException.class);
         assertThat(ex).hasMessage("No value with id id found at engine/secretName");
     }
-
-
-    @Test
-    public void setSecretThrowsExceptionIfProvidedDataIsNotCorrectType() {
-        SetSecretData setSecretData = mock(SetSecretData.class);
-        when(setSecretData.getType()).thenReturn(null);
-
-        Throwable ex = catchThrowable(() -> keyVaultService.setSecret(setSecretData));
-
-        assertThat(ex).isExactlyInstanceOf(KeyVaultException.class);
-        assertThat(ex).hasMessage("Incorrect data type passed to HashicorpKeyVaultService.  Type was null");
-    }
-
 
     @Test
     public void setSecretReturnsMetadataObject() {
@@ -156,5 +128,4 @@ public class HashicorpKeyVaultServiceTest {
         assertThat(ex).isExactlyInstanceOf(HashicorpVaultException.class);
         assertThat(ex.getMessage()).isEqualTo("Unable to save generated secret to vault.  Ensure that the secret engine being used is a v2 kv secret engine");
     }
-
 }

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/KeyVaultService.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/KeyVaultService.java
@@ -3,9 +3,9 @@ package com.quorum.tessera.key.vault;
 import com.quorum.tessera.config.vault.data.GetSecretData;
 import com.quorum.tessera.config.vault.data.SetSecretData;
 
-public interface KeyVaultService {
-    String getSecret(GetSecretData getSecretData);
+public interface KeyVaultService<T extends SetSecretData, U extends GetSecretData> {
 
-    Object setSecret(SetSecretData setSecretData);
+    String getSecret(U getSecretData);
 
+    Object setSecret(T setSecretData);
 }


### PR DESCRIPTION
Adds generics for key vault services & removed the redundant tests.

Note that a type warning is now shown in `DefaultKeyGeneratorFactory.java` since the service factory doesn't have the generics implemented, although this only produces a compilation warning, not error.

Fixes #865