### PR TITLE
Azure Key Vault: Use latest client library version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,7 @@ jobs:
       jdk:  oraclejdk11
       before_install: *install_hashicorp
       install: *build_no_checks
-      script: mvn verify -pl tests/acceptance-test -P hashicorp-vault-acceptance-tests,reduce-logging -o || travis_terminate 1
-    # TODO use vault-acceptance-tests profile when Travis is updated to use jdk 11.0.3+
+      script: mvn verify -pl tests/acceptance-test -P vault-acceptance-tests,reduce-logging -o || travis_terminate 1
 
 #    - stage: deploy only
 #      name: "Deploy to OSSRH"

--- a/pom.xml
+++ b/pom.xml
@@ -1266,7 +1266,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-keyvault</artifactId>
-                <version>1.1.2</version>
+                <version>1.2.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Resolves #880, resolves #889.

Latest version of `com.microsoft.azure:azure-keyvault` includes bug fixes that resolve the above issues.

Consequently, enable Java 11 Azure Key Vault acceptance tests in Travis builds.