### PR TITLE
Use latest version of Hashicorp Vault in acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ jobs:
     - name: "Vault Acceptance Tests Java 8"
       jdk:  oraclejdk8
       before_install: &install_hashicorp
-        - wget https://releases.hashicorp.com/vault/1.0.1/vault_1.0.1_linux_amd64.zip -O /tmp/vault_1.0.1_linux_amd64.zip
+        - wget https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip -O /tmp/vault_1.2.2_linux_amd64.zip
         - mkdir -p vault/bin && pushd $_
-        - unzip /tmp/vault_1.0.1_linux_amd64.zip
+        - unzip /tmp/vault_1.2.2_linux_amd64.zip
         - export PATH=$PATH:$PWD && popd
       install: *build_no_checks
       script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/hashicorp/HashicorpStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/hashicorp/HashicorpStepDefs.java
@@ -4,9 +4,9 @@ import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.HashicorpKeyVaultConfig;
 import com.quorum.tessera.config.keypairs.HashicorpVaultKeyPair;
 import com.quorum.tessera.config.util.JaxbUtil;
-import exec.NodeExecManager;
 import com.quorum.tessera.test.util.ElUtil;
 import cucumber.api.java8.En;
+import exec.NodeExecManager;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -38,9 +38,11 @@ public class HashicorpStepDefs implements En {
     private String vaultToken;
 
     private String unsealKey;
-    
+
+    private final String secretEngineName = "kv";
+
     private String approleRoleId;
-    
+
     private String approleSecretId;
 
     private Path tempTesseraConfig;
@@ -49,551 +51,619 @@ public class HashicorpStepDefs implements En {
         final AtomicReference<Process> vaultServerProcess = new AtomicReference<>();
         final AtomicReference<Process> tesseraProcess = new AtomicReference<>();
 
-        Before(() -> {
-            //only needed when running outside of maven build process
-//            System.setProperty("application.jar", "/Users/yourname/jpmc-tessera/tessera-app/target/tessera-app-0.9-SNAPSHOT-app.jar");
+        Before(
+                () -> {
+                    // only needed when running outside of maven build process
+                    //            System.setProperty("application.jar",
+                    // "/Users/yourname/jpmc-tessera/tessera-app/target/tessera-app-0.11-SNAPSHOT-app.jar");
 
-            tempTesseraConfig = null;
-        });
+                    tempTesseraConfig = null;
+                });
 
-        Given("^the vault server has been started with TLS-enabled$", () -> {
-            Path vaultDir = Files.createDirectories(Paths.get("target/temp/" + UUID.randomUUID().toString() + "/vault"));
+        Given(
+                "^the vault server has been started with TLS-enabled$",
+                () -> {
+                    Path vaultDir =
+                            Files.createDirectories(
+                                    Paths.get("target/temp/" + UUID.randomUUID().toString() + "/vault"));
 
-            Map<String, Object> params = new HashMap<>();
-            params.put("vaultPath", vaultDir.toString());
-            params.put("vaultCert", getServerTlsCert());
-            params.put("vaultKey", getServerTlsKey());
-            params.put("clientCert", getClientCaTlsCert());
+                    Map<String, Object> params = new HashMap<>();
+                    params.put("vaultPath", vaultDir.toString());
+                    params.put("vaultCert", getServerTlsCert());
+                    params.put("vaultKey", getServerTlsKey());
+                    params.put("clientCert", getClientCaTlsCert());
 
-            Path configFile = ElUtil.createTempFileFromTemplate(getClass().getResource("/vault/hashicorp-tls-config.hcl"), params);
+                    Path configFile =
+                            ElUtil.createTempFileFromTemplate(
+                                    getClass().getResource("/vault/hashicorp-tls-config.hcl"), params);
 
-            List<String> args = Arrays.asList(
-                "vault",
-                "server",
-                "-config=" + configFile.toString()
-            );
-            System.out.println(String.join(" ", args));
+                    List<String> args = Arrays.asList("vault", "server", "-config=" + configFile.toString());
+                    System.out.println(String.join(" ", args));
 
-            ProcessBuilder vaultServerProcessBuilder = new ProcessBuilder(args);
+                    ProcessBuilder vaultServerProcessBuilder = new ProcessBuilder(args);
 
-            vaultServerProcess.set(
-                vaultServerProcessBuilder.redirectErrorStream(true)
-                    .start()
-            );
+                    vaultServerProcess.set(vaultServerProcessBuilder.redirectErrorStream(true).start());
 
-            AtomicBoolean isAddressAlreadyInUse = new AtomicBoolean(false);
+                    AtomicBoolean isAddressAlreadyInUse = new AtomicBoolean(false);
 
-            executorService.submit(() -> {
-                try(BufferedReader reader = Stream.of(vaultServerProcess.get().getInputStream())
-                    .map(InputStreamReader::new)
-                    .map(BufferedReader::new)
-                    .findAny().get()) {
+                    executorService.submit(
+                            () -> {
+                                try (BufferedReader reader =
+                                        Stream.of(vaultServerProcess.get().getInputStream())
+                                                .map(InputStreamReader::new)
+                                                .map(BufferedReader::new)
+                                                .findAny()
+                                                .get()) {
 
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        System.out.println(line);
-                        if(line.matches("^Error.+address already in use")) {
-                            isAddressAlreadyInUse.set(true);
-                        }
+                                    String line;
+                                    while ((line = reader.readLine()) != null) {
+                                        System.out.println(line);
+                                        if (line.matches("^Error.+address already in use")) {
+                                            isAddressAlreadyInUse.set(true);
+                                        }
+                                    }
+
+                                } catch (IOException ex) {
+                                    throw new UncheckedIOException(ex);
+                                }
+                            });
+
+                    // wait so that assertion is not evaluated before output is checked
+                    CountDownLatch startUpLatch = new CountDownLatch(1);
+                    startUpLatch.await(5, TimeUnit.SECONDS);
+
+                    assertThat(isAddressAlreadyInUse).isFalse();
+
+                    setKeyStoreProperties();
+
+                    // Initialise the vault
+                    final URL initUrl =
+                            UriBuilder.fromUri("https://localhost:8200").path("v1/sys/init").build().toURL();
+                    HttpsURLConnection initUrlConnection = (HttpsURLConnection) initUrl.openConnection();
+
+                    initUrlConnection.setDoOutput(true);
+                    initUrlConnection.setRequestMethod("PUT");
+
+                    String initData = "{\"secret_shares\": 1, \"secret_threshold\": 1}";
+
+                    try (OutputStreamWriter writer = new OutputStreamWriter(initUrlConnection.getOutputStream())) {
+                        writer.write(initData);
                     }
 
-                } catch (IOException ex) {
-                    throw new UncheckedIOException(ex);
-                }
-            });
+                    initUrlConnection.connect();
+                    assertThat(initUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
 
-            // wait so that assertion is not evaluated before output is checked
-            CountDownLatch startUpLatch = new CountDownLatch(1);
-            startUpLatch.await(5, TimeUnit.SECONDS);
+                    JsonReader initResponseReader = Json.createReader(initUrlConnection.getInputStream());
 
-            assertThat(isAddressAlreadyInUse).isFalse();
+                    JsonObject initResponse = initResponseReader.readObject();
 
-            setKeyStoreProperties();
+                    assertThat(initResponse.getString("root_token")).isNotEmpty();
+                    vaultToken = initResponse.getString("root_token");
 
-            //Initialise the vault
-            final URL initUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/sys/init").build().toURL();
-            HttpsURLConnection initUrlConnection = (HttpsURLConnection) initUrl.openConnection();
+                    assertThat(initResponse.getJsonArray("keys_base64").size()).isEqualTo(1);
+                    assertThat(initResponse.getJsonArray("keys_base64").get(0).toString()).isNotEmpty();
+                    String quotedUnsealKey = initResponse.getJsonArray("keys_base64").get(0).toString();
 
-            initUrlConnection.setDoOutput(true);
-            initUrlConnection.setRequestMethod("PUT");
-
-            String initData = "{\"secret_shares\": 1, \"secret_threshold\": 1}";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(initUrlConnection.getOutputStream())) {
-                writer.write(initData);
-            }
-
-            initUrlConnection.connect();
-            assertThat(initUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-
-            JsonReader initResponseReader = Json.createReader(initUrlConnection.getInputStream());
-
-            JsonObject initResponse = initResponseReader.readObject();
-
-            assertThat(initResponse.getString("root_token")).isNotEmpty();
-            vaultToken = initResponse.getString("root_token");
-
-            assertThat(initResponse.getJsonArray("keys_base64").size()).isEqualTo(1);
-            assertThat(initResponse.getJsonArray("keys_base64").get(0).toString()).isNotEmpty();
-            String quotedUnsealKey = initResponse.getJsonArray("keys_base64").get(0).toString();
-
-            if('\"' == quotedUnsealKey.charAt(0) && '\"' == quotedUnsealKey.charAt(quotedUnsealKey.length() - 1)) {
-                unsealKey = quotedUnsealKey.substring(1, quotedUnsealKey.length() - 1);
-            }
-
-            //Unseal the vault
-            final URL unsealUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/sys/unseal").build().toURL();
-            HttpsURLConnection unsealUrlConnection = (HttpsURLConnection) unsealUrl.openConnection();
-
-            unsealUrlConnection.setDoOutput(true);
-            unsealUrlConnection.setRequestMethod("PUT");
-
-            String unsealData = "{\"key\": \"" + unsealKey + "\"}";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(unsealUrlConnection.getOutputStream())) {
-                writer.write(unsealData);
-            }
-
-            unsealUrlConnection.connect();
-            assertThat(unsealUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-        });
-
-        Given("the vault is initialised and unsealed", () -> {
-            final URL initUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/sys/health").build().toURL();
-            HttpsURLConnection initUrlConnection = (HttpsURLConnection) initUrl.openConnection();
-            initUrlConnection.connect();
-
-            // See https://www.vaultproject.io/api/system/health.html for info on response codes for this endpoint
-            assertThat(initUrlConnection.getResponseCode()).as("check vault is initialized").isNotEqualTo(HttpsURLConnection.HTTP_NOT_IMPLEMENTED);
-            assertThat(initUrlConnection.getResponseCode()).as("check vault is unsealed").isNotEqualTo(503);
-            assertThat(initUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-        });
-
-        Given("the vault has a v2 kv secret engine", () -> {
-            setKeyStoreProperties();
-
-            //Upgrade secret to v2
-            final URL upgradeSecretUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/sys/mounts/secret/tune").build().toURL();
-            HttpsURLConnection upgradeSecretUrlConnection = (HttpsURLConnection) upgradeSecretUrl.openConnection();
-
-            upgradeSecretUrlConnection.setDoOutput(true);
-            upgradeSecretUrlConnection.setRequestMethod("POST");
-            upgradeSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            String upgradeSecretData = "{\"options\": {\"version\": \"2\"}}";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(upgradeSecretUrlConnection.getOutputStream())) {
-                writer.write(upgradeSecretData);
-            }
-
-            upgradeSecretUrlConnection.connect();
-            assertThat(upgradeSecretUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-        });
-
-        Given("^the AppRole auth method is enabled at (?:the|a) (default|custom) path$", (String approleType) -> {
-
-            setKeyStoreProperties();
-
-            String approlePath;
-
-            if("default".equals(approleType)) {
-                approlePath = "approle";
-            } else {
-                approlePath = "different-approle";
-            }
-
-            //Enable approle authentication
-            final URL enableApproleUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/sys/auth/" + approlePath).build().toURL();
-            HttpsURLConnection enableApproleUrlConnection = (HttpsURLConnection) enableApproleUrl.openConnection();
-
-            enableApproleUrlConnection.setDoOutput(true);
-            enableApproleUrlConnection.setRequestMethod("POST");
-            enableApproleUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            String enableApproleData = "{\"type\": \"approle\"}";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(enableApproleUrlConnection.getOutputStream())) {
-                writer.write(enableApproleData);
-            }
-
-            enableApproleUrlConnection.connect();
-            assertThat(enableApproleUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
-
-            //Create a policy and assign to a new approle
-            final URL createPolicyUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/sys/policy/simple-policy").build().toURL();
-            HttpsURLConnection createPolicyUrlConnection = (HttpsURLConnection) createPolicyUrl.openConnection();
-
-            createPolicyUrlConnection.setDoOutput(true);
-            createPolicyUrlConnection.setRequestMethod("POST");
-            createPolicyUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            String createPolicyData = "{ \"policy\": \"path \\\"secret/data/tessera*\\\" { capabilities = [\\\"create\\\", \\\"update\\\", \\\"read\\\"]}\" }";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(createPolicyUrlConnection.getOutputStream())) {
-                writer.write(createPolicyData);
-            }
-
-            createPolicyUrlConnection.connect();
-            assertThat(createPolicyUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
-
-            final URL createApproleUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/auth/" + approlePath + "/role/simple-role").build().toURL();
-            HttpsURLConnection createApproleUrlConnection = (HttpsURLConnection) createApproleUrl.openConnection();
-
-            createApproleUrlConnection.setDoOutput(true);
-            createApproleUrlConnection.setRequestMethod("POST");
-            createApproleUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            String createApproleData = "{ \"policies\": [\"simple-policy\"] }";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(createApproleUrlConnection.getOutputStream())) {
-                writer.write(createApproleData);
-            }
-
-            createApproleUrlConnection.connect();
-            assertThat(createApproleUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
-
-            //Retrieve approle credentials
-            final URL getRoleIdUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/auth/" + approlePath + "/role/simple-role/role-id").build().toURL();
-            HttpsURLConnection getRoleIdUrlConnection = (HttpsURLConnection) getRoleIdUrl.openConnection();
-
-            getRoleIdUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            getRoleIdUrlConnection.connect();
-            assertThat(getRoleIdUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-
-            JsonReader jsonReader = Json.createReader(getRoleIdUrlConnection.getInputStream());
-            JsonObject getRoleIdObject = jsonReader.readObject().getJsonObject("data");
-
-            assertThat(getRoleIdObject.getString("role_id")).isNotEmpty();
-            approleRoleId = getRoleIdObject.getString("role_id");
-
-            final URL createSecretIdUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/auth/" + approlePath + "/role/simple-role/secret-id").build().toURL();
-            HttpsURLConnection createSecretIdUrlConnection = (HttpsURLConnection) createSecretIdUrl.openConnection();
-
-            createSecretIdUrlConnection.setRequestMethod("POST");
-            createSecretIdUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            createSecretIdUrlConnection.connect();
-            assertThat(createSecretIdUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-
-            JsonReader anotherJsonReader = Json.createReader(createSecretIdUrlConnection.getInputStream());
-            JsonObject createSecretIdObject = anotherJsonReader.readObject().getJsonObject("data");
-
-            assertThat(createSecretIdObject.getString("secret_id")).isNotEmpty();
-            approleSecretId = createSecretIdObject.getString("secret_id");
-
-            createTempTesseraConfigWithApprole(approlePath);
-        });
-
-        Given("the vault contains a key pair", () -> {
-            Objects.requireNonNull(vaultToken);
-
-            setKeyStoreProperties();
-
-            //Set secret data
-            final URL setSecretUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/secret/data/tessera").build().toURL();
-            HttpsURLConnection setSecretUrlConnection = (HttpsURLConnection) setSecretUrl.openConnection();
-
-            setSecretUrlConnection.setDoOutput(true);
-            setSecretUrlConnection.setRequestMethod("POST");
-            setSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-
-            String setSecretData = "{\"data\": {\"publicKey\": \"/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\", \"privateKey\": \"yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=\"}}";
-
-            try(OutputStreamWriter writer = new OutputStreamWriter(setSecretUrlConnection.getOutputStream())) {
-                writer.write(setSecretData);
-            }
-
-            setSecretUrlConnection.connect();
-            assertThat(setSecretUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-
-            final URL getSecretUrl = UriBuilder.fromUri("https://localhost:8200").path("v1/secret/data/tessera").build().toURL();
-            HttpsURLConnection getSecretUrlConnection = (HttpsURLConnection) getSecretUrl.openConnection();
-            getSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-
-            getSecretUrlConnection.connect();
-            assertThat(getSecretUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
-
-            JsonReader jsonReader = Json.createReader(getSecretUrlConnection.getInputStream());
-
-            JsonObject getSecretObject = jsonReader.readObject();
-            JsonObject keyDataObject = getSecretObject.getJsonObject("data").getJsonObject("data");
-            assertThat(keyDataObject.getString("publicKey")).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-            assertThat(keyDataObject.getString("privateKey")).isEqualTo("yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=");
-        });
-
-        Given("^the configfile contains the correct vault configuration(| and custom approle configuration)", (String isCustomApprole) -> {
-            createTempTesseraConfig();
-
-            final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
-
-            HashicorpKeyVaultConfig expectedVaultConfig = new HashicorpKeyVaultConfig();
-            expectedVaultConfig.setUrl("https://localhost:8200");
-            expectedVaultConfig.setTlsKeyStorePath(Paths.get(getClientTlsKeystore()));
-            expectedVaultConfig.setTlsTrustStorePath(Paths.get(getClientTlsTruststore()));
-
-            if(!isCustomApprole.isEmpty()) {
-                expectedVaultConfig.setApprolePath("different-approle");
-            }
-
-            assertThat(config.getKeys().getHashicorpKeyVaultConfig()).isEqualToComparingFieldByField(expectedVaultConfig);
-        });
-
-        Given("the configfile contains the correct key data", () -> {
-            createTempTesseraConfig();
-
-            final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
-
-            HashicorpVaultKeyPair expectedKeyData = new HashicorpVaultKeyPair("publicKey", "privateKey", "secret", "tessera", null);
-
-            assertThat(config.getKeys().getKeyData().size()).isEqualTo(1);
-            assertThat(config.getKeys().getKeyData().get(0)).isEqualToComparingFieldByField(expectedKeyData);
-        });
-
-        When("^Tessera is started with the following CLI args and (token|approle) environment variables*$", (String authMethod, String cliArgs) -> {
-            final String jarfile = System.getProperty("application.jar");
-
-            final URL logbackConfigFile = NodeExecManager.class.getResource("/logback-node.xml");
-            Path pid = Paths.get(System.getProperty("java.io.tmpdir"), "pidA.pid");
-
-            String formattedArgs = String.format(cliArgs, tempTesseraConfig.toString(), pid.toAbsolutePath().toString());
-
-            List<String> args = new ArrayList<>();
-            args.addAll(
-                Arrays.asList(
-                    "java",
-                    "-Dspring.profiles.active=disable-unixsocket",
-                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
-                    "-Ddebug=true",
-                    "-jar",
-                    jarfile
-                )
-            );
-            args.addAll(Arrays.asList(formattedArgs.split(" ")));
-            System.out.println(String.join(" ", args));
-
-            ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
-
-            Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
-            tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
-            tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
-
-            if("token".equals(authMethod)) {
-
-                Objects.requireNonNull(vaultToken);
-                tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
-
-            } else {
-
-                Objects.requireNonNull(approleRoleId);
-                Objects.requireNonNull(approleSecretId);
-                tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
-                tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
-
-            }
-
-            try {
-                tesseraProcess.set(
-                    tesseraProcessBuilder.redirectErrorStream(true)
-                        .start()
-                );
-            } catch(NullPointerException ex) {
-                throw new NullPointerException("Check that application.jar property has been set");
-            }
-
-            executorService.submit(() -> {
-
-                try(BufferedReader reader = Stream.of(tesseraProcess.get().getInputStream())
-                    .map(InputStreamReader::new)
-                    .map(BufferedReader::new)
-                    .findAny().get()) {
-
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        System.out.println(line);
+                    if ('\"' == quotedUnsealKey.charAt(0)
+                            && '\"' == quotedUnsealKey.charAt(quotedUnsealKey.length() - 1)) {
+                        unsealKey = quotedUnsealKey.substring(1, quotedUnsealKey.length() - 1);
                     }
 
-                } catch (IOException ex) {
-                    throw new UncheckedIOException(ex);
-                }
-            });
+                    // Unseal the vault
+                    final URL unsealUrl =
+                            UriBuilder.fromUri("https://localhost:8200").path("v1/sys/unseal").build().toURL();
+                    HttpsURLConnection unsealUrlConnection = (HttpsURLConnection) unsealUrl.openConnection();
 
-            final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
+                    unsealUrlConnection.setDoOutput(true);
+                    unsealUrlConnection.setRequestMethod("PUT");
 
-            final URL bindingUrl = UriBuilder.fromUri(config.getP2PServerConfig().getBindingUri()).path("upcheck").build().toURL();
+                    String unsealData = "{\"key\": \"" + unsealKey + "\"}";
 
-            CountDownLatch startUpLatch = new CountDownLatch(1);
+                    try (OutputStreamWriter writer = new OutputStreamWriter(unsealUrlConnection.getOutputStream())) {
+                        writer.write(unsealData);
+                    }
 
-            executorService.submit(() -> {
+                    unsealUrlConnection.connect();
+                    assertThat(unsealUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
+                });
 
-                while (true) {
+        Given(
+                "the vault is initialised and unsealed",
+                () -> {
+                    final URL initUrl =
+                            UriBuilder.fromUri("https://localhost:8200").path("v1/sys/health").build().toURL();
+                    HttpsURLConnection initUrlConnection = (HttpsURLConnection) initUrl.openConnection();
+                    initUrlConnection.connect();
+
+                    // See https://www.vaultproject.io/api/system/health.html for info on response codes for this
+                    // endpoint
+                    assertThat(initUrlConnection.getResponseCode())
+                            .as("check vault is initialized")
+                            .isNotEqualTo(HttpsURLConnection.HTTP_NOT_IMPLEMENTED);
+                    assertThat(initUrlConnection.getResponseCode()).as("check vault is unsealed").isNotEqualTo(503);
+                    assertThat(initUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
+                });
+
+        Given(
+                "the vault has a v2 kv secret engine",
+                () -> {
+                    setKeyStoreProperties();
+
+                    // Create new v2 kv secret engine
+                    final String mountPath = String.format("v1/sys/mounts/%s", secretEngineName);
+                    final URL createSecretEngineUrl =
+                            UriBuilder.fromUri("https://localhost:8200").path(mountPath).build().toURL();
+                    HttpsURLConnection createSecretEngineUrlConnection =
+                            (HttpsURLConnection) createSecretEngineUrl.openConnection();
+
+                    createSecretEngineUrlConnection.setDoOutput(true);
+                    createSecretEngineUrlConnection.setRequestMethod("POST");
+                    createSecretEngineUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    final String createSecretEngineData = "{\"type\": \"kv\", \"options\": {\"version\": \"2\"}}";
+
+                    try (OutputStreamWriter writer =
+                            new OutputStreamWriter(createSecretEngineUrlConnection.getOutputStream())) {
+                        writer.write(createSecretEngineData);
+                    }
+
+                    createSecretEngineUrlConnection.connect();
+                    assertThat(createSecretEngineUrlConnection.getResponseCode())
+                            .isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
+                });
+
+        Given(
+                "^the AppRole auth method is enabled at (?:the|a) (default|custom) path$",
+                (String approleType) -> {
+                    setKeyStoreProperties();
+
+                    String approlePath;
+
+                    if ("default".equals(approleType)) {
+                        approlePath = "approle";
+                    } else {
+                        approlePath = "different-approle";
+                    }
+
+                    // Enable approle authentication
+                    final URL enableApproleUrl =
+                            UriBuilder.fromUri("https://localhost:8200")
+                                    .path("v1/sys/auth/" + approlePath)
+                                    .build()
+                                    .toURL();
+                    HttpsURLConnection enableApproleUrlConnection =
+                            (HttpsURLConnection) enableApproleUrl.openConnection();
+
+                    enableApproleUrlConnection.setDoOutput(true);
+                    enableApproleUrlConnection.setRequestMethod("POST");
+                    enableApproleUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    String enableApproleData = "{\"type\": \"approle\"}";
+
+                    try (OutputStreamWriter writer =
+                            new OutputStreamWriter(enableApproleUrlConnection.getOutputStream())) {
+                        writer.write(enableApproleData);
+                    }
+
+                    enableApproleUrlConnection.connect();
+                    assertThat(enableApproleUrlConnection.getResponseCode())
+                            .isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
+
+                    // Create a policy and assign to a new approle
+                    final URL createPolicyUrl =
+                            UriBuilder.fromUri("https://localhost:8200")
+                                    .path("v1/sys/policy/simple-policy")
+                                    .build()
+                                    .toURL();
+                    HttpsURLConnection createPolicyUrlConnection =
+                            (HttpsURLConnection) createPolicyUrl.openConnection();
+
+                    createPolicyUrlConnection.setDoOutput(true);
+                    createPolicyUrlConnection.setRequestMethod("POST");
+                    createPolicyUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    final String createPolicyData =
+                            String.format(
+                                    "{ \"policy\": \"path \\\"%s/data/tessera*\\\" { capabilities = [\\\"create\\\", \\\"update\\\", \\\"read\\\"]}\" }",
+                                    secretEngineName);
+
+                    try (OutputStreamWriter writer =
+                            new OutputStreamWriter(createPolicyUrlConnection.getOutputStream())) {
+                        writer.write(createPolicyData);
+                    }
+
+                    createPolicyUrlConnection.connect();
+                    assertThat(createPolicyUrlConnection.getResponseCode())
+                            .isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
+
+                    final URL createApproleUrl =
+                            UriBuilder.fromUri("https://localhost:8200")
+                                    .path("v1/auth/" + approlePath + "/role/simple-role")
+                                    .build()
+                                    .toURL();
+                    HttpsURLConnection createApproleUrlConnection =
+                            (HttpsURLConnection) createApproleUrl.openConnection();
+
+                    createApproleUrlConnection.setDoOutput(true);
+                    createApproleUrlConnection.setRequestMethod("POST");
+                    createApproleUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    final String createApproleData = "{ \"policies\": [\"simple-policy\"] }";
+
+                    try (OutputStreamWriter writer =
+                            new OutputStreamWriter(createApproleUrlConnection.getOutputStream())) {
+                        writer.write(createApproleData);
+                    }
+
+                    createApproleUrlConnection.connect();
+                    assertThat(createApproleUrlConnection.getResponseCode())
+                            .isEqualTo(HttpsURLConnection.HTTP_NO_CONTENT);
+
+                    // Retrieve approle credentials
+                    final URL getRoleIdUrl =
+                            UriBuilder.fromUri("https://localhost:8200")
+                                    .path("v1/auth/" + approlePath + "/role/simple-role/role-id")
+                                    .build()
+                                    .toURL();
+                    HttpsURLConnection getRoleIdUrlConnection = (HttpsURLConnection) getRoleIdUrl.openConnection();
+
+                    getRoleIdUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    getRoleIdUrlConnection.connect();
+                    assertThat(getRoleIdUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
+
+                    JsonReader jsonReader = Json.createReader(getRoleIdUrlConnection.getInputStream());
+                    JsonObject getRoleIdObject = jsonReader.readObject().getJsonObject("data");
+
+                    assertThat(getRoleIdObject.getString("role_id")).isNotEmpty();
+                    approleRoleId = getRoleIdObject.getString("role_id");
+
+                    final URL createSecretIdUrl =
+                            UriBuilder.fromUri("https://localhost:8200")
+                                    .path("v1/auth/" + approlePath + "/role/simple-role/secret-id")
+                                    .build()
+                                    .toURL();
+                    HttpsURLConnection createSecretIdUrlConnection =
+                            (HttpsURLConnection) createSecretIdUrl.openConnection();
+
+                    createSecretIdUrlConnection.setRequestMethod("POST");
+                    createSecretIdUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    createSecretIdUrlConnection.connect();
+                    assertThat(createSecretIdUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
+
+                    JsonReader anotherJsonReader = Json.createReader(createSecretIdUrlConnection.getInputStream());
+                    JsonObject createSecretIdObject = anotherJsonReader.readObject().getJsonObject("data");
+
+                    assertThat(createSecretIdObject.getString("secret_id")).isNotEmpty();
+                    approleSecretId = createSecretIdObject.getString("secret_id");
+
+                    createTempTesseraConfigWithApprole(approlePath);
+                });
+
+        Given(
+                "the vault contains a key pair",
+                () -> {
+                    Objects.requireNonNull(vaultToken);
+
+                    setKeyStoreProperties();
+
+                    // Set secret data
+                    final String setPath = String.format("v1/%s/data/tessera", secretEngineName);
+                    final URL setSecretUrl = UriBuilder.fromUri("https://localhost:8200").path(setPath).build().toURL();
+                    HttpsURLConnection setSecretUrlConnection = (HttpsURLConnection) setSecretUrl.openConnection();
+
+                    setSecretUrlConnection.setDoOutput(true);
+                    setSecretUrlConnection.setRequestMethod("POST");
+                    setSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    String setSecretData =
+                            "{\"data\": {\"publicKey\": \"/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\", \"privateKey\": \"yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=\"}}";
+
+                    try (OutputStreamWriter writer = new OutputStreamWriter(setSecretUrlConnection.getOutputStream())) {
+                        writer.write(setSecretData);
+                    }
+
+                    setSecretUrlConnection.connect();
+                    assertThat(setSecretUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
+
+                    final String getPath = String.format("v1/%s/data/tessera", secretEngineName);
+                    final URL getSecretUrl = UriBuilder.fromUri("https://localhost:8200").path(getPath).build().toURL();
+                    HttpsURLConnection getSecretUrlConnection = (HttpsURLConnection) getSecretUrl.openConnection();
+                    getSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+
+                    getSecretUrlConnection.connect();
+                    assertThat(getSecretUrlConnection.getResponseCode()).isEqualTo(HttpsURLConnection.HTTP_OK);
+
+                    JsonReader jsonReader = Json.createReader(getSecretUrlConnection.getInputStream());
+
+                    JsonObject getSecretObject = jsonReader.readObject();
+                    JsonObject keyDataObject = getSecretObject.getJsonObject("data").getJsonObject("data");
+                    assertThat(keyDataObject.getString("publicKey"))
+                            .isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+                    assertThat(keyDataObject.getString("privateKey"))
+                            .isEqualTo("yAWAJjwPqUtNVlqGjSrBmr1/iIkghuOh1803Yzx9jLM=");
+                });
+
+        Given(
+                "^the configfile contains the correct vault configuration(| and custom approle configuration)",
+                (String isCustomApprole) -> {
+                    createTempTesseraConfig();
+
+                    final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
+
+                    HashicorpKeyVaultConfig expectedVaultConfig = new HashicorpKeyVaultConfig();
+                    expectedVaultConfig.setUrl("https://localhost:8200");
+                    expectedVaultConfig.setTlsKeyStorePath(Paths.get(getClientTlsKeystore()));
+                    expectedVaultConfig.setTlsTrustStorePath(Paths.get(getClientTlsTruststore()));
+
+                    if (!isCustomApprole.isEmpty()) {
+                        expectedVaultConfig.setApprolePath("different-approle");
+                    }
+
+                    assertThat(config.getKeys().getHashicorpKeyVaultConfig())
+                            .isEqualToComparingFieldByField(expectedVaultConfig);
+                });
+
+        Given(
+                "the configfile contains the correct key data",
+                () -> {
+                    createTempTesseraConfig();
+
+                    final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
+
+                    final HashicorpVaultKeyPair expectedKeyData =
+                            new HashicorpVaultKeyPair("publicKey", "privateKey", secretEngineName, "tessera", null);
+
+                    assertThat(config.getKeys().getKeyData().size()).isEqualTo(1);
+                    assertThat(config.getKeys().getKeyData().get(0)).isEqualToComparingFieldByField(expectedKeyData);
+                });
+
+        When(
+                "^Tessera is started with the following CLI args and (token|approle) environment variables*$",
+                (String authMethod, String cliArgs) -> {
+                    final String jarfile = System.getProperty("application.jar");
+
+                    final URL logbackConfigFile = NodeExecManager.class.getResource("/logback-node.xml");
+                    Path pid = Paths.get(System.getProperty("java.io.tmpdir"), "pidA.pid");
+
+                    String formattedArgs =
+                            String.format(cliArgs, tempTesseraConfig.toString(), pid.toAbsolutePath().toString());
+
+                    List<String> args = new ArrayList<>();
+                    args.addAll(
+                            Arrays.asList(
+                                    "java",
+                                    "-Dspring.profiles.active=disable-unixsocket",
+                                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
+                                    "-Ddebug=true",
+                                    "-jar",
+                                    jarfile));
+                    args.addAll(Arrays.asList(formattedArgs.split(" ")));
+                    System.out.println(String.join(" ", args));
+
+                    ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
+
+                    Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
+                    tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
+                    tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
+
+                    if ("token".equals(authMethod)) {
+
+                        Objects.requireNonNull(vaultToken);
+                        tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
+
+                    } else {
+
+                        Objects.requireNonNull(approleRoleId);
+                        Objects.requireNonNull(approleSecretId);
+                        tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
+                        tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
+                    }
+
                     try {
-                        HttpURLConnection conn = (HttpURLConnection) bindingUrl.openConnection();
-                        conn.connect();
-
-                        System.out.println(bindingUrl + " started." + conn.getResponseCode());
-
-                        startUpLatch.countDown();
-                        return;
-                    } catch (IOException ex) {
-                        try {
-                            TimeUnit.MILLISECONDS.sleep(200L);
-                        } catch (InterruptedException ex1) {
-                        }
-                    }
-                }
-
-            });
-
-            boolean started = startUpLatch.await(30, TimeUnit.SECONDS);
-
-            if (!started) {
-                System.err.println(bindingUrl + " Not started. ");
-            }
-
-            executorService.submit(() -> {
-                try {
-                    int exitCode = tesseraProcess.get().waitFor();
-                    if (0 != exitCode) {
-                        System.err.println("Tessera node exited with code " + exitCode);
-                    }
-                } catch (InterruptedException ex) {
-                    ex.printStackTrace();
-                }
-            });
-
-            startUpLatch.await(30, TimeUnit.SECONDS);
-        });
-
-        When("^Tessera keygen is run with the following CLI args and (token|approle) environment variables*$", (String authMethod, String cliArgs) -> {
-            final String jarfile = System.getProperty("application.jar");
-            final URL logbackConfigFile = NodeExecManager.class.getResource("/logback-node.xml");
-
-            String formattedArgs = String.format(cliArgs, getClientTlsKeystore(), getClientTlsTruststore());
-
-            List<String> args = new ArrayList<>();
-            args.addAll(
-                Arrays.asList(
-                    "java",
-                    "-Dspring.profiles.active=disable-unixsocket",
-                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
-                    "-Ddebug=true",
-                    "-jar",
-                    jarfile
-                )
-            );
-            args.addAll(Arrays.asList(formattedArgs.split(" ")));
-            System.out.println(String.join(" ", args));
-
-            ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
-
-            Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
-            tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
-            tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
-
-            if("token".equals(authMethod)) {
-
-                Objects.requireNonNull(vaultToken);
-                tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
-
-            } else {
-
-                Objects.requireNonNull(approleRoleId);
-                Objects.requireNonNull(approleSecretId);
-                tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
-                tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
-
-            }
-
-            try {
-                tesseraProcess.set(
-                    tesseraProcessBuilder.redirectErrorStream(true)
-                        .start()
-                );
-            } catch(NullPointerException ex) {
-                throw new NullPointerException("Check that application.jar property has been set");
-            }
-
-            executorService.submit(() -> {
-
-                try(BufferedReader reader = Stream.of(tesseraProcess.get().getInputStream())
-                    .map(InputStreamReader::new)
-                    .map(BufferedReader::new)
-                    .findAny().get()) {
-
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        System.out.println(line);
+                        tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());
+                    } catch (NullPointerException ex) {
+                        throw new NullPointerException("Check that application.jar property has been set");
                     }
 
-                } catch (IOException ex) {
-                    throw new UncheckedIOException(ex);
-                }
-            });
+                    executorService.submit(
+                            () -> {
+                                try (BufferedReader reader =
+                                        Stream.of(tesseraProcess.get().getInputStream())
+                                                .map(InputStreamReader::new)
+                                                .map(BufferedReader::new)
+                                                .findAny()
+                                                .get()) {
 
-            CountDownLatch startUpLatch = new CountDownLatch(1);
-            startUpLatch.await(10, TimeUnit.SECONDS);
-        });
+                                    String line;
+                                    while ((line = reader.readLine()) != null) {
+                                        System.out.println(line);
+                                    }
 
-        Then("Tessera will retrieve the key pair from the vault", () -> {
-            final URL partyInfoUrl = UriBuilder.fromUri("http://localhost")
-                .port(8080)
-                .path("partyinfo")
-                .build()
-                .toURL();
+                                } catch (IOException ex) {
+                                    throw new UncheckedIOException(ex);
+                                }
+                            });
 
-            HttpURLConnection partyInfoUrlConnection = (HttpURLConnection) partyInfoUrl.openConnection();
-            partyInfoUrlConnection.connect();
+                    final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
 
-            int partyInfoResponseCode = partyInfoUrlConnection.getResponseCode();
-            assertThat(partyInfoResponseCode).isEqualTo(HttpURLConnection.HTTP_OK);
+                    final URL bindingUrl =
+                            UriBuilder.fromUri(config.getP2PServerConfig().getBindingUri())
+                                    .path("upcheck")
+                                    .build()
+                                    .toURL();
 
-            JsonReader jsonReader = Json.createReader(partyInfoUrlConnection.getInputStream());
+                    CountDownLatch startUpLatch = new CountDownLatch(1);
 
-            JsonObject partyInfoObject = jsonReader.readObject();
+                    executorService.submit(
+                            () -> {
+                                while (true) {
+                                    try {
+                                        HttpURLConnection conn = (HttpURLConnection) bindingUrl.openConnection();
+                                        conn.connect();
 
-            assertThat(partyInfoObject).isNotNull();
-            assertThat(partyInfoObject.getJsonArray("keys")).hasSize(1);
-            assertThat(partyInfoObject.getJsonArray("keys").getJsonObject(0).getString("key")).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        });
+                                        System.out.println(bindingUrl + " started." + conn.getResponseCode());
 
-        Then("^a new key pair (.+) will have been added to the vault$", (String secretName) -> {
-            Objects.requireNonNull(vaultToken);
+                                        startUpLatch.countDown();
+                                        return;
+                                    } catch (IOException ex) {
+                                        try {
+                                            TimeUnit.MILLISECONDS.sleep(200L);
+                                        } catch (InterruptedException ex1) {
+                                        }
+                                    }
+                                }
+                            });
 
-            setKeyStoreProperties();
+                    boolean started = startUpLatch.await(30, TimeUnit.SECONDS);
 
-            final URL getSecretUrl = UriBuilder.fromUri("https://localhost:8200")
-                .path("v1/secret/data/" + secretName)
-                .build()
-                .toURL();
+                    if (!started) {
+                        System.err.println(bindingUrl + " Not started. ");
+                    }
 
-            HttpsURLConnection getSecretUrlConnection = (HttpsURLConnection) getSecretUrl.openConnection();
-            getSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
-            getSecretUrlConnection.connect();
+                    executorService.submit(
+                            () -> {
+                                try {
+                                    int exitCode = tesseraProcess.get().waitFor();
+                                    if (0 != exitCode) {
+                                        System.err.println("Tessera node exited with code " + exitCode);
+                                    }
+                                } catch (InterruptedException ex) {
+                                    ex.printStackTrace();
+                                }
+                            });
 
-            int getSecretResponseCode = getSecretUrlConnection.getResponseCode();
-            assertThat(getSecretResponseCode).isEqualTo(HttpURLConnection.HTTP_OK);
+                    startUpLatch.await(30, TimeUnit.SECONDS);
+                });
 
-            JsonReader jsonReader = Json.createReader(getSecretUrlConnection.getInputStream());
+        When(
+                "^Tessera keygen is run with the following CLI args and (token|approle) environment variables*$",
+                (String authMethod, String cliArgs) -> {
+                    final String jarfile = System.getProperty("application.jar");
+                    final URL logbackConfigFile = NodeExecManager.class.getResource("/logback-node.xml");
 
-            JsonObject getSecretObject = jsonReader.readObject();
-            JsonObject keyDataObject = getSecretObject.getJsonObject("data").getJsonObject("data");
+                    String formattedArgs = String.format(cliArgs, getClientTlsKeystore(), getClientTlsTruststore());
 
-            assertThat(keyDataObject.size()).isEqualTo(2);
-            assertThat(keyDataObject.getString("publicKey")).isNotBlank();
-            assertThat(keyDataObject.getString("privateKey")).isNotBlank();
-        });
+                    List<String> args = new ArrayList<>();
+                    args.addAll(
+                            Arrays.asList(
+                                    "java",
+                                    "-Dspring.profiles.active=disable-unixsocket",
+                                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
+                                    "-Ddebug=true",
+                                    "-jar",
+                                    jarfile));
+                    args.addAll(Arrays.asList(formattedArgs.split(" ")));
+                    System.out.println(String.join(" ", args));
 
-        After(() -> {
-            if(vaultServerProcess.get() != null && vaultServerProcess.get().isAlive()) {
-                vaultServerProcess.get().destroy();
-            }
+                    ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
 
-            if(tesseraProcess.get() != null && tesseraProcess.get().isAlive()) {
-                tesseraProcess.get().destroy();
-            }
-        });
+                    Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
+                    tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
+                    tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
+
+                    if ("token".equals(authMethod)) {
+
+                        Objects.requireNonNull(vaultToken);
+                        tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
+
+                    } else {
+
+                        Objects.requireNonNull(approleRoleId);
+                        Objects.requireNonNull(approleSecretId);
+                        tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
+                        tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
+                    }
+
+                    try {
+                        tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());
+                    } catch (NullPointerException ex) {
+                        throw new NullPointerException("Check that application.jar property has been set");
+                    }
+
+                    executorService.submit(
+                            () -> {
+                                try (BufferedReader reader =
+                                        Stream.of(tesseraProcess.get().getInputStream())
+                                                .map(InputStreamReader::new)
+                                                .map(BufferedReader::new)
+                                                .findAny()
+                                                .get()) {
+
+                                    String line;
+                                    while ((line = reader.readLine()) != null) {
+                                        System.out.println(line);
+                                    }
+
+                                } catch (IOException ex) {
+                                    throw new UncheckedIOException(ex);
+                                }
+                            });
+
+                    CountDownLatch startUpLatch = new CountDownLatch(1);
+                    startUpLatch.await(10, TimeUnit.SECONDS);
+                });
+
+        Then(
+                "Tessera will retrieve the key pair from the vault",
+                () -> {
+                    final URL partyInfoUrl =
+                            UriBuilder.fromUri("http://localhost").port(8080).path("partyinfo").build().toURL();
+
+                    HttpURLConnection partyInfoUrlConnection = (HttpURLConnection) partyInfoUrl.openConnection();
+                    partyInfoUrlConnection.connect();
+
+                    int partyInfoResponseCode = partyInfoUrlConnection.getResponseCode();
+                    assertThat(partyInfoResponseCode).isEqualTo(HttpURLConnection.HTTP_OK);
+
+                    JsonReader jsonReader = Json.createReader(partyInfoUrlConnection.getInputStream());
+
+                    JsonObject partyInfoObject = jsonReader.readObject();
+
+                    assertThat(partyInfoObject).isNotNull();
+                    assertThat(partyInfoObject.getJsonArray("keys")).hasSize(1);
+                    assertThat(partyInfoObject.getJsonArray("keys").getJsonObject(0).getString("key"))
+                            .isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+                });
+
+        Then(
+                "^a new key pair (.+) will have been added to the vault$",
+                (String secretName) -> {
+                    Objects.requireNonNull(vaultToken);
+
+                    setKeyStoreProperties();
+
+                    final String getPath = String.format("v1/%s/data/%s", secretEngineName, secretName);
+                    final URL getSecretUrl = UriBuilder.fromUri("https://localhost:8200").path(getPath).build().toURL();
+
+                    HttpsURLConnection getSecretUrlConnection = (HttpsURLConnection) getSecretUrl.openConnection();
+                    getSecretUrlConnection.setRequestProperty("X-Vault-Token", vaultToken);
+                    getSecretUrlConnection.connect();
+
+                    int getSecretResponseCode = getSecretUrlConnection.getResponseCode();
+                    assertThat(getSecretResponseCode).isEqualTo(HttpURLConnection.HTTP_OK);
+
+                    JsonReader jsonReader = Json.createReader(getSecretUrlConnection.getInputStream());
+
+                    JsonObject getSecretObject = jsonReader.readObject();
+                    JsonObject keyDataObject = getSecretObject.getJsonObject("data").getJsonObject("data");
+
+                    assertThat(keyDataObject.size()).isEqualTo(2);
+                    assertThat(keyDataObject.getString("publicKey")).isNotBlank();
+                    assertThat(keyDataObject.getString("privateKey")).isNotBlank();
+                });
+
+        After(
+                () -> {
+                    if (vaultServerProcess.get() != null && vaultServerProcess.get().isAlive()) {
+                        vaultServerProcess.get().destroy();
+                    }
+
+                    if (tesseraProcess.get() != null && tesseraProcess.get().isAlive()) {
+                        tesseraProcess.get().destroy();
+                    }
+                });
     }
 
     private void setKeyStoreProperties() {
@@ -606,24 +676,28 @@ public class HashicorpStepDefs implements En {
     }
 
     private void createTempTesseraConfig() {
-        if(tempTesseraConfig == null) {
+        if (tempTesseraConfig == null) {
             Map<String, Object> params = new HashMap<>();
             params.put("clientKeystore", getClientTlsKeystore());
             params.put("clientTruststore", getClientTlsTruststore());
 
-            tempTesseraConfig = ElUtil.createTempFileFromTemplate(getClass().getResource("/vault/tessera-hashicorp-config.json"), params);
+            tempTesseraConfig =
+                    ElUtil.createTempFileFromTemplate(
+                            getClass().getResource("/vault/tessera-hashicorp-config.json"), params);
             tempTesseraConfig.toFile().deleteOnExit();
         }
     }
 
     private void createTempTesseraConfigWithApprole(String approlePath) {
-        if(tempTesseraConfig == null) {
+        if (tempTesseraConfig == null) {
             Map<String, Object> params = new HashMap<>();
             params.put("clientKeystore", getClientTlsKeystore());
             params.put("clientTruststore", getClientTlsTruststore());
             params.put("approlePath", approlePath);
 
-            tempTesseraConfig = ElUtil.createTempFileFromTemplate(getClass().getResource("/vault/tessera-hashicorp-approle-config.json"), params);
+            tempTesseraConfig =
+                    ElUtil.createTempFileFromTemplate(
+                            getClass().getResource("/vault/tessera-hashicorp-approle-config.json"), params);
             tempTesseraConfig.toFile().deleteOnExit();
         }
     }
@@ -647,5 +721,4 @@ public class HashicorpStepDefs implements En {
     private String getClientTlsTruststore() {
         return getClass().getResource("/certificates/truststore.jks").getFile();
     }
-
 }

--- a/tests/acceptance-test/src/test/resources/features/vault/hashicorp.feature
+++ b/tests/acceptance-test/src/test/resources/features/vault/hashicorp.feature
@@ -41,7 +41,7 @@ Feature: Hashicorp Vault support
     Scenario: Tessera generates and stores a keypair in the Vault using the Token auth method
         When Tessera keygen is run with the following CLI args and token environment variable
             """
-            -keygen -keygenvaulttype HASHICORP -keygenvaulturl https://localhost:8200 -keygenvaultsecretengine secret -filename tessera/nodeA,tessera/nodeB -keygenvaultkeystore %s -keygenvaulttruststore %s
+            -keygen -keygenvaulttype HASHICORP -keygenvaulturl https://localhost:8200 -keygenvaultsecretengine kv -filename tessera/nodeA,tessera/nodeB -keygenvaultkeystore %s -keygenvaulttruststore %s
             """
         Then a new key pair tessera/nodeA will have been added to the vault
         And a new key pair tessera/nodeB will have been added to the vault
@@ -50,7 +50,7 @@ Feature: Hashicorp Vault support
         Given the AppRole auth method is enabled at the default path
         When Tessera keygen is run with the following CLI args and approle environment variables
             """
-            -keygen -keygenvaulttype HASHICORP -keygenvaulturl https://localhost:8200 -keygenvaultsecretengine secret -filename tessera/nodeA,tessera/nodeB -keygenvaultkeystore %s -keygenvaulttruststore %s
+            -keygen -keygenvaulttype HASHICORP -keygenvaulturl https://localhost:8200 -keygenvaultsecretengine kv -filename tessera/nodeA,tessera/nodeB -keygenvaultkeystore %s -keygenvaulttruststore %s
             """
         Then a new key pair tessera/nodeA will have been added to the vault
         And a new key pair tessera/nodeB will have been added to the vault
@@ -59,7 +59,7 @@ Feature: Hashicorp Vault support
         Given the AppRole auth method is enabled at the custom path
         When Tessera keygen is run with the following CLI args and approle environment variables
             """
-            -keygen -keygenvaulttype HASHICORP -keygenvaulturl https://localhost:8200 -keygenvaultsecretengine secret -filename tessera/nodeA,tessera/nodeB -keygenvaultkeystore %s -keygenvaulttruststore %s -keygenvaultapprole different-approle
+            -keygen -keygenvaulttype HASHICORP -keygenvaulturl https://localhost:8200 -keygenvaultsecretengine kv -filename tessera/nodeA,tessera/nodeB -keygenvaultkeystore %s -keygenvaulttruststore %s -keygenvaultapprole different-approle
             """
         Then a new key pair tessera/nodeA will have been added to the vault
         And a new key pair tessera/nodeB will have been added to the vault

--- a/tests/acceptance-test/src/test/resources/vault/tessera-hashicorp-approle-config.json
+++ b/tests/acceptance-test/src/test/resources/vault/tessera-hashicorp-approle-config.json
@@ -34,7 +34,7 @@
         },
         "keyData": [
             {
-                "hashicorpVaultSecretEngineName": "secret",
+                "hashicorpVaultSecretEngineName": "kv",
                 "hashicorpVaultSecretName": "tessera",
                 "hashicorpVaultPublicKeyId": "publicKey",
                 "hashicorpVaultPrivateKeyId": "privateKey"

--- a/tests/acceptance-test/src/test/resources/vault/tessera-hashicorp-config.json
+++ b/tests/acceptance-test/src/test/resources/vault/tessera-hashicorp-config.json
@@ -33,7 +33,7 @@
         },
         "keyData": [
             {
-                "hashicorpVaultSecretEngineName": "secret",
+                "hashicorpVaultSecretEngineName": "kv",
                 "hashicorpVaultSecretName": "tessera",
                 "hashicorpVaultPublicKeyId": "publicKey",
                 "hashicorpVaultPrivateKeyId": "privateKey"


### PR DESCRIPTION
Resolves #879 

This change includes the following:

* Update the version of Hashicorp Vault used in acceptance tests.
* Update the Hashicorp acceptance tests to create a new secret engine instead of using the `secret` default.  This is because since v1.0.0 of Vault the `secret` secret engine is no longer created by default.  
* Use a unique name (`kv`) for the secret engine to prevent potential conflicts if this default is re-enabled.