### PR TITLE
Replace uses of ServiceLoader with the utility method

### DIFF
--- a/argon2/pom.xml
+++ b/argon2/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>argon2-jvm</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>shared</artifactId>
+        </dependency>
+
     </dependencies>
 
 

--- a/argon2/src/main/java/com/quorum/tessera/argon2/Argon2.java
+++ b/argon2/src/main/java/com/quorum/tessera/argon2/Argon2.java
@@ -1,13 +1,8 @@
 package com.quorum.tessera.argon2;
 
-import java.util.ServiceLoader;
+import com.quorum.tessera.ServiceLoaderUtil;
 
-/**
- * Provides hashing functions using the Argon2 algorithms
- * Validation of various inputs is left to the implementor, although
- * the validation should be consistent amongst implementations.
- * (i.e. the same inputs should work for any implementation)
- */
+/** Provides hashing functions using the Argon2 class of algorithms. */
 public interface Argon2 {
 
     /**
@@ -29,8 +24,8 @@ public interface Argon2 {
      */
     ArgonResult hash(String password, byte[] salt);
 
+    // TODO: move into factory and return the stream itself
     static Argon2 create() {
-        return ServiceLoader.load(Argon2.class).iterator().next();
+        return ServiceLoaderUtil.loadAll(Argon2.class).findAny().get();
     }
-
 }

--- a/config/src/main/java/com/quorum/tessera/config/ConfigFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/ConfigFactory.java
@@ -1,17 +1,17 @@
 package com.quorum.tessera.config;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.ServiceLoader;
 
 public interface ConfigFactory {
 
     Config create(InputStream configData, List<ConfigKeyPair> newkeys);
 
     static ConfigFactory create() {
-        return ServiceLoader.load(ConfigFactory.class).iterator().next();
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(ConfigFactory.class).findAny().get();
     }
-
 }

--- a/config/src/main/java/com/quorum/tessera/config/apps/TesseraAppFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/apps/TesseraAppFactory.java
@@ -1,14 +1,14 @@
 package com.quorum.tessera.config.apps;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.AppType;
 import com.quorum.tessera.config.CommunicationType;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.ServiceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 public class TesseraAppFactory {
 
@@ -18,24 +18,19 @@ public class TesseraAppFactory {
 
     private static final TesseraAppFactory INSTANCE = new TesseraAppFactory();
 
-    public static Optional<TesseraApp> create(CommunicationType communicationType,AppType appType) {
-        return INSTANCE.createApp(communicationType,appType);
+    public static Optional<TesseraApp> create(CommunicationType communicationType, AppType appType) {
+        return INSTANCE.createApp(communicationType, appType);
     }
 
     private TesseraAppFactory() {
-        Iterator<TesseraApp> it = ServiceLoader.load(TesseraApp.class).iterator();
-        while (it.hasNext()) {
-            TesseraApp app = it.next();
-            LOGGER.info("Loaded app {}", app);
-            cache.add(app);
-        }
+        ServiceLoaderUtil.loadAll(TesseraApp.class).peek(app -> LOGGER.info("Loaded app {}", app)).forEach(cache::add);
     }
 
-    private Optional<TesseraApp> createApp(CommunicationType communicationType,AppType appType) {
-        LOGGER.info("Creating application type {} for {}", appType,communicationType);
+    private Optional<TesseraApp> createApp(CommunicationType communicationType, AppType appType) {
+        LOGGER.info("Creating application type {} for {}", appType, communicationType);
         return cache.stream()
                 .filter(a -> a.getAppType() == appType)
-                .filter(a -> a.getCommunicationType()== communicationType)
+                .filter(a -> a.getCommunicationType() == communicationType)
                 .findAny();
     }
 }

--- a/config/src/main/java/com/quorum/tessera/config/util/EnvironmentVariableProviderFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/EnvironmentVariableProviderFactory.java
@@ -1,16 +1,14 @@
 package com.quorum.tessera.config.util;
 
-import java.util.ServiceLoader;
+import com.quorum.tessera.ServiceLoaderUtil;
 
-/**
- * Exists to enable the loading of a mocked EnvironmentVariableProvider in tests
- */
+/** Exists to enable the loading of a mocked EnvironmentVariableProvider in tests */
 public interface EnvironmentVariableProviderFactory {
 
     EnvironmentVariableProvider create();
 
     static EnvironmentVariableProviderFactory load() {
-        return ServiceLoader.load(EnvironmentVariableProviderFactory.class).iterator().next();
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(EnvironmentVariableProviderFactory.class).findAny().get();
     }
-
 }

--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/EnclaveClientFactory.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/EnclaveClientFactory.java
@@ -1,8 +1,7 @@
 package com.quorum.tessera.enclave;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.Config;
-
-import java.util.ServiceLoader;
 
 /**
  * Creates clients which connect to remote instances of an enclave.
@@ -14,7 +13,7 @@ public interface EnclaveClientFactory<T extends EnclaveClient> {
     T create(Config config);
 
     static EnclaveClientFactory create() {
-        return ServiceLoader.load(EnclaveClientFactory.class).iterator().next();
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(EnclaveClientFactory.class).findAny().get();
     }
-
 }

--- a/encryption/encryption-api/pom.xml
+++ b/encryption/encryption-api/pom.xml
@@ -13,7 +13,8 @@
     </parent>
     
     <dependencies>
-        
+
+<!--        TODO: remove this as its not used-->
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>service-locator-api</artifactId>
@@ -24,6 +25,11 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>shared</artifactId>
         </dependency>
 
     </dependencies>

--- a/encryption/encryption-api/src/main/java/com/quorum/tessera/nacl/NaclFacadeFactory.java
+++ b/encryption/encryption-api/src/main/java/com/quorum/tessera/nacl/NaclFacadeFactory.java
@@ -1,11 +1,8 @@
 package com.quorum.tessera.nacl;
 
-import java.util.ServiceLoader;
+import com.quorum.tessera.ServiceLoaderUtil;
 
-/**
- * A factory for providing the implementation of the {@link NaclFacade}
- * with all its dependencies set up
- */
+/** A factory for providing the implementation of the {@link NaclFacade} with all its dependencies set up */
 public interface NaclFacadeFactory {
 
     /**
@@ -18,11 +15,10 @@ public interface NaclFacadeFactory {
     /**
      * Retrieves the implementation of the factory from the service loader
      *
-     * @return the factory implementation that will provide instances of that
-     * implementations {@link NaclFacade}
+     * @return the factory implementation that will provide instances of that implementations {@link NaclFacade}
      */
     static NaclFacadeFactory newFactory() {
-        return ServiceLoader.load(NaclFacadeFactory.class).iterator().next();
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(NaclFacadeFactory.class).findAny().get();
     }
-
 }

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/KeyVaultServiceFactory.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/KeyVaultServiceFactory.java
@@ -1,12 +1,9 @@
 package com.quorum.tessera.key.vault;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ServiceLoader;
 
 public interface KeyVaultServiceFactory {
 
@@ -15,13 +12,13 @@ public interface KeyVaultServiceFactory {
     KeyVaultType getType();
 
     static KeyVaultServiceFactory getInstance(KeyVaultType keyVaultType) {
-        List<KeyVaultServiceFactory> providers = new ArrayList<>();
-        ServiceLoader.load(KeyVaultServiceFactory.class).forEach(providers::add);
-
-        return providers.stream()
-            .filter(factory -> factory.getType() == keyVaultType)
-            .findFirst()
-            .orElseThrow(() -> new NoKeyVaultServiceFactoryException(keyVaultType + " implementation of KeyVaultServiceFactory was not found on the classpath"));
+        return ServiceLoaderUtil.loadAll(KeyVaultServiceFactory.class)
+                .filter(factory -> factory.getType() == keyVaultType)
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new NoKeyVaultServiceFactoryException(
+                                        keyVaultType
+                                                + " implementation of KeyVaultServiceFactory was not found on the classpath"));
     }
-
 }

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -20,6 +20,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>shared</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>

--- a/security/src/main/java/com/quorum/tessera/ssl/context/ClientSSLContextFactory.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/context/ClientSSLContextFactory.java
@@ -1,11 +1,11 @@
 package com.quorum.tessera.ssl.context;
 
-import java.util.ServiceLoader;
+import com.quorum.tessera.ServiceLoaderUtil;
 
 public interface ClientSSLContextFactory extends SSLContextFactory {
 
     static SSLContextFactory create() {
-        return ServiceLoader.load(ClientSSLContextFactory.class).iterator().next();
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(ClientSSLContextFactory.class).findAny().get();
     }
-
 }

--- a/security/src/main/java/com/quorum/tessera/ssl/context/ServerSSLContextFactory.java
+++ b/security/src/main/java/com/quorum/tessera/ssl/context/ServerSSLContextFactory.java
@@ -1,11 +1,11 @@
 package com.quorum.tessera.ssl.context;
 
-import java.util.ServiceLoader;
+import com.quorum.tessera.ServiceLoaderUtil;
 
 public interface ServerSSLContextFactory extends SSLContextFactory {
-    
-    static SSLContextFactory create() {
-        return ServiceLoader.load(ServerSSLContextFactory.class).iterator().next();
-    }
 
+    static SSLContextFactory create() {
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(ServerSSLContextFactory.class).findAny().get();
+    }
 }

--- a/security/src/main/resources/META-INF/services/com.quorum.tessera.config.util.EnvironmentVariableProviderFactory
+++ b/security/src/main/resources/META-INF/services/com.quorum.tessera.config.util.EnvironmentVariableProviderFactory
@@ -1,1 +1,0 @@
-com.quorum.tessera.config.util.EnvironmentVariableProviderFactoryImpl

--- a/server/server-api/pom.xml
+++ b/server/server-api/pom.xml
@@ -3,6 +3,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <name>server-api</name>
     <artifactId>server-api</artifactId>
     <packaging>jar</packaging>
 
@@ -16,9 +17,14 @@
 
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>shared</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>config</artifactId>
         </dependency>
         
     </dependencies>
-    <name>server-api</name>
+
 </project>

--- a/server/server-api/src/main/java/com/quorum/tessera/server/TesseraServerFactory.java
+++ b/server/server-api/src/main/java/com/quorum/tessera/server/TesseraServerFactory.java
@@ -1,31 +1,25 @@
 package com.quorum.tessera.server;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.CommunicationType;
 import com.quorum.tessera.config.ServerConfig;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public interface TesseraServerFactory<T> {
+import java.util.Set;
 
-    TesseraServer createServer(ServerConfig config, Set<T> services);
+public interface TesseraServerFactory<T> {
 
     Logger LOGGER = LoggerFactory.getLogger(TesseraServerFactory.class);
 
+    TesseraServer createServer(ServerConfig config, Set<T> services);
+
+    CommunicationType communicationType();
+
     static TesseraServerFactory create(CommunicationType communicationType) {
-
-        List<TesseraServerFactory> all = new ArrayList<>();
-        ServiceLoader.load(TesseraServerFactory.class).forEach(all::add);
-
-        return all.stream()
+        return ServiceLoaderUtil.loadAll(TesseraServerFactory.class)
                 .filter(f -> f.communicationType() == communicationType)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No server factory found for " + communicationType));
     }
-
-    CommunicationType communicationType();
 }

--- a/service-locator/service-locator-api/pom.xml
+++ b/service-locator/service-locator-api/pom.xml
@@ -13,5 +13,14 @@
         <artifactId>service-locator</artifactId>
         <version>0.11-SNAPSHOT</version>
     </parent>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>shared</artifactId>
+        </dependency>
+
+    </dependencies>
     
 </project>

--- a/service-locator/service-locator-api/src/main/java/com/quorum/tessera/service/locator/ServiceLocator.java
+++ b/service-locator/service-locator-api/src/main/java/com/quorum/tessera/service/locator/ServiceLocator.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.service.locator;
 
-import java.util.ServiceLoader;
+import com.quorum.tessera.ServiceLoaderUtil;
+
 import java.util.Set;
 
 /** Creates a set of services that are configured */
@@ -19,6 +20,7 @@ public interface ServiceLocator {
      * @return the {@link ServiceLocator} instance
      */
     static ServiceLocator create() {
-        return ServiceLoader.load(ServiceLocator.class).iterator().next();
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(ServiceLocator.class).findAny().get();
     }
 }

--- a/shared/src/main/java/com/quorum/tessera/ServiceLoaderUtil.java
+++ b/shared/src/main/java/com/quorum/tessera/ServiceLoaderUtil.java
@@ -1,19 +1,18 @@
 package com.quorum.tessera;
 
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public interface ServiceLoaderUtil {
 
     static <T> Optional<T> load(Class<T> type) {
-        final Iterator<T> it = ServiceLoader.load(type).iterator();
-
-        if (it.hasNext()) {
-            return Optional.of(it.next());
-        }
-
-        return Optional.empty();
+        return ServiceLoaderUtil.loadAll(type).findFirst();
     }
 
+    static <T> Stream<T> loadAll(Class<T> type) {
+        // TODO: Java 9 defines a native stream method for the service loader, use that instead
+        return StreamSupport.stream(ServiceLoader.load(type).spliterator(), false);
+    }
 }

--- a/shared/src/test/java/com/quorum/tessera/ServiceLoaderUtilTest.java
+++ b/shared/src/test/java/com/quorum/tessera/ServiceLoaderUtilTest.java
@@ -5,6 +5,7 @@ import com.acme.TestService;
 import org.junit.Test;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,4 +26,17 @@ public class ServiceLoaderUtilTest {
         assertThat(result).get().isInstanceOf(DefaultTestService.class);
     }
 
+    @Test
+    public void noServiceFoundWithStream() {
+        final Stream<ServiceLoaderUtilTest> result = ServiceLoaderUtil.loadAll(ServiceLoaderUtilTest.class);
+
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void serviceFoundWithStream() {
+        final Stream<TestService> result = ServiceLoaderUtil.loadAll(TestService.class);
+
+        assertThat(result).hasSize(1);
+    }
 }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/P2pClientFactory.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/P2pClientFactory.java
@@ -1,11 +1,8 @@
 package com.quorum.tessera.partyinfo;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.CommunicationType;
 import com.quorum.tessera.config.Config;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ServiceLoader;
 
 @Deprecated
 // TODO: Remove the p2p clint and related factories.
@@ -16,11 +13,8 @@ public interface P2pClientFactory {
     CommunicationType communicationType();
 
     static P2pClientFactory newFactory(Config config) {
-        List<P2pClientFactory> all = new ArrayList<>();
-
-        ServiceLoader.load(P2pClientFactory.class).forEach(all::add);
-
-        return all.stream()
+        // TODO: return the stream and let the caller deal with it
+        return ServiceLoaderUtil.loadAll(P2pClientFactory.class)
                 .filter(c -> c.communicationType() == config.getP2PServerConfig().getCommunicationType())
                 .findFirst()
                 .get();

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PayloadPublisherFactory.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PayloadPublisherFactory.java
@@ -1,34 +1,24 @@
-
 package com.quorum.tessera.partyinfo;
 
+import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.config.CommunicationType;
 import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.ServerConfig;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ServiceLoader;
-
 
 public interface PayloadPublisherFactory {
-    
+
     PayloadPublisher create(Config config);
 
     CommunicationType communicationType();
-    
+
     static PayloadPublisherFactory newFactory(Config config) {
-        
-        ServerConfig serverConfig = config.getP2PServerConfig();
-        List<PayloadPublisherFactory> factories = new ArrayList<>();
-        Iterator<PayloadPublisherFactory> it = ServiceLoader.load(PayloadPublisherFactory.class).iterator();
-        while(it.hasNext()) {
-            factories.add(it.next());
-        }
-        return factories.stream()
-                .filter(f -> f.communicationType() == serverConfig.getCommunicationType())
+        final CommunicationType commType = config.getP2PServerConfig().getCommunicationType();
+
+        return ServiceLoaderUtil.loadAll(PayloadPublisherFactory.class)
+                .filter(f -> f.communicationType() == commType)
                 .findAny()
-                .orElseThrow(() -> new UnsupportedOperationException("Unable to create a PayloadPublisherFactory for"+ serverConfig.getCommunicationType()));
-        
+                .orElseThrow(
+                        () ->
+                                new UnsupportedOperationException(
+                                        "Unable to create a PayloadPublisherFactory for " + commType));
     }
-    
 }


### PR DESCRIPTION
This PR replaces all the uses of ServiceLoader directly with the utility method, which returns a stream; it allows for a continuous definition instead of having a load all services and adding them to an intermediate list, which is then streamed.

This does not attempt to deal with the issues where an implementation is not present, although this is not a concern right now since all implementations are defined.

This mimics the behaviour of the Java 9 ServiceLoader, which returns a stream of services that are available.

`TODO`s are added where we want the caller to filter through the implementations it needs, instead of only expecting a single one to be available.

---

Other minor changes found:
- removed a duplicate definition of a service in the `security` package
- moves some checks for filters on services outside the stream, where it wasn't dependant on the item being streamed (e.g. see `CliDelegate.java`)

Fixes #869 