### PR TITLE
Acceptance tests for Azure Key Vault functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,14 +57,14 @@ jobs:
         - unzip /tmp/vault_1.0.1_linux_amd64.zip
         - export PATH=$PATH:$PWD && popd
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P akv-acceptance-tests,vault-acceptance-tests,reduce-logging -o || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1
 
     - name: "Vault Acceptance Tests Java 11"
       jdk:  oraclejdk11
       before_install: *install_hashicorp
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1
-      # TODO add akv-acceptance-tests profile when Travis is updated to use jdk 11.0.3+
+      script: mvn verify -pl tests/acceptance-test -P hashicorp-vault-acceptance-tests,reduce-logging -o || travis_terminate 1
+    # TODO use vault-acceptance-tests profile when Travis is updated to use jdk 11.0.3+
 
 #    - stage: deploy only
 #      name: "Deploy to OSSRH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,14 @@ jobs:
         - unzip /tmp/vault_1.0.1_linux_amd64.zip
         - export PATH=$PATH:$PWD && popd
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1
+      script: mvn verify -pl tests/acceptance-test -P akv-acceptance-tests,vault-acceptance-tests,reduce-logging -o || travis_terminate 1
 
     - name: "Vault Acceptance Tests Java 11"
       jdk:  oraclejdk11
       before_install: *install_hashicorp
       install: *build_no_checks
       script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1
+      # TODO add akv-acceptance-tests profile when Travis is updated to use jdk 11.0.3+
 
 #    - stage: deploy only
 #      name: "Deploy to OSSRH"

--- a/key-vault/azure-key-vault/src/main/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultClientCredentials.java
+++ b/key-vault/azure-key-vault/src/main/java/com/quorum/tessera/key/vault/azure/AzureKeyVaultClientCredentials.java
@@ -46,7 +46,7 @@ public class AzureKeyVaultClientCredentials extends KeyVaultCredentials {
             if(Objects.isNull(authenticationContext)) {
                 this.authenticationContext = new AuthenticationContext(authorization, false, executorService);
             }
-            ClientCredential credential = new ClientCredential(clientId,clientSecret);
+            ClientCredential credential = new ClientCredential(clientId, clientSecret);
 
             return authenticationContext.acquireToken(resource, credential, null).get().getAccessToken();
 

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
                 <version>0.0.10</version>
                 <configuration>
                     <basedir>${session.executionRootDirectory}</basedir>
-                    
+
                 </configuration>
                 <executions>
                     <execution>
@@ -442,7 +442,7 @@
                             <fixImports>false</fixImports>
                             <maxLineLength>120</maxLineLength>
                             <indentSize>4</indentSize>
-                            
+
                         </configuration>
                         <goals>
                             <goal>format</goal>
@@ -629,19 +629,19 @@
                 <artifactId>admin-jaxrs</artifactId>
                 <version>0.11-SNAPSHOT</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>sync-jaxrs</artifactId>
                 <version>0.11-SNAPSHOT</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>transaction-jaxrs</artifactId>
                 <version>0.11-SNAPSHOT</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>thirdparty-jaxrs</artifactId>
@@ -694,7 +694,7 @@
                 <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>tessera-data</artifactId>
                 <version>0.11-SNAPSHOT</version>
-            </dependency> 
+            </dependency>
 
 
             <dependency>
@@ -900,8 +900,8 @@
                 <version>${logback.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
-            <!-- Provided by slf4j --> 
+
+            <!-- Provided by slf4j -->
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-jcl</artifactId>
@@ -1065,7 +1065,7 @@
                 <artifactId>gson</artifactId>
                 <version>2.8.5</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
@@ -1139,7 +1139,7 @@
                 <version>${jetty.version}</version>
                 <type>jar</type>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
@@ -1298,25 +1298,25 @@
                 <artifactId>asm-commons</artifactId>
                 <version>${asm.version}</version>
             </dependency>
-        
+
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>${asm.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-util</artifactId>
                 <version>${asm.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
                 <version>${asm.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-analysis</artifactId>

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -20,34 +20,34 @@
             <classifier>${tesssra.app.classifer}</classifier>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>tessera-simple</artifactId>
             <classifier>${tesssra.app.classifer}</classifier>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>tessera-grpc-dist</artifactId>
             <classifier>${tesssra.app.classifer}</classifier>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>enclave-jaxrs</artifactId>
             <scope>test</scope>
         </dependency>
-   
+
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>enclave-jaxrs</artifactId>
             <classifier>${enclave.server.classifer}</classifier>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.jpmorgan.quorum</groupId>
             <artifactId>test-util</artifactId>
@@ -98,6 +98,13 @@
             <artifactId>tessera-partyinfo</artifactId>
             <scope>test</scope>
             <type>jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.24.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -187,7 +194,7 @@
                 <configuration>
                     <skip>false</skip>
                     <rerunFailingTestsCount>0</rerunFailingTestsCount>
-                    
+
                     <systemPropertyVariables>
                         <application.jar>${application.jar}</application.jar>
                         <jdbc.hsql.jar>${org.hsqldb:hsqldb:jar}</jdbc.hsql.jar>
@@ -210,7 +217,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>integration-test</id> 
+                        <id>integration-test</id>
                         <phase>integration-test</phase>
                         <goals>
                             <goal>integration-test</goal>
@@ -225,8 +232,8 @@
                     </execution>
                 </executions>
             </plugin>
-            
-            
+
+
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -266,6 +273,23 @@
                         <configuration>
                             <includes>
                                 <include>RunHashicorpIT</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>akv-acceptance-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>RunAzureIT</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -273,6 +273,7 @@
                         <configuration>
                             <includes>
                                 <include>RunHashicorpIT</include>
+                                <include>RunAzureIT</include>
                             </includes>
                         </configuration>
                     </plugin>
@@ -281,7 +282,24 @@
         </profile>
 
         <profile>
-            <id>akv-acceptance-tests</id>
+            <id>hashicorp-vault-acceptance-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>RunHashicorpIT</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>azure-vault-acceptance-tests</id>
             <build>
                 <plugins>
                     <plugin>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/azure/AzureStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/azure/AzureStepDefs.java
@@ -1,0 +1,431 @@
+package com.quorum.tessera.test.vault.azure;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.util.JaxbUtil;
+import com.quorum.tessera.test.util.ElUtil;
+import cucumber.api.java8.En;
+import exec.NodeExecManager;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.ws.rs.core.UriBuilder;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.quorum.tessera.config.util.EnvironmentVariables.AZURE_CLIENT_ID;
+import static com.quorum.tessera.config.util.EnvironmentVariables.AZURE_CLIENT_SECRET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AzureStepDefs implements En {
+
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+    private final AtomicReference<Process> tesseraProcess = new AtomicReference<>();
+    private final AtomicReference<WireMockServer> wireMockServer = new AtomicReference<>();
+
+    private final String publicKey = "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=";
+    private final String privateKey = "Wl+xSyXVuuqzpvznOS7dOobhcn4C5auxkFRi7yLtgtA=";
+
+    private final String authUrl = "/auth/oauth2/token";
+
+    // /secrets/{name}/{version}
+    // note: '/' must be provided at start of version arg, e.g. "/1". this is to allow urls with no version by setting
+    // version arg to "".
+    private final String urlFormat = "/secrets/%s%s";
+
+    private final String publicKeyUrl = String.format(urlFormat, "Pub", "/bvfw05z4cbu11ra2g94e43v9xxewqdq7");
+    private final String privateKeyUrl = String.format(urlFormat, "Key", "/0my1ora2dciijx5jq9gv07sauzs5wjo2");
+
+    private final String nodeAPubUrl = String.format(urlFormat, "nodeAPub", "");
+    private final String nodeAKeyUrl = String.format(urlFormat, "nodeAKey", "");
+    private final String nodeBPubUrl = String.format(urlFormat, "nodeBPub", "");
+    private final String nodeBKeyUrl = String.format(urlFormat, "nodeBKey", "");
+
+    public AzureStepDefs() {
+
+//                Before(
+//                    () -> {
+//                        // only needed when running outside of maven build process
+//                        System.setProperty(
+//                            "application.jar",
+//                            "/Users/chrishounsom/jpmc-tessera/tessera-dist/tessera-app/target/tessera-app-0.11-SNAPSHOT-app.jar");
+//                    });
+
+        After(
+                () -> {
+                    if (wireMockServer.get() != null && wireMockServer.get().isRunning()) {
+                        wireMockServer.get().stop();
+                        System.out.println("Stopped WireMockServer...");
+                    }
+
+                    if (tesseraProcess.get() != null && tesseraProcess.get().isAlive()) {
+                        tesseraProcess.get().destroy();
+                        System.out.println("Stopped Tessera node...");
+                    }
+                });
+
+        Given(
+                "^the mock AKV server has been started$",
+                () -> {
+                    final URL keystore = getClass().getResource("/certificates/localhost-with-san-keystore.jks");
+
+                    // wiremock configures an HTTP server by default.  Even though we'll only use the HTTPS server we
+                    // dynamically assign the HTTP port to ensure the default of 8080 is not used
+                    wireMockServer.set(
+                            new WireMockServer(
+                                    options()
+                                            .dynamicPort()
+                                            .dynamicHttpsPort()
+                                            .keystoreType("JKS")
+                                            .keystorePath(keystore.getFile())
+                                            .keystorePassword("testtest")
+                                            .extensions(new ResponseTemplateTransformer(false))
+                                    //                            .notifier(new ConsoleNotifier(true)) //enable to turn
+                                    // on verbose debug msgs
+                                    ));
+
+                    wireMockServer.get().start();
+                });
+
+        Given(
+                "^the mock AKV server has stubs for the endpoints used to get secrets$",
+                () -> {
+                    // --- Authentication flow for the AKV client ---
+                    // The AKV Client makes a request to GET a secret from the AKV.  If the response is 200 Success then
+                    // no authentication is required and the secret is returned to the caller.  If the response is 401
+                    // Unauthorized then the client proceeds to authenticate itself.  Any other response code results in
+                    // error being returned and termination of the GET request.
+                    // See https://docs.microsoft.com/en-us/rest/api/keyvault/getsecret/getsecret for the AKV HTTP
+                    // GetSecret API docs
+                    //
+                    // The 401 Unauthorized response will contain a WWW-Authenticate header which the AKV Client uses to
+                    // authenticate itself.
+                    // The 'authorization' component of the header provides the url of the authorization server to be
+                    // used.
+                    // The 'resource' component provides the Azure resource (i.e. key vault) to request authentication
+                    // for.
+                    //
+                    // To authenticate, the client POSTs to the {authorization}/oauth2/token endpoint, where
+                    // {authorization}
+                    // is the authorization server url provided in the WWW-Authenticate header.
+                    // See
+                    // https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#use-the-authorization-code-to-request-an-access-token
+                    // for more info.
+                    //
+                    // The WWW-Authenticate header is used in subsequent GETs to the same Azure resource to make
+                    // authentication requests immediately instead of having to first make 401 GETs.
+
+                    final String respFormat = "{ \"value\": \"%s\" }";
+
+                    final String authScenario = "AUTH";
+                    final String received401 = "RECEIVED_401";
+
+                    final String authenticateHeader =
+                            String.format(
+                                    "Bearer authorization=%s, resource=%s",
+                                    wireMockServer.get().baseUrl() + "/auth", wireMockServer.get().baseUrl());
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    get(urlPathEqualTo(publicKeyUrl))
+                                            .inScenario(authScenario)
+                                            .whenScenarioStateIs(Scenario.STARTED)
+                                            .willSetStateTo(received401)
+                                            .willReturn(
+                                                    unauthorized().withHeader("WWW-Authenticate", authenticateHeader)));
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    post(urlPathEqualTo(authUrl))
+                                            .willReturn(
+                                                    okJson(
+                                                                    "{ \"access_token\": \"my-token\", \"token_type\": \"Bearer\", \"expires_in\": \"3600\", \"expires_on\": \"1388444763\", \"resource\": \"https://resource/\", \"refresh_token\": \"some-val\", \"scope\": \"some-val\", \"id_token\": \"some-val\"}")
+                                                            .withHeader(
+                                                                    "client-request-id",
+                                                                    "{{request.headers.client-request-id}}")
+                                                            .withTransformers("response-template")));
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    get(urlPathEqualTo(publicKeyUrl))
+                                            .inScenario(authScenario)
+                                            .whenScenarioStateIs(received401)
+                                            .willReturn(okJson(String.format(respFormat, publicKey))));
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    get(urlPathEqualTo(privateKeyUrl))
+                                            .willReturn(okJson(String.format(respFormat, privateKey))));
+                });
+
+        When(
+                "^Tessera is started with the correct AKV environment variables$",
+                () -> {
+                    Map<String, Object> params = new HashMap<>();
+                    params.put("azureKeyVaultUrl", wireMockServer.get().baseUrl());
+
+                    Path tempTesseraConfig =
+                            ElUtil.createTempFileFromTemplate(
+                                    getClass().getResource("/vault/tessera-azure-config.json"), params);
+                    tempTesseraConfig.toFile().deleteOnExit();
+
+                    final String jarfile = System.getProperty("application.jar");
+
+                    final URL logbackConfigFile = NodeExecManager.class.getResource("/logback-node.xml");
+                    Path pid = Paths.get(System.getProperty("java.io.tmpdir"), "pidA.pid");
+
+                    final URL truststore = getClass().getResource("/certificates/truststore.jks");
+
+                    List<String> args =
+                            new ArrayList<>(
+                                    Arrays.asList(
+                                            "java",
+                                            // we set the truststore so that Tessera can trust the wiremock server
+                                            "-Djavax.net.ssl.trustStore=" + truststore.getFile(),
+                                            "-Djavax.net.ssl.trustStorePassword=testtest",
+                                            "-Dspring.profiles.active=disable-unixsocket",
+                                            "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
+                                            "-Ddebug=true",
+                                            "-jar",
+                                            jarfile,
+                                            "-configfile",
+                                            tempTesseraConfig.toString(),
+                                            "-pidfile",
+                                            pid.toAbsolutePath().toString(),
+                                            "-jdbc.autoCreateTables",
+                                            "true"));
+
+                    startTessera(args, tempTesseraConfig);
+                });
+
+        Then(
+                "^Tessera will retrieve the key pair from AKV$",
+                () -> {
+                    wireMockServer.get().verify(2, postRequestedFor(urlEqualTo(authUrl)));
+                    wireMockServer.get().verify(2, getRequestedFor(urlPathEqualTo(publicKeyUrl)));
+                    wireMockServer.get().verify(1, getRequestedFor(urlPathEqualTo(privateKeyUrl)));
+
+                    final URL partyInfoUrl =
+                            UriBuilder.fromUri("http://localhost").port(8080).path("partyinfo").build().toURL();
+
+                    HttpURLConnection partyInfoUrlConnection = (HttpURLConnection) partyInfoUrl.openConnection();
+                    partyInfoUrlConnection.connect();
+
+                    int partyInfoResponseCode = partyInfoUrlConnection.getResponseCode();
+                    assertThat(partyInfoResponseCode).isEqualTo(HttpURLConnection.HTTP_OK);
+
+                    JsonReader jsonReader = Json.createReader(partyInfoUrlConnection.getInputStream());
+
+                    JsonObject partyInfoObject = jsonReader.readObject();
+
+                    assertThat(partyInfoObject).isNotNull();
+                    assertThat(partyInfoObject.getJsonArray("keys")).hasSize(1);
+                    assertThat(partyInfoObject.getJsonArray("keys").getJsonObject(0).getString("key"))
+                            .isEqualTo(publicKey);
+                });
+
+        Given(
+                "^the mock AKV server has stubs for the endpoints used to store secrets$",
+                () -> {
+                    final String authScenario = "AUTH";
+                    final String received401 = "RECEIVED_401";
+
+                    final String authenticateHeader =
+                            String.format(
+                                    "Bearer authorization=%s, resource=%s",
+                                    wireMockServer.get().baseUrl() + "/auth", wireMockServer.get().baseUrl());
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    put(urlPathEqualTo(nodeAPubUrl))
+                                            .inScenario(authScenario)
+                                            .whenScenarioStateIs(Scenario.STARTED)
+                                            .willSetStateTo(received401)
+                                            .willReturn(
+                                                    unauthorized().withHeader("WWW-Authenticate", authenticateHeader)));
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    post(urlPathEqualTo(authUrl))
+                                            .willReturn(
+                                                    okJson(
+                                                                    "{ \"access_token\": \"my-token\", \"token_type\": \"Bearer\", \"expires_in\": \"3600\", \"expires_on\": \"1388444763\", \"resource\": \"https://resource/\", \"refresh_token\": \"some-val\", \"scope\": \"some-val\", \"id_token\": \"some-val\"}")
+                                                            .withHeader(
+                                                                    "client-request-id",
+                                                                    "{{request.headers.client-request-id}}")
+                                                            .withTransformers("response-template")));
+
+                    wireMockServer
+                            .get()
+                            .stubFor(
+                                    put(urlPathEqualTo(nodeAPubUrl))
+                                            .inScenario(authScenario)
+                                            .whenScenarioStateIs(received401)
+                                            .willReturn(ok()));
+
+                    wireMockServer.get().stubFor(put(urlPathEqualTo(nodeAKeyUrl)).willReturn(ok()));
+                    wireMockServer.get().stubFor(put(urlPathEqualTo(nodeBPubUrl)).willReturn(ok()));
+                    wireMockServer.get().stubFor(put(urlPathEqualTo(nodeBKeyUrl)).willReturn(ok()));
+                });
+
+        When(
+                "^Tessera keygen is run with the following CLI args and AKV environment variables$",
+                (String cliArgs) -> {
+                    Map<String, Object> params = new HashMap<>();
+                    params.put("azureKeyVaultUrl", wireMockServer.get().baseUrl());
+
+                    Path tempTesseraConfig =
+                            ElUtil.createTempFileFromTemplate(
+                                    getClass().getResource("/vault/tessera-azure-config.json"), params);
+                    tempTesseraConfig.toFile().deleteOnExit();
+
+                    final String jarfile = System.getProperty("application.jar");
+
+                    final URL logbackConfigFile = NodeExecManager.class.getResource("/logback-test.xml");
+
+                    final URL truststore = getClass().getResource("/certificates/truststore.jks");
+
+                    String formattedArgs = String.format(cliArgs, wireMockServer.get().baseUrl());
+
+                    List<String> args = new ArrayList<>();
+                    args.addAll(
+                            Arrays.asList(
+                                    "java",
+                                    // we set the truststore so that Tessera can trust the wiremock server
+                                    "-Djavax.net.ssl.trustStore=" + truststore.getFile(),
+                                    "-Djavax.net.ssl.trustStorePassword=testtest",
+                                    "-Dspring.profiles.active=disable-unixsocket",
+                                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
+                                    "-Ddebug=true",
+                                    "-jar",
+                                    jarfile));
+                    args.addAll(Arrays.asList(formattedArgs.split(" ")));
+
+                    startTessera(args, null); // node is not started during keygen so do not want to verify
+                });
+
+        Then(
+                "^key pairs nodeA and nodeB will have been added to the AKV$",
+                () -> {
+                    // nodeAPub is the first key to be PUT so request 1 returns 401 and request 2 is done after auth
+                    wireMockServer.get().verify(2, putRequestedFor(urlPathEqualTo(nodeAPubUrl)));
+                    // the nodeAPub 401 response is cached by the client so auth is automatically attempted before the
+                    // other PUTs
+                    wireMockServer.get().verify(1, putRequestedFor(urlPathEqualTo(nodeAKeyUrl)));
+                    wireMockServer.get().verify(1, putRequestedFor(urlPathEqualTo(nodeBPubUrl)));
+                    wireMockServer.get().verify(1, putRequestedFor(urlPathEqualTo(nodeBKeyUrl)));
+                    // each PUT url (nodeAPub, nodeAKey, nodeBPub, nodeBKey) is authenticated
+                    wireMockServer.get().verify(4, postRequestedFor(urlEqualTo(authUrl)));
+                });
+    }
+
+    private void startTessera(List<String> args, Path verifyConfig) throws Exception {
+        System.out.println(String.join(" ", args));
+
+        ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
+
+        Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
+        tesseraEnvironment.put(AZURE_CLIENT_ID, "my-client-id");
+        tesseraEnvironment.put(AZURE_CLIENT_SECRET, "my-client-secret");
+
+        try {
+            tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());
+        } catch (NullPointerException ex) {
+            throw new NullPointerException("Check that application.jar property has been set");
+        }
+
+        executorService.submit(
+                () -> {
+                    try (BufferedReader reader =
+                            Stream.of(tesseraProcess.get().getInputStream())
+                                    .map(InputStreamReader::new)
+                                    .map(BufferedReader::new)
+                                    .findAny()
+                                    .get()) {
+
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            System.out.println(line);
+                        }
+
+                    } catch (IOException ex) {
+                        throw new UncheckedIOException(ex);
+                    }
+                });
+
+        CountDownLatch startUpLatch = new CountDownLatch(1);
+
+        if (Objects.nonNull(verifyConfig)) {
+            final Config config = JaxbUtil.unmarshal(Files.newInputStream(verifyConfig), Config.class);
+
+            final URL bindingUrl =
+                    UriBuilder.fromUri(config.getP2PServerConfig().getBindingUri()).path("upcheck").build().toURL();
+
+            executorService.submit(
+                    () -> {
+                        while (true) {
+                            try {
+                                HttpURLConnection conn = (HttpURLConnection) bindingUrl.openConnection();
+                                conn.connect();
+
+                                System.out.println(bindingUrl + " started." + conn.getResponseCode());
+
+                                startUpLatch.countDown();
+                                return;
+                            } catch (IOException ex) {
+                                try {
+                                    TimeUnit.MILLISECONDS.sleep(200L);
+                                } catch (InterruptedException ex1) {
+                                }
+                            }
+                        }
+                    });
+
+            boolean started = startUpLatch.await(30, TimeUnit.SECONDS);
+
+            if (!started) {
+                System.err.println(bindingUrl + " Not started. ");
+            }
+        }
+
+        executorService.submit(
+                () -> {
+                    try {
+                        int exitCode = tesseraProcess.get().waitFor();
+                        startUpLatch.countDown();
+                        if (0 != exitCode) {
+                            System.err.println("Tessera node exited with code " + exitCode);
+                        }
+                    } catch (InterruptedException ex) {
+                        ex.printStackTrace();
+                    }
+                });
+
+        startUpLatch.await(30, TimeUnit.SECONDS);
+    }
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/azure/RunAzureIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/azure/RunAzureIT.java
@@ -1,0 +1,11 @@
+package com.quorum.tessera.test.vault.azure;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = "classpath:features/vault/azure.feature",
+        plugin = {"pretty"})
+public class RunAzureIT {}

--- a/tests/acceptance-test/src/test/resources/features/vault/azure.feature
+++ b/tests/acceptance-test/src/test/resources/features/vault/azure.feature
@@ -1,0 +1,18 @@
+Feature: Azure Key Vault support
+    Storing and retrieving Tessera public/private key pairs from an Azure Key Vault
+
+    Background:
+        Given the mock AKV server has been started
+
+    Scenario: Tessera authenticates with AKV and retrieves a key pair
+        Given the mock AKV server has stubs for the endpoints used to get secrets
+        When Tessera is started with the correct AKV environment variables
+        Then Tessera will retrieve the key pair from AKV
+
+    Scenario: Tessera generates and stores multiple keypairs in AKV
+        Given the mock AKV server has stubs for the endpoints used to store secrets
+        When Tessera keygen is run with the following CLI args and AKV environment variables
+            """
+            -keygen -keygenvaulttype AZURE -keygenvaulturl %s -filename nodeA,nodeB
+            """
+        Then key pairs nodeA and nodeB will have been added to the AKV

--- a/tests/acceptance-test/src/test/resources/vault/tessera-azure-config.json
+++ b/tests/acceptance-test/src/test/resources/vault/tessera-azure-config.json
@@ -1,0 +1,42 @@
+{
+    "useWhiteList": false,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:./target/h2/rest1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9090"
+    },
+    "serverConfigs": [
+        {
+            "app": "Q2T",
+            "enabled": true,
+            "serverAddress": "http://localhost:18080",
+            "communicationType": "REST"
+        },
+        {
+            "app": "P2P",
+            "enabled": true,
+            "serverAddress": "http://localhost:8080",
+            "communicationType": "REST"
+        }
+    ],
+    "peer": [
+        {
+            "url": "http://localhost:8081/"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "azureKeyVaultConfig": {
+            "url": "${azureKeyVaultUrl}"
+        },
+        "keyData": [
+            {
+                "azureVaultPrivateKeyId": "Key",
+                "azureVaultPublicKeyId": "Pub",
+                "azureVaultPublicKeyVersion": "bvfw05z4cbu11ra2g94e43v9xxewqdq7",
+                "azureVaultPrivateKeyVersion": "0my1ora2dciijx5jq9gv07sauzs5wjo2"
+            }
+        ]
+    },
+    "alwaysSendTo": []
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <parent>
         <artifactId>tessera</artifactId>
         <groupId>com.jpmorgan.quorum</groupId>
         <version>0.11-SNAPSHOT</version>
     </parent>
-    
+
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tests</artifactId>
@@ -43,7 +43,7 @@
                 <version>0.11-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>tessera-grpc-dist</artifactId>
@@ -51,12 +51,33 @@
                 <version>0.11-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>enclave-jaxrs</artifactId>
                 <classifier>${enclave.server.classifer}</classifier>
                 <version>0.11-SNAPSHOT</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Resolves #877 

Add tests for the retrieval of existing keys and storage of generated keys in an Azure Key Vault.  

Uses [WireMock](http://wiremock.org/docs/) to create a mock HTTPS server instead of an actual AKV server.

These tests are currently only run for `jdk8`.  See #880 for more info.

(Note: the versions of `jetty-http`, `jetty-continuation` and `jetty-io` dependencies have been explicitly defined in the acceptance test pom to resolve dependency convergence issues introduced by adding wiremock)