### PR TITLE
ensure jaxrs Responses are closed

### DIFF
--- a/cli/admin-cli/src/main/java/com/quorum/tessera/admin/cli/subcommands/AddPeerCommand.java
+++ b/cli/admin-cli/src/main/java/com/quorum/tessera/admin/cli/subcommands/AddPeerCommand.java
@@ -81,20 +81,21 @@ public class AddPeerCommand implements Callable<CliResult> {
 
         URI uri = UriBuilder.fromUri(serverConfig.getBindingUri()).port(port).scheme(scheme).build();
 
-        Response response =
+        try (Response response =
                 restClient
                         .target(uri)
                         .path("config")
                         .path("peers")
                         .request(APPLICATION_JSON)
                         .accept(APPLICATION_JSON)
-                        .put(Entity.entity(peer, APPLICATION_JSON));
+                        .put(Entity.entity(peer, APPLICATION_JSON))) {
 
-        if (response.getStatus() == Response.Status.CREATED.getStatusCode()) {
-            sys.out().printf("Peer %s added.", response.getLocation());
-            sys.out().println();
+            if (response.getStatus() == Response.Status.CREATED.getStatusCode()) {
+                sys.out().printf("Peer %s added.", response.getLocation());
+                sys.out().println();
 
-            return new CliResult(0, true, null);
+                return new CliResult(0, true, null);
+            }
         }
 
         sys.err().println("Unable to create peer");

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
@@ -116,22 +116,23 @@ public class PartyInfoResource {
 
                         final byte[] encodedPayloadData = payloadEncoder.encode(encodedPayload);
 
-                        Response response =
+                        try (Response response =
                                 restClient
                                         .target(r.getUrl())
                                         .path("partyinfo")
                                         .path("validate")
                                         .request()
-                                        .post(Entity.entity(encodedPayloadData, MediaType.APPLICATION_OCTET_STREAM));
+                                        .post(Entity.entity(encodedPayloadData, MediaType.APPLICATION_OCTET_STREAM))) {
 
-                        String unencodedValidationData = response.readEntity(String.class);
+                            String unencodedValidationData = response.readEntity(String.class);
 
-                        boolean isValid = Objects.equals(unencodedValidationData, dataToEncrypt);
-                        if (!isValid) {
-                            LOGGER.warn("Invalid key found {} recipient will be ignored.", r.getUrl());
+                            boolean isValid = Objects.equals(unencodedValidationData, dataToEncrypt);
+                            if (!isValid) {
+                                LOGGER.warn("Invalid key found {} recipient will be ignored.", r.getUrl());
+                            }
+
+                            return isValid;
                         }
-
-                        return isValid;
                         // Assume any all exceptions to mean invalid. enclave bubbles up nacl array out of
                         // bounds when calculating shared key from invalid data
                     } catch (Exception ex) {

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/RestP2pClient.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/RestP2pClient.java
@@ -19,44 +19,47 @@ public class RestP2pClient implements P2pClient {
     @Override
     public byte[] push(String targetUrl, byte[] data) {
 
-        final Response response =
+        try (Response response =
                 client.target(targetUrl)
                         .path("/push")
                         .request()
-                        .post(Entity.entity(data, MediaType.APPLICATION_OCTET_STREAM_TYPE));
+                        .post(Entity.entity(data, MediaType.APPLICATION_OCTET_STREAM_TYPE))) {
 
-        if (Response.Status.OK.getStatusCode() != response.getStatus()
-                && Response.Status.CREATED.getStatusCode() != response.getStatus()) {
-            return null;
+            if (Response.Status.OK.getStatusCode() != response.getStatus()
+                    && Response.Status.CREATED.getStatusCode() != response.getStatus()) {
+                return null;
+            }
+
+            return response.readEntity(byte[].class);
         }
-
-        return response.readEntity(byte[].class);
     }
 
     @Override
     public boolean sendPartyInfo(String targetUrl, byte[] data) {
-        final Response response =
+        try (Response response =
                 client.target(targetUrl)
                         .path("/partyinfo")
                         .request()
-                        .post(Entity.entity(data, MediaType.APPLICATION_OCTET_STREAM_TYPE));
+                        .post(Entity.entity(data, MediaType.APPLICATION_OCTET_STREAM_TYPE))) {
 
-        if (Response.Status.OK.getStatusCode() != response.getStatus()
-                && Response.Status.CREATED.getStatusCode() != response.getStatus()) {
-            return false;
+            if (Response.Status.OK.getStatusCode() != response.getStatus()
+                    && Response.Status.CREATED.getStatusCode() != response.getStatus()) {
+                return false;
+            }
+
+            return Objects.nonNull(response.readEntity(byte[].class));
         }
-
-        return Objects.nonNull(response.readEntity(byte[].class));
     }
 
     @Override
     public boolean makeResendRequest(String targetUrl, ResendRequest request) {
-        final Response response =
+        try (Response response =
                 client.target(targetUrl)
                         .path("/resend")
                         .request()
-                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+                        .post(Entity.entity(request, MediaType.APPLICATION_JSON))) {
 
-        return Response.Status.OK.getStatusCode() == response.getStatus();
+            return Response.Status.OK.getStatusCode() == response.getStatus();
+        }
     }
 }

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -367,6 +367,24 @@
             </build>
         </profile>
 
+        <profile>
+            <id>stress-tests</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>StressRestSuite</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
 </project>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/StressRestSuite.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/StressRestSuite.java
@@ -1,0 +1,30 @@
+package com.quorum.tessera.test.rest;
+
+import com.quorum.tessera.test.DBType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import suite.EnclaveType;
+import suite.ParameterizedTestSuiteRunnerFactory;
+import suite.ProcessConfiguration;
+import suite.TestSuite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.quorum.tessera.config.CommunicationType.REST;
+import static suite.SocketType.HTTP;
+
+@TestSuite.SuiteClasses({StressSendIT.class})
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(ParameterizedTestSuiteRunnerFactory.class)
+public class StressRestSuite {
+
+    @Parameterized.Parameters
+    public static List<ProcessConfiguration> configurations() {
+        final List<ProcessConfiguration> configurations = new ArrayList<>();
+
+        configurations.add(new ProcessConfiguration(DBType.H2, REST, HTTP, EnclaveType.LOCAL, false, ""));
+
+        return configurations;
+    }
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/StressSendIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/StressSendIT.java
@@ -1,0 +1,93 @@
+package com.quorum.tessera.test.rest;
+
+import com.quorum.tessera.api.model.SendRequest;
+import com.quorum.tessera.test.Party;
+import com.quorum.tessera.test.PartyHelper;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StressSendIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StressSendIT.class);
+
+    private static final String SEND_PATH = "/send";
+
+    private final Client client = ClientBuilder.newClient();
+
+    private RestUtils utils = new RestUtils();
+
+    private PartyHelper partyHelper = PartyHelper.create();
+
+    private static final int MAX_COUNT = 20000;
+    private static final int THREAD_COUNT = 10;
+
+    /** Quorum sends transaction with single public recipient key */
+    @Test
+    public void sendToSingleRecipientUntilFailureOrMaxReached() {
+        LOGGER.info("stress test starting");
+
+        final Party firstParty = partyHelper.findByAlias("A");
+        final Party secondParty = partyHelper.findByAlias("B");
+        byte[] transactionData = utils.createTransactionData();
+
+        final AtomicInteger sendCounter = new AtomicInteger(0);
+        final AtomicInteger invalidResults = new AtomicInteger(0);
+
+        final List<Thread> stressThreads = new ArrayList<>();
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final Thread stressThread =
+                    new Thread(
+                            () -> {
+                                int currentCount = sendCounter.incrementAndGet();
+                                while (currentCount < MAX_COUNT) {
+                                    final SendRequest sendRequest = new SendRequest();
+                                    sendRequest.setFrom(firstParty.getPublicKey());
+                                    sendRequest.setTo(secondParty.getPublicKey());
+                                    sendRequest.setPayload(transactionData);
+
+                                    try (Response response =
+                                            client.target(firstParty.getQ2TUri())
+                                                    .path(SEND_PATH)
+                                                    .request()
+                                                    .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON))) {
+
+                                        if (response.getStatus() != 201) {
+                                            LOGGER.info("Response is not 201. MessageCount=" + currentCount);
+                                            sendCounter.addAndGet(MAX_COUNT);
+                                            invalidResults.incrementAndGet();
+                                        }
+                                    }
+
+                                    currentCount = sendCounter.incrementAndGet();
+                                    if (currentCount % 1000 == 0) {
+                                        LOGGER.info("currentCount={}", currentCount);
+                                    }
+                                }
+                            });
+            stressThread.start();
+            stressThreads.add(stressThread);
+        }
+
+        // wait for stress threads to finish
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            try {
+                stressThreads.get(i).join();
+            } catch (InterruptedException e) {
+                LOGGER.error("Error while waiting for clients to stop.", e);
+            }
+        }
+        LOGGER.info("stress test finished");
+        assertThat(invalidResults.get()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
Close jaxrs Response instances after the results/status codes are processed. This prevents duplicate push messages between P2P nodes.

Fixes https://github.com/jpmorganchase/tessera/issues/882