### PR TITLE
Introduce PicoCLI for parsing CLI arguments

### DIFF
--- a/cli/admin-cli/src/main/java/com/quorum/tessera/admin/cli/AdminCliAdapter.java
+++ b/cli/admin-cli/src/main/java/com/quorum/tessera/admin/cli/AdminCliAdapter.java
@@ -1,43 +1,22 @@
 package com.quorum.tessera.admin.cli;
 
+import com.quorum.tessera.admin.cli.subcommands.AddPeerCommand;
 import com.quorum.tessera.cli.CliAdapter;
 import com.quorum.tessera.cli.CliResult;
 import com.quorum.tessera.cli.CliType;
-import com.quorum.tessera.cli.parsers.ConfigurationParser;
-import com.quorum.tessera.config.AppType;
-import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.Peer;
-import com.quorum.tessera.config.ServerConfig;
-import com.quorum.tessera.jaxrs.client.ClientFactory;
-import org.apache.commons.cli.*;
+import picocli.CommandLine;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.io.PrintWriter;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.concurrent.Callable;
 
-/**
- * Cli Adapter to be used for runtime updates
- */
-public class AdminCliAdapter implements CliAdapter {
+/** Cli Adapter to be used for runtime updates */
+@CommandLine.Command(
+        exitCodeOnInvalidInput = 1,
+        name = "admin",
+        subcommands = {AddPeerCommand.class})
+public class AdminCliAdapter implements CliAdapter, Callable<CliResult> {
 
-    private final ClientFactory clientFactory;
-
-    // For service loader
-    public AdminCliAdapter() {
-        this(new ClientFactory());
-    }
-
-    public AdminCliAdapter(final ClientFactory clientFactory) {
-        this.clientFactory = Objects.requireNonNull(clientFactory);
-    }
+    @CommandLine.Option(names = "help", usageHelp = true, description = "display this help message")
+    private boolean isHelpRequested;
 
     @Override
     public CliType getType() {
@@ -45,100 +24,16 @@ public class AdminCliAdapter implements CliAdapter {
     }
 
     /**
-     *
      * @param args
      * @return CliResult with config object always null.
-     * @throws Exception
      */
     @Override
-    public CliResult execute(String... args) throws Exception {
-
-        final Options options = new Options();
-
-        options.addOption(
-                Option.builder("configfile")
-                        .desc("Path to node configuration file")
-                        .hasArg(true)
-                        .required()
-                        .optionalArg(false)
-                        .numberOfArgs(1)
-                        .argName("PATH")
-                        .build());
-
-        options.addOption(Option.builder("addpeer")
-                .desc("Add peer to running node")
-                .hasArg(true)
-                .optionalArg(false)
-                .numberOfArgs(1)
-                .argName("URL")
-                .build());
-
-        final List<String> argsList = Arrays.asList(args);
-
-        if (argsList.contains("help") || argsList.isEmpty()) {
-            HelpFormatter formatter = new HelpFormatter();
-            PrintWriter pw = new PrintWriter(sys().out());
-            formatter.printHelp(pw,
-                    200, "tessera admin",
-                    null, options, formatter.getLeftPadding(),
-                    formatter.getDescPadding(), null, false);
-            pw.flush();
-
-            return new CliResult(0, true, null);
-        }
-
-        final CommandLine line = new DefaultParser().parse(options, args);
-        if (!line.hasOption("addpeer")) {
-            sys().out().println("No peer defined");
-            return new CliResult(1, true, null);
-        }
-
-        Config config = new ConfigurationParser().parse(line);
-
-        //TODO revisit - maybe the admin stuff should be reached via unix socket - in order to avoid security concerns
-        ServerConfig serverConfig = config.getServerConfigs().stream()
-                .filter(c -> c.getApp() == AppType.ADMIN)
-                .findFirst().orElse(config.getServerConfigs().stream().findAny().get());
-
-        Client restClient = clientFactory.buildFrom(serverConfig);
-
-        String peerUrl = line.getOptionValue("addpeer");
-
-        final Peer peer = new Peer(peerUrl);
-
-        String scheme = Optional.of(serverConfig)
-                .map(ServerConfig::getBindingUri)
-                .map(URI::getScheme)
-                .orElse("http");
-
-        Integer port = Optional.of(serverConfig)
-                .map(ServerConfig::getServerUri)
-                .map(URI::getPort)
-                .orElse(80);
-
-        URI uri = UriBuilder.fromUri(serverConfig.getBindingUri())
-                .port(port)
-                .scheme(scheme)
-                .build();
-
-        Response response = restClient.target(uri)
-                .path("config")
-                .path("peers")
-                .request(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .put(Entity.entity(peer, MediaType.APPLICATION_JSON));
-
-        if (response.getStatus() == Response.Status.CREATED.getStatusCode()) {
-
-            sys().out().printf("Peer %s added.", response.getLocation());
-            sys().out().println();
-
-            return new CliResult(0, true, null);
-        }
-
-        sys().err().println("Unable to create peer");
-
-        return new CliResult(1, true, null);
+    public CliResult execute(String... args) {
+        return new CliResult(0, true, null);
     }
 
+    @Override
+    public CliResult call() {
+        return this.execute();
+    }
 }

--- a/cli/admin-cli/src/main/java/com/quorum/tessera/admin/cli/subcommands/AddPeerCommand.java
+++ b/cli/admin-cli/src/main/java/com/quorum/tessera/admin/cli/subcommands/AddPeerCommand.java
@@ -1,0 +1,112 @@
+package com.quorum.tessera.admin.cli.subcommands;
+
+import com.quorum.tessera.cli.CliResult;
+import com.quorum.tessera.cli.parsers.ConfigurationMixin;
+import com.quorum.tessera.config.AppType;
+import com.quorum.tessera.config.Peer;
+import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.io.SystemAdapter;
+import com.quorum.tessera.jaxrs.client.ClientFactory;
+import picocli.CommandLine;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static java.util.Objects.isNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@CommandLine.Command(
+        name = "addpeer",
+        aliases = {"-addpeer"},
+        headerHeading = "Usage:%n%n",
+        synopsisHeading = "%n",
+        descriptionHeading = "%nDescription:%n%n",
+        parameterListHeading = "%nParameters:%n",
+        optionListHeading = "%nOptions:%n",
+        header = "Add a new peer to the local node",
+        description =
+                "Calls the 'PUT /config/peers' API endpoint over REST to add a new peer to the local node, with which it will start exchanging network information")
+public class AddPeerCommand implements Callable<CliResult> {
+
+    @CommandLine.Option(names = "help", usageHelp = true, description = "display this help message")
+    private boolean isHelpRequested;
+
+    @CommandLine.Mixin private ConfigurationMixin configMixin;
+
+    private final SystemAdapter sys;
+
+    private final ClientFactory clientFactory;
+
+    @CommandLine.Parameters(index = "0", description = "the URL of the peer to add")
+    private String peerUrl = null;
+
+    public AddPeerCommand() {
+        this(new ClientFactory(), SystemAdapter.INSTANCE);
+    }
+
+    public AddPeerCommand(final ClientFactory clientFactory, final SystemAdapter systemAdapter) {
+        this.clientFactory = Objects.requireNonNull(clientFactory);
+        this.sys = Objects.requireNonNull(systemAdapter);
+    }
+
+    @Override
+    public CliResult call() {
+        if (isNull(configMixin) || isNull(configMixin.getConfig()) || isNull(peerUrl)) {
+            return new CliResult(1, true, null);
+        }
+
+        final List<ServerConfig> serverConfigs = configMixin.getConfig().getServerConfigs();
+
+        // TODO revisit - maybe the admin stuff should be reached via unix socket - in order to avoid security concerns
+        ServerConfig serverConfig =
+                serverConfigs.stream()
+                        .filter(c -> c.getApp() == AppType.ADMIN)
+                        .findFirst()
+                        .orElse(serverConfigs.stream().findAny().get());
+
+        Client restClient = clientFactory.buildFrom(serverConfig);
+
+        final Peer peer = new Peer(peerUrl);
+
+        String scheme = Optional.of(serverConfig).map(ServerConfig::getBindingUri).map(URI::getScheme).orElse("http");
+
+        Integer port = Optional.of(serverConfig).map(ServerConfig::getServerUri).map(URI::getPort).orElse(80);
+
+        URI uri = UriBuilder.fromUri(serverConfig.getBindingUri()).port(port).scheme(scheme).build();
+
+        Response response =
+                restClient
+                        .target(uri)
+                        .path("config")
+                        .path("peers")
+                        .request(APPLICATION_JSON)
+                        .accept(APPLICATION_JSON)
+                        .put(Entity.entity(peer, APPLICATION_JSON));
+
+        if (response.getStatus() == Response.Status.CREATED.getStatusCode()) {
+            sys.out().printf("Peer %s added.", response.getLocation());
+            sys.out().println();
+
+            return new CliResult(0, true, null);
+        }
+
+        sys.err().println("Unable to create peer");
+        return new CliResult(1, true, null);
+    }
+
+    // setters for testing
+    public void setPeerUrl(final String peerUrl) {
+        this.peerUrl = peerUrl;
+    }
+
+    public void setConfigMixin(final ConfigurationMixin configMixin) {
+        this.configMixin = configMixin;
+    }
+}

--- a/cli/admin-cli/src/test/java/com/quorum/tessera/admin/cli/AdminCliAdapterTest.java
+++ b/cli/admin-cli/src/test/java/com/quorum/tessera/admin/cli/AdminCliAdapterTest.java
@@ -2,57 +2,13 @@ package com.quorum.tessera.admin.cli;
 
 import com.quorum.tessera.cli.CliResult;
 import com.quorum.tessera.cli.CliType;
-import com.quorum.tessera.config.Peer;
-import com.quorum.tessera.config.ServerConfig;
-import com.quorum.tessera.jaxrs.client.ClientFactory;
-import com.quorum.tessera.test.util.ElUtil;
-import org.junit.Before;
 import org.junit.Test;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.net.URI;
-import java.nio.file.Path;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 public class AdminCliAdapterTest {
 
-    private AdminCliAdapter adminCliAdapter;
-
-    private ClientFactory clientFactory;
-
-    private Invocation.Builder invocationBuilder;
-
-    @Before
-    public void onSetUp() {
-
-        invocationBuilder = mock(Invocation.Builder.class);
-
-        clientFactory = mock(ClientFactory.class);
-
-        Client client = mock(Client.class);
-        WebTarget webTarget = mock(WebTarget.class);
-
-        when(client.target(any(URI.class))).thenReturn(webTarget);
-        when(webTarget.path(anyString())).thenReturn(webTarget,webTarget);
-
-        when(webTarget.request(MediaType.APPLICATION_JSON)).thenReturn(invocationBuilder);
-
-        when(invocationBuilder.accept(MediaType.APPLICATION_JSON)).thenReturn(invocationBuilder);
-
-        when(clientFactory.buildFrom(any(ServerConfig.class))).thenReturn(client);
-
-        adminCliAdapter = new AdminCliAdapter(clientFactory);
-    }
+    private AdminCliAdapter adminCliAdapter = new AdminCliAdapter();
 
     @Test
     public void getType() {
@@ -60,78 +16,20 @@ public class AdminCliAdapterTest {
     }
 
     @Test
-    public void defaultConstructor() {
-        AdminCliAdapter def = new AdminCliAdapter();
-        AdminCliAdapter arg = new AdminCliAdapter(new ClientFactory());
+    public void callIsSuccessful() {
+        final CliResult result = adminCliAdapter.call();
 
-        assertThat(def).isEqualToComparingFieldByFieldRecursively(arg);
-    }
-
-    @Test
-    public void help() throws Exception {
-        //new CliResult(0, true, false, null);
-        CliResult result = adminCliAdapter.execute("help");
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
-        assertThat(result.isSuppressStartup()).isTrue();
-    }
-
-    @Test
-    public void noArgsSameAsHelp() throws Exception {
-        CliResult result = adminCliAdapter.execute();
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
-        assertThat(result.isSuppressStartup()).isTrue();
-    }
-
-    @Test
-    public void addPeer() throws Exception {
-
-        Peer peer = new Peer("http://junit.com:8989");
-        Entity entity = Entity.entity(peer, MediaType.APPLICATION_JSON);
-
-        URI uri = UriBuilder.fromPath("/result").build();
-        when(invocationBuilder.put(entity)).thenReturn(Response.created(uri).build());
-
-        Path configFile = ElUtil.createAndPopulatePaths(getClass().getResource("/sample-config.json"));
-
-        CliResult result = adminCliAdapter.execute("-addpeer",peer.getUrl(),"-configfile",configFile.toString());
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
-        assertThat(result.isSuppressStartup()).isTrue();
-
+        assertThat(result.getConfig()).isEmpty();
         assertThat(result.getStatus()).isEqualTo(0);
-
-        verify(invocationBuilder).put(entity);
-    }
-
-    @Test
-    public void addPeerSomethingBadWentDown() throws Exception {
-
-        Peer peer = new Peer("http://junit.com:8989");
-        Entity entity = Entity.entity(peer, MediaType.APPLICATION_JSON);
-
-        URI uri = UriBuilder.fromPath("/result").build();
-        when(invocationBuilder.put(entity)).thenReturn(Response.serverError().build());
-
-        Path configFile = ElUtil.createAndPopulatePaths(getClass().getResource("/sample-config.json"));
-
-        CliResult result = adminCliAdapter.execute("-addpeer",peer.getUrl(),"-configfile",configFile.toString());
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
         assertThat(result.isSuppressStartup()).isTrue();
-
-        assertThat(result.getStatus()).isEqualTo(1);
-
-        verify(invocationBuilder).put(entity);
     }
 
     @Test
-    public void noPeerProvidedReturnsNonZeroStatus() throws Exception {
-        CliResult result = adminCliAdapter.execute("-configfile", "/path/to/file");
-        assertThat(result).isNotNull();
-        assertThat(result.getStatus()).isEqualTo(1);
-        assertThat(result.getConfig()).isNotPresent();
+    public void successfulRunGivesZeroExitCode() {
+        final CliResult result = this.adminCliAdapter.execute();
+
+        assertThat(result.getConfig()).isEmpty();
+        assertThat(result.getStatus()).isEqualTo(0);
         assertThat(result.isSuppressStartup()).isTrue();
     }
 }

--- a/cli/admin-cli/src/test/java/com/quorum/tessera/admin/cli/subcommands/AddPeerCommandTest.java
+++ b/cli/admin-cli/src/test/java/com/quorum/tessera/admin/cli/subcommands/AddPeerCommandTest.java
@@ -1,0 +1,134 @@
+package com.quorum.tessera.admin.cli.subcommands;
+
+import com.quorum.tessera.cli.CliResult;
+import com.quorum.tessera.cli.parsers.ConfigurationMixin;
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ConfigFactory;
+import com.quorum.tessera.config.Peer;
+import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.io.SystemAdapter;
+import com.quorum.tessera.jaxrs.client.ClientFactory;
+import com.quorum.tessera.test.util.ElUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class AddPeerCommandTest {
+
+    private AddPeerCommand command;
+
+    private Invocation.Builder invocationBuilder;
+
+    @Before
+    public void onSetUp() {
+        invocationBuilder = mock(Invocation.Builder.class);
+
+        final ClientFactory clientFactory = mock(ClientFactory.class);
+
+        Client client = mock(Client.class);
+        WebTarget webTarget = mock(WebTarget.class);
+
+        when(client.target(any(URI.class))).thenReturn(webTarget);
+        when(webTarget.path(anyString())).thenReturn(webTarget, webTarget);
+
+        when(webTarget.request(APPLICATION_JSON)).thenReturn(invocationBuilder);
+
+        when(invocationBuilder.accept(APPLICATION_JSON)).thenReturn(invocationBuilder);
+
+        when(clientFactory.buildFrom(any(ServerConfig.class))).thenReturn(client);
+
+        command = new AddPeerCommand(clientFactory, SystemAdapter.INSTANCE);
+    }
+
+    @Test
+    public void defaultConstructor() {
+        AddPeerCommand def = new AddPeerCommand();
+        AddPeerCommand arg = new AddPeerCommand(new ClientFactory(), SystemAdapter.INSTANCE);
+
+        assertThat(def).isEqualToComparingFieldByFieldRecursively(arg);
+    }
+
+    @Test
+    public void nullParametersReturnsFalse() {
+        // First go
+        command.setConfigMixin(null);
+        final CliResult resultOne = command.call();
+        assertThat(resultOne).isEqualToComparingFieldByField(new CliResult(1, true, null));
+
+        // Second go
+        final ConfigurationMixin configurationMixin = new ConfigurationMixin();
+        command.setConfigMixin(configurationMixin);
+        final CliResult resultTwo = command.call();
+        assertThat(resultTwo).isEqualToComparingFieldByField(new CliResult(1, true, null));
+
+        // Third go
+        final Config config = new Config();
+        configurationMixin.setConfig(config);
+        final CliResult resultThree = command.call();
+        assertThat(resultThree).isEqualToComparingFieldByField(new CliResult(1, true, null));
+    }
+
+    @Test
+    public void addPeer() throws Exception {
+        final Entity entity = Entity.entity(new Peer("http://junit.com:8989"), APPLICATION_JSON);
+
+        final URI uri = UriBuilder.fromPath("/result").build();
+        when(invocationBuilder.put(entity)).thenReturn(Response.created(uri).build());
+
+        final Path configFile = ElUtil.createAndPopulatePaths(getClass().getResource("/sample-config.json"));
+        final ConfigurationMixin mixin = new ConfigurationMixin();
+        try (InputStream in = Files.newInputStream(configFile)) {
+            final Config config = ConfigFactory.create().create(in, Collections.emptyList());
+            mixin.setConfig(config);
+        }
+
+        command.setConfigMixin(mixin);
+        command.setPeerUrl("http://junit.com:8989");
+
+        final CliResult result = command.call();
+        assertThat(result).isEqualToComparingFieldByField(new CliResult(0, true, null));
+
+        verify(invocationBuilder).put(entity);
+    }
+
+    @Test
+    public void failToAddPeerReturnsFalse() throws Exception {
+
+        Peer peer = new Peer("http://junit.com:8989");
+        Entity entity = Entity.entity(peer, APPLICATION_JSON);
+
+        when(invocationBuilder.put(entity)).thenReturn(Response.serverError().build());
+
+        final Path configFile = ElUtil.createAndPopulatePaths(getClass().getResource("/sample-config.json"));
+        final ConfigurationMixin mixin = new ConfigurationMixin();
+        try (InputStream in = Files.newInputStream(configFile)) {
+            final Config config = ConfigFactory.create().create(in, Collections.emptyList());
+            mixin.setConfig(config);
+        }
+
+        command.setConfigMixin(mixin);
+        command.setPeerUrl("http://junit.com:8989");
+
+        final CliResult result = command.call();
+        assertThat(result).isEqualToComparingFieldByField(new CliResult(1, true, null));
+
+        verify(invocationBuilder).put(entity);
+    }
+}

--- a/cli/cli-api/pom.xml
+++ b/cli/cli-api/pom.xml
@@ -9,5 +9,15 @@
 
     <artifactId>cli-api</artifactId>
 
+    <dependencies>
+
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.0.3</version>
+        </dependency>
+
+    </dependencies>
+
 
 </project>

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/CLIExceptionCapturer.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/CLIExceptionCapturer.java
@@ -1,0 +1,22 @@
+package com.quorum.tessera.cli;
+
+import picocli.CommandLine;
+
+// This method usually returns an exit code for a given exception whilst parsing and handling commandline args
+// however, we have a different system in place to do this.
+// So here a dummy exit code is returned with access to the exception thrown
+public class CLIExceptionCapturer implements CommandLine.IExecutionExceptionHandler {
+
+    private Exception thrown;
+
+    @Override
+    public int handleExecutionException(
+            final Exception ex, final CommandLine cmd, final CommandLine.ParseResult result) {
+        this.thrown = ex;
+        return 0;
+    }
+
+    public Exception getThrown() {
+        return thrown;
+    }
+}

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/CliDelegate.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/CliDelegate.java
@@ -1,10 +1,16 @@
 package com.quorum.tessera.cli;
 
 import com.quorum.tessera.ServiceLoaderUtil;
+import com.quorum.tessera.cli.parsers.ConfigConverter;
 import com.quorum.tessera.config.Config;
+import picocli.CommandLine;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static picocli.CommandLine.Model.CommandSpec.DEFAULT_COMMAND_NAME;
 
 public enum CliDelegate {
     INSTANCE;
@@ -23,18 +29,62 @@ public enum CliDelegate {
 
     public CliResult execute(String... args) throws Exception {
 
-        final boolean adminArgPresent = Arrays.asList(args).contains("admin");
+        final List<CliAdapter> adapters = ServiceLoaderUtil.loadAll(CliAdapter.class).collect(Collectors.toList());
 
-        final CliAdapter cliAdapter =
-                ServiceLoaderUtil.loadAll(CliAdapter.class)
-                        .filter(p -> adminArgPresent == (p.getType() == CliType.ADMIN))
+        // Finds the top level adapter that we want to start with. Exactly one is expected to be on the classpath.
+        final CliAdapter adapter =
+                adapters.stream()
+                        .filter(a -> a.getClass().isAnnotationPresent(CommandLine.Command.class))
+                        .filter(
+                                a ->
+                                        a.getClass()
+                                                .getAnnotation(CommandLine.Command.class)
+                                                .name()
+                                                .equals(DEFAULT_COMMAND_NAME))
                         .findFirst()
-                        .orElseThrow(
-                                () -> new CliException("No valid implementation of CliAdapter found on the classpath"));
+                        .get();
 
-        final CliResult result = cliAdapter.execute(args);
+        // The will find all the others and attach them as sub-commands. It is expected that they have defined their
+        // own hierarchy and command names.
+        final List<CliAdapter> others = new ArrayList<>(adapters);
+        others.remove(adapter);
 
-        this.config = result.getConfig().orElse(null);
+        // the mapper will give us access to the exception from the outside, if one occurred.
+        // mostly since we have an existing system, and this is a workaround
+        final CLIExceptionCapturer mapper = new CLIExceptionCapturer();
+        final CommandLine commandLine = new CommandLine(adapter);
+        others.forEach(commandLine::addSubcommand);
+
+        commandLine
+                .registerConverter(Config.class, new ConfigConverter())
+                .setSeparator(" ")
+                .setUnmatchedArgumentsAllowed(true)
+                .setExecutionExceptionHandler(mapper);
+
+        commandLine.execute(args);
+
+        // if an exception occurred, throw it to to the upper levels where it gets handled
+        if (mapper.getThrown() != null) {
+            throw mapper.getThrown();
+        }
+
+        // otherwise, set the config object (if there is one) and return
+        final CliResult result = this.getResult(commandLine.getParseResult());
+        this.config = Optional.ofNullable(result).flatMap(CliResult::getConfig).orElse(null);
         return result;
+    }
+
+    // checks all the commands thats ran for a result, and returns it, or null otherwise
+    public CliResult getResult(final CommandLine.ParseResult parseResult) {
+        if (parseResult == null) {
+            return null;
+        }
+
+        final CliResult result = parseResult.commandSpec().commandLine().getExecutionResult();
+        if (result != null) {
+            return result;
+        }
+
+        return getResult(parseResult.subcommand());
     }
 }

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/parsers/ConfigConverter.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/parsers/ConfigConverter.java
@@ -1,0 +1,30 @@
+package com.quorum.tessera.cli.parsers;
+
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ConfigFactory;
+import picocli.CommandLine;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+public class ConfigConverter implements CommandLine.ITypeConverter<Config> {
+
+    @Override
+    public Config convert(final String value) throws Exception {
+        final ConfigFactory configFactory = ConfigFactory.create();
+
+        final Path path = Paths.get(value);
+
+        if (!Files.exists(path)) {
+            throw new FileNotFoundException(String.format("%s not found.", path));
+        }
+
+        try (InputStream in = Files.newInputStream(path)) {
+            return configFactory.create(in, Collections.emptyList());
+        }
+    }
+}

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/parsers/ConfigurationMixin.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/parsers/ConfigurationMixin.java
@@ -1,0 +1,18 @@
+package com.quorum.tessera.cli.parsers;
+
+import com.quorum.tessera.config.Config;
+import picocli.CommandLine;
+
+public class ConfigurationMixin {
+
+    @CommandLine.Option(names = {"-configfile"}, description = "path to configuration file")
+    private Config config;
+
+    public void setConfig(final Config config) {
+        this.config = config;
+    }
+
+    public Config getConfig() {
+        return this.config;
+    }
+}

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/parsers/PidFileMixin.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/parsers/PidFileMixin.java
@@ -1,0 +1,48 @@
+package com.quorum.tessera.cli.parsers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
+public class PidFileMixin implements Callable<Boolean> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PidFileMixin.class);
+
+    @CommandLine.Option(names = "-pidfile", arity = "1", description = "the path to write the PID to")
+    private Path pidFilePath = null;
+
+    @Override
+    public Boolean call() throws Exception {
+        if (pidFilePath == null) {
+            return true;
+        }
+
+        if (Files.exists(pidFilePath)) {
+            LOGGER.info("File already exists {}", pidFilePath);
+        } else {
+            LOGGER.info("Created pid file {}", pidFilePath);
+        }
+
+        final String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+
+        try (OutputStream stream = Files.newOutputStream(pidFilePath, CREATE, TRUNCATE_EXISTING)) {
+            stream.write(pid.getBytes(UTF_8));
+        }
+
+        return true;
+    }
+
+    public void setPidFilePath(final Path pidFilePath) {
+        this.pidFilePath = pidFilePath;
+    }
+}

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/CLIExceptionCapturerTest.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/CLIExceptionCapturerTest.java
@@ -1,0 +1,20 @@
+package com.quorum.tessera.cli;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CLIExceptionCapturerTest {
+
+    private CLIExceptionCapturer capturer = new CLIExceptionCapturer();
+
+    @Test
+    public void exceptionIsRetrievableAfterInvocation() {
+        final Exception testException = new Exception();
+
+        final int exitCode = capturer.handleExecutionException(testException, null, null);
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(capturer.getThrown()).isSameAs(testException);
+    }
+}

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/MockSubcommandCliAdapter.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/MockSubcommandCliAdapter.java
@@ -4,14 +4,18 @@ import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
-// Static methods allow the type of the mock and the result of execute() to be set statically in tests.
-// The mock will then be retrieved by the ServiceLoader in CliDelegate.
-@CommandLine.Command
-public class MockCliAdapter implements CliAdapter, Callable<CliResult> {
+/**
+ * This is a command that is intended to not be a <main class> command, and gets attached as a subcommand to other CLI
+ * adapters.
+ */
+@CommandLine.Command(name = "some-subcommand")
+public class MockSubcommandCliAdapter implements CliAdapter, Callable<CliResult> {
 
     private static CliType t;
 
     private static CliResult r;
+
+    private static Exception exceptionToBeThrown;
 
     @picocli.CommandLine.Unmatched private String[] allParameters = new String[0];
 
@@ -21,6 +25,10 @@ public class MockCliAdapter implements CliAdapter, Callable<CliResult> {
 
     public static void setResult(CliResult result) {
         r = result;
+    }
+
+    public static void setExceptionToBeThrown(final Exception exceptionToBeThrown) {
+        MockSubcommandCliAdapter.exceptionToBeThrown = exceptionToBeThrown;
     }
 
     @Override
@@ -35,6 +43,9 @@ public class MockCliAdapter implements CliAdapter, Callable<CliResult> {
 
     @Override
     public CliResult execute(String... args) throws Exception {
+        if (exceptionToBeThrown != null) {
+            throw exceptionToBeThrown;
+        }
         return r;
     }
 }

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/ConfigurationConverterTest.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/ConfigurationConverterTest.java
@@ -1,0 +1,34 @@
+package com.quorum.tessera.cli.parsers;
+
+import com.quorum.tessera.config.Config;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+
+import static com.quorum.tessera.test.util.ElUtil.createAndPopulatePaths;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class ConfigurationConverterTest {
+
+    private ConfigConverter configConverter = new ConfigConverter();
+
+    @Test
+    public void configReadFromFile() throws Exception {
+        final Path configFile = createAndPopulatePaths(getClass().getResource("/sample-config.json"));
+
+        final Config result = configConverter.convert(configFile.toString());
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    public void configfileDoesNotExistThrowsException() {
+        final String path = "does/not/exist.config";
+
+        final Throwable throwable = catchThrowable(() -> configConverter.convert(path));
+
+        assertThat(throwable).isInstanceOf(FileNotFoundException.class).hasMessage(path + " not found.");
+    }
+}

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/ConfigurationMixinTest.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/ConfigurationMixinTest.java
@@ -1,0 +1,19 @@
+package com.quorum.tessera.cli.parsers;
+
+import com.openpojo.reflection.impl.PojoClassFactory;
+import com.openpojo.validation.ValidatorBuilder;
+import com.openpojo.validation.test.impl.GetterTester;
+import com.openpojo.validation.test.impl.SetterTester;
+import org.junit.Test;
+
+public class ConfigurationMixinTest {
+
+    @Test
+    public void pojoTest() {
+        ValidatorBuilder.create()
+                .with(new GetterTester())
+                .with(new SetterTester())
+                .build()
+                .validate(PojoClassFactory.getPojoClass(ConfigurationMixin.class));
+    }
+}

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/PidFileMixinTest.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/parsers/PidFileMixinTest.java
@@ -1,0 +1,57 @@
+package com.quorum.tessera.cli.parsers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PidFileMixinTest {
+
+    private PidFileMixin pidFileMixin;
+
+    private Path pidFile;
+
+    @Before
+    public void init() throws IOException {
+        this.pidFileMixin = new PidFileMixin();
+        this.pidFile = Files.createTempFile(UUID.randomUUID().toString(), ".tmp");
+    }
+
+    @Test
+    public void noPidFileReturnsEarly() throws Exception {
+        final boolean result = this.pidFileMixin.call();
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void fileOverwrittenIfAlreadyExists() throws Exception {
+        final byte[] message = "THIS ISNT A PID".getBytes();
+        Files.write(this.pidFile, message);
+
+        this.pidFileMixin.setPidFilePath(this.pidFile.toAbsolutePath());
+        assertThat(this.pidFile).exists();
+
+        this.pidFileMixin.call();
+
+        final byte[] filesBytes = Files.readAllBytes(this.pidFile);
+        assertThat(filesBytes).isNotEqualTo(message);
+    }
+
+    @Test
+    public void fileCreatedIfNotAlreadyExists() throws Exception {
+        Files.deleteIfExists(this.pidFile);
+
+        this.pidFileMixin.setPidFilePath(this.pidFile.toAbsolutePath());
+        assertThat(this.pidFile).doesNotExist();
+
+        this.pidFileMixin.call();
+
+        assertThat(this.pidFile).exists();
+    }
+}

--- a/cli/cli-api/src/test/resources/META-INF/services/com.quorum.tessera.cli.CliAdapter
+++ b/cli/cli-api/src/test/resources/META-INF/services/com.quorum.tessera.cli.CliAdapter
@@ -1,1 +1,2 @@
 com.quorum.tessera.cli.MockCliAdapter
+com.quorum.tessera.cli.MockSubcommandCliAdapter

--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/DefaultCliAdapterTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/DefaultCliAdapterTest.java
@@ -63,6 +63,17 @@ public class DefaultCliAdapterTest {
     }
 
     @Test
+    public void helpViaCall() throws Exception {
+        cliDelegate.setAllParameters(new String[] {"help"});
+        final CliResult result = cliDelegate.call();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getConfig()).isNotPresent();
+        assertThat(result.getStatus()).isEqualTo(0);
+        assertThat(result.isSuppressStartup()).isTrue();
+    }
+
+    @Test
     public void noArgsPrintsHelp() throws Exception {
 
         final CliResult result = cliDelegate.execute();
@@ -119,7 +130,7 @@ public class DefaultCliAdapterTest {
         Path privateKeyPath = Files.createTempFile(UUID.randomUUID().toString(), "");
 
         Files.write(privateKeyPath, Arrays.asList("SOMEDATA"));
-         Files.write(publicKeyPath, Arrays.asList("SOMEDATA"));
+        Files.write(publicKeyPath, Arrays.asList("SOMEDATA"));
 
         FilesystemKeyPair keypair = new FilesystemKeyPair(publicKeyPath, privateKeyPath);
         when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);
@@ -132,11 +143,11 @@ public class DefaultCliAdapterTest {
         Path configFilePath = ElUtil.createTempFileFromTemplate(getClass().getResource("/keygen-sample.json"), params);
 
         CliResult result = cliDelegate.execute(
-                "-keygen",
-                "-filename",
-                UUID.randomUUID().toString(),
-                "-configfile",
-                configFilePath.toString());
+            "-keygen",
+            "-filename",
+            UUID.randomUUID().toString(),
+            "-configfile",
+            configFilePath.toString());
 
         assertThat(result).isNotNull();
         assertThat(result.getStatus()).isEqualTo(0);
@@ -237,10 +248,10 @@ public class DefaultCliAdapterTest {
         Path configFile = createAndPopulatePaths(getClass().getResource("/sample-config.json"));
 
         CliResult result = cliDelegate.execute(
-                "-configfile",
-                configFile.toString(),
-                "-jdbc.username",
-                "somename"
+            "-configfile",
+            configFile.toString(),
+            "-jdbc.username",
+            "somename"
         );
 
         assertThat(result).isNotNull();
@@ -258,12 +269,12 @@ public class DefaultCliAdapterTest {
         params.put("privateKeyPath", "BOGUS.bogus");
 
         Path configFile = ElUtil.createTempFileFromTemplate(
-                getClass().getResource("/sample-config-invalidpath.json"), params);
+            getClass().getResource("/sample-config-invalidpath.json"), params);
 
         try {
             cliDelegate.execute(
-                    "-configfile",
-                    configFile.toString());
+                "-configfile",
+                configFile.toString());
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException ex) {
             assertThat(ex.getConstraintViolations())
@@ -306,10 +317,10 @@ public class DefaultCliAdapterTest {
         Path configFile = createAndPopulatePaths(getClass().getResource("/sample-config.json"));
 
         CliResult result = cliDelegate.execute(
-                "-configfile",
-                configFile.toString(),
-                "-alwaysSendTo",
-                alwaysSendToKey
+            "-configfile",
+            configFile.toString(),
+            "-alwaysSendTo",
+            alwaysSendToKey
         );
 
         assertThat(result).isNotNull();
@@ -325,20 +336,20 @@ public class DefaultCliAdapterTest {
         Path configFile = createAndPopulatePaths(getClass().getResource("/sample-config.json"));
 
         CliResult result = cliDelegate.execute(
-                "-configfile",
-                configFile.toString(),
-                "-peer.url",
-                "anotherpeer",
-                "-peer.url",
-                "yetanotherpeer"
+            "-configfile",
+            configFile.toString(),
+            "-peer.url",
+            "anotherpeer",
+            "-peer.url",
+            "yetanotherpeer"
         );
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
         assertThat(result.getConfig().get().getPeers()).hasSize(4);
         assertThat(result.getConfig().get().getPeers().stream()
-                .map(Peer::getUrl))
-                .containsExactlyInAnyOrder("anotherpeer","yetanotherpeer","http://bogus1.com","http://bogus2.com");
+            .map(Peer::getUrl))
+            .containsExactlyInAnyOrder("anotherpeer","yetanotherpeer","http://bogus1.com","http://bogus2.com");
 
     }
 
@@ -386,7 +397,7 @@ public class DefaultCliAdapterTest {
         Path privateKeyPath = Files.createTempFile(UUID.randomUUID().toString(), "");
 
         Files.write(privateKeyPath, Arrays.asList("SOMEDATA"));
-         Files.write(publicKeyPath, Arrays.asList("SOMEDATA"));
+        Files.write(publicKeyPath, Arrays.asList("SOMEDATA"));
 
         FilesystemKeyPair keypair = new FilesystemKeyPair(publicKeyPath, privateKeyPath);
         when(keyGenerator.generate(anyString(), eq(null), eq(null))).thenReturn(keypair);

--- a/enclave/enclave-server/src/main/java/com/quorum/tessera/enclave/server/EnclaveCliAdapter.java
+++ b/enclave/enclave-server/src/main/java/com/quorum/tessera/enclave/server/EnclaveCliAdapter.java
@@ -14,8 +14,12 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 
-public class EnclaveCliAdapter implements CliAdapter {
+@picocli.CommandLine.Command
+public class EnclaveCliAdapter implements CliAdapter, Callable<CliResult> {
+
+    @picocli.CommandLine.Unmatched private String[] allParameters = new String[0];
 
     private final CommandLineParser parser;
 
@@ -28,14 +32,18 @@ public class EnclaveCliAdapter implements CliAdapter {
 
     public EnclaveCliAdapter() {
         this(
-            new DefaultParser(),
-            ServiceLoaderUtil.load(KeyPasswordResolver.class).orElse(new CliKeyPasswordResolver())
-        );
+                new DefaultParser(),
+                ServiceLoaderUtil.load(KeyPasswordResolver.class).orElse(new CliKeyPasswordResolver()));
     }
 
     @Override
     public CliType getType() {
         return CliType.ENCLAVE;
+    }
+
+    @Override
+    public CliResult call() throws Exception {
+        return this.execute(allParameters);
     }
 
     @Override
@@ -85,4 +93,8 @@ public class EnclaveCliAdapter implements CliAdapter {
         }
     }
 
+    // TODO: for testing, remove if possible
+    public void setAllParameters(final String[] allParameters) {
+        this.allParameters = allParameters;
+    }
 }

--- a/enclave/enclave-server/src/test/java/com/quorum/tessera/enclave/server/EnclaveCliAdapterTest.java
+++ b/enclave/enclave-server/src/test/java/com/quorum/tessera/enclave/server/EnclaveCliAdapterTest.java
@@ -51,6 +51,16 @@ public class EnclaveCliAdapterTest {
     }
 
     @Test
+    public void helpViaCall() throws Exception {
+        enclaveCliAdapter.setAllParameters(new String[] {"help"});
+        CliResult result = enclaveCliAdapter.call();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getConfig()).isNotPresent();
+        assertThat(result.getStatus()).isEqualTo(0);
+    }
+
+    @Test
     public void withFile() throws Exception {
 
         URI uri = getClass().getResource("/sample-config.json").toURI();

--- a/tests/acceptance-test/src/test/java/admin/cmd/Utils.java
+++ b/tests/acceptance-test/src/test/java/admin/cmd/Utils.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class Utils {
 
-    private static String jarPath = System.getProperty("application.jar", "../../tessera-app/target/tessera-app-0.8-SNAPSHOT-app.jar");
+    private static String jarPath = System.getProperty("application.jar");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 
@@ -86,16 +86,16 @@ public class Utils {
 
     public static int addPeer(Party party, String url) throws IOException, InterruptedException {
 
-        List<String> args = Arrays.asList(
-                "java",
-                "-jar",
-                jarPath,
-                "-configfile",
-                party.getConfigFilePath().toAbsolutePath().toString(),
-                "admin",
-                "-addpeer",
-                url
-        );
+        List<String> args =
+                Arrays.asList(
+                        "java",
+                        "-jar",
+                        jarPath,
+                        "admin",
+                        "-addpeer",
+                        url,
+                        "-configfile",
+                        party.getConfigFilePath().toAbsolutePath().toString());
 
         LOGGER.info("exec : {}", String.join(" ", args));
         ProcessBuilder processBuilder = new ProcessBuilder(args);


### PR DESCRIPTION
Note this is only fully replaced for the Admin CLI adapter to start with.

The Enclave and Default CLI adapter can come after we are happy with it.
Until this time, there is some duplication of functionality, e.g. PID file parsing.

---

PicoCLI allows for a top level command, and then nesting commands under it.

For example, `tessera admin -addpeer <url> -configfile <path>` has 3 commands:

`tessera` - the main "top level command", given by DefaultCliAdapter
`admin` - the first subcommand, given by AdminCommand and included in the top level command.
`-addpeer` - the next subcommand, put under AddPeerAction. This one is a bit annoying, since we decided to go with combining the action and parameter in the same argument. It would have been more idiomatic to use ... addpeer -url ..., but has been kept for backwards-compatibility.
The ability to create a PID file is common functionality. It has been included in the addpeer command directly, instead of being at a common point higher up in the tree (i.e. having it apply to every subcommand automatically), because I haven't figured out yet if thats possible.
New commands can remain entirely separate, and only need to worry about themselves. A reference is added the parent command, and the library takes care about invoking it.

Below is an example of how the subcommands are laid out and routed, including some that don't exist for explanation purposes.

```
tessera (enclave or TM)
|
|
|----- admin
|        |
|        |----- -addpeer
|        |
|        |----- migrate
|        |
|        |----- deleteForKey
|
|----- -keygen
|
etc
```

Notable user differences:

help messages have more information, but are limited to the (sub)command they are displaying, instead of showing everything at once. (like git help shows all top level commands, git help add shows only the add subcommand help)

command line args are ordered to the command they are for, instead of being in any order. e.g.
`java -jar tessera.jar -configfile <path> admin -addpeer <url>`
becomes
`java -jar tessera.jar admin -addpeer <url> -configfile <path>`
so whilst this may be considered breaking, it is small and actually enforces more standard usage.

Part of https://github.com/jpmorganchase/tessera/issues/874