### PR TITLE
Change migration tools to use PicoCLI instead of commons-cli

### DIFF
--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/CliDelegate.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/CliDelegate.java
@@ -58,6 +58,7 @@ public enum CliDelegate {
         commandLine
                 .registerConverter(Config.class, new ConfigConverter())
                 .setSeparator(" ")
+                .setCaseInsensitiveEnumValuesAllowed(true)
                 .setUnmatchedArgumentsAllowed(true)
                 .setExecutionExceptionHandler(mapper)
                 .setParameterExceptionHandler(mapper);

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/CliType.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/CliType.java
@@ -1,5 +1,9 @@
 package com.quorum.tessera.cli;
 
 public enum CliType {
-    CONFIG, ADMIN, ENCLAVE, CONFIG_MIGRATION
+    CONFIG,
+    ADMIN,
+    ENCLAVE,
+    CONFIG_MIGRATION,
+    DATA_MIGRATION
 }

--- a/config-migration/pom.xml
+++ b/config-migration/pom.xml
@@ -1,25 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.jpmorgan.quorum</groupId>
         <artifactId>tessera</artifactId>
         <version>0.11-SNAPSHOT</version>
     </parent>
+
+    <name>config-migration</name>
     <artifactId>config-migration</artifactId>
     <packaging>jar</packaging>
 
-
     <dependencies>
+
         <dependency>
             <groupId>com.moandjiezana.toml</groupId>
             <artifactId>toml4j</artifactId>
             <version>0.7.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
         </dependency>
 
         <dependency>
@@ -39,7 +38,6 @@
         </dependency>
 
     </dependencies>
-
 
     <build>
 

--- a/config-migration/src/main/java/com/quorum/tessera/config/migration/LegacyCliAdapter.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/migration/LegacyCliAdapter.java
@@ -5,37 +5,54 @@ import com.quorum.tessera.cli.CliResult;
 import com.quorum.tessera.cli.CliType;
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.KeyConfiguration;
-import com.quorum.tessera.config.SslAuthenticationMode;
 import com.quorum.tessera.config.builder.ConfigBuilder;
 import com.quorum.tessera.config.builder.JdbcConfigFactory;
 import com.quorum.tessera.config.builder.KeyDataBuilder;
-import com.quorum.tessera.config.builder.SslTrustModeFactory;
 import com.quorum.tessera.config.util.JaxbUtil;
 import com.quorum.tessera.io.FilesDelegate;
 import com.quorum.tessera.io.SystemAdapter;
-import org.apache.commons.cli.*;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Mixin;
 
 import javax.validation.ConstraintViolationException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
-public class LegacyCliAdapter implements CliAdapter {
+@Command(
+        headerHeading = "Usage:%n%n",
+        synopsisHeading = "%n",
+        descriptionHeading = "%nDescription:%n%n",
+        parameterListHeading = "%nParameters:%n",
+        optionListHeading = "%nOptions:%n",
+        header = "Generate Tessera JSON config file from a Constellation TOML config file")
+public class LegacyCliAdapter implements CliAdapter, Callable<CliResult> {
 
-    private final FilesDelegate fileDelegate = FilesDelegate.create();
+    private final FilesDelegate fileDelegate;
 
     private final TomlConfigFactory configFactory;
 
+    @Option(names = "help", usageHelp = true, description = "display this help message")
+    private boolean isHelpRequested;
+
+    @Option(names = "--outputfile", arity = "1", description = "the path to write the configuration to")
+    private Path outputPath = Paths.get("tessera-config.json");
+
+    @Option(names = "--tomlfile", arity = "1", description = "the path to the existing TOML configuration")
+    private Path tomlfile;
+
+    @Mixin private LegacyOverridesMixin overrides = new LegacyOverridesMixin();
+
     public LegacyCliAdapter() {
         this.configFactory = new TomlConfigFactory();
+        this.fileDelegate = FilesDelegate.create();
     }
 
     @Override
@@ -44,48 +61,28 @@ public class LegacyCliAdapter implements CliAdapter {
     }
 
     @Override
+    public CliResult call() throws Exception {
+        return this.execute();
+    }
+
+    @Override
     public CliResult execute(String... args) throws Exception {
 
-        Options options = buildOptions();
-        final List<String> argsList = Arrays.asList(args);
-        if (argsList.isEmpty() || argsList.contains("help")) {
-            String header = "Generate Tessera JSON config file from a Constellation TOML config file";
-            HelpFormatter formatter = new HelpFormatter();
+        final ConfigBuilder configBuilder =
+                Optional.ofNullable(tomlfile)
+                        .map(fileDelegate::newInputStream)
+                        .map(stream -> this.configFactory.create(stream, null))
+                        .orElse(ConfigBuilder.create());
 
-            PrintWriter pw = new PrintWriter(sys().out());
-            formatter.printHelp(pw,
-                    200, "tessera-config-migration",
-                    header, options, formatter.getLeftPadding(),
-                    formatter.getDescPadding(), null, false);
-            pw.flush();
+        final KeyDataBuilder keyDataBuilder =
+                Optional.ofNullable(tomlfile)
+                        .map(fileDelegate::newInputStream)
+                        .map(configFactory::createKeyDataBuilder)
+                        .orElse(KeyDataBuilder.create());
 
-            final int exitCode = argsList.isEmpty() ? 1 : 0;
-            return new CliResult(exitCode, true, null);
-        }
-
-        CommandLineParser parser = new DefaultParser();
-
-        CommandLine line = parser.parse(options, args);
-
-        final ConfigBuilder configBuilder = Optional.ofNullable(line.getOptionValue("tomlfile"))
-                .map(Paths::get)
-                .map(fileDelegate::newInputStream)
-                .map(stream -> this.configFactory.create(stream, null))
-                .orElse(ConfigBuilder.create());
-
-        final KeyDataBuilder keyDataBuilder = Optional.ofNullable(line.getOptionValue("tomlfile"))
-                .map(Paths::get)
-                .map(fileDelegate::newInputStream)
-                .map(configFactory::createKeyDataBuilder)
-                .orElse(KeyDataBuilder.create());
-
-        ConfigBuilder adjustedConfig = applyOverrides(line, configBuilder, keyDataBuilder);
+        ConfigBuilder adjustedConfig = applyOverrides(configBuilder, keyDataBuilder);
 
         Config config = adjustedConfig.build();
-
-        String outputfilevalue = line.getOptionValue("outputfile", "tessera-config.json");
-
-        Path outputPath = Paths.get(outputfilevalue).toAbsolutePath();
 
         return writeToOutputFile(config, outputPath);
     }
@@ -97,14 +94,13 @@ public class LegacyCliAdapter implements CliAdapter {
         JaxbUtil.marshalWithNoValidation(config, systemAdapter.out());
         systemAdapter.out().println();
 
-        try (OutputStream outputStream = Files.newOutputStream(outputPath)){
+        try (OutputStream outputStream = Files.newOutputStream(outputPath)) {
             JaxbUtil.marshal(config, outputStream);
             systemAdapter.out().printf("Saved config to  %s", outputPath);
             systemAdapter.out().println();
             return new CliResult(0, false, config);
         } catch (ConstraintViolationException validationException) {
-            validationException.getConstraintViolations()
-                    .stream()
+            validationException.getConstraintViolations().stream()
                     .map(cv -> "Warning: " + cv.getMessage() + " on property " + cv.getPropertyPath())
                     .forEach(systemAdapter.err()::println);
 
@@ -115,354 +111,67 @@ public class LegacyCliAdapter implements CliAdapter {
         }
     }
 
-    static ConfigBuilder applyOverrides(CommandLine line, ConfigBuilder configBuilder, KeyDataBuilder keyDataBuilder) {
+    ConfigBuilder applyOverrides(ConfigBuilder configBuilder, KeyDataBuilder keyDataBuilder) {
 
-        Optional.ofNullable(line.getOptionValue("workdir"))
-                .ifPresent(configBuilder::workdir);
+        Optional.ofNullable(overrides.workdir).ifPresent(configBuilder::workdir);
+        Optional.ofNullable(overrides.workdir).ifPresent(keyDataBuilder::withWorkingDirectory);
 
-        Optional.ofNullable(line.getOptionValue("workdir"))
-                .ifPresent(keyDataBuilder::withWorkingDirectory);
-
-        Optional.ofNullable(line.getOptionValue("url"))
-                .map(url -> {
-                    try{
-                        return new URL(url);
-                    } catch (MalformedURLException e) {
-                        throw new RuntimeException("Bad server url given: " + e.getMessage());
-                    }
-                }).map(uri -> uri.getProtocol() + "://" + uri.getHost())
+        Optional.ofNullable(overrides.url)
+                .map(
+                        url -> {
+                            try {
+                                return new URL(url);
+                            } catch (MalformedURLException e) {
+                                throw new RuntimeException("Bad server url given: " + e.getMessage());
+                            }
+                        })
+                .map(uri -> uri.getProtocol() + "://" + uri.getHost())
                 .ifPresent(configBuilder::serverHostname);
 
-        Optional.ofNullable(line.getOptionValue("port"))
-                .map(Integer::valueOf)
-                .ifPresent(configBuilder::serverPort);
+        Optional.ofNullable(overrides.port).ifPresent(configBuilder::serverPort);
+        Optional.ofNullable(overrides.socket).ifPresent(configBuilder::unixSocketFile);
+        Optional.ofNullable(overrides.othernodes).ifPresent(configBuilder::peers);
+        Optional.ofNullable(overrides.publickeys).ifPresent(keyDataBuilder::withPublicKeys);
+        Optional.ofNullable(overrides.privatekeys).ifPresent(keyDataBuilder::withPrivateKeys);
+        Optional.ofNullable(overrides.alwayssendto).ifPresent(configBuilder::alwaysSendTo);
+        Optional.ofNullable(overrides.passwords).ifPresent(keyDataBuilder::withPrivateKeyPasswordFile);
 
-        Optional.ofNullable(line.getOptionValue("socket"))
-                .ifPresent(configBuilder::unixSocketFile);
-
-        Optional.ofNullable(line.getOptionValues("othernodes"))
-                .map(Arrays::asList)
-                .ifPresent(configBuilder::peers);
-
-        Optional.ofNullable(line.getOptionValues("publickeys"))
-                .map(Arrays::asList)
-                .ifPresent(keyDataBuilder::withPublicKeys);
-
-        Optional.ofNullable(line.getOptionValues("privatekeys"))
-                .map(Arrays::asList)
-                .ifPresent(keyDataBuilder::withPrivateKeys);
-
-        Optional.ofNullable(line.getOptionValues("alwayssendto"))
-                .map(Arrays::asList)
-                .ifPresent(configBuilder::alwaysSendTo);
-
-        Optional.ofNullable(line.getOptionValue("passwords"))
-                .ifPresent(keyDataBuilder::withPrivateKeyPasswordFile);
-
-        Optional.ofNullable(line.getOptionValue("storage"))
+        Optional.ofNullable(overrides.storage)
                 .map(JdbcConfigFactory::fromLegacyStorageString)
                 .ifPresent(configBuilder::jdbcConfig);
 
-        if (line.hasOption("ipwhitelist")) {
+        if (overrides.whitelist) {
             configBuilder.useWhiteList(true);
         }
 
-        Optional.ofNullable(line.getOptionValue("tls"))
-                .map(String::toUpperCase)
-                .map(SslAuthenticationMode::valueOf)
-                .ifPresent(configBuilder::sslAuthenticationMode);
-
-        Optional.ofNullable(line.getOptionValue("tlsservertrust"))
-                .map(SslTrustModeFactory::resolveByLegacyValue)
-                .ifPresent(configBuilder::sslServerTrustMode);
-
-        Optional.ofNullable(line.getOptionValue("tlsclienttrust"))
-                .map(SslTrustModeFactory::resolveByLegacyValue)
-                .ifPresent(configBuilder::sslClientTrustMode);
-
-        Optional.ofNullable(line.getOptionValue("tlsservercert"))
-                .ifPresent(configBuilder::sslServerTlsCertificatePath);
-
-        Optional.ofNullable(line.getOptionValue("tlsclientcert"))
-                .ifPresent(configBuilder::sslClientTlsCertificatePath);
-
-        Optional.ofNullable(line.getOptionValues("tlsserverchain"))
-                .map(Arrays::asList)
-                .ifPresent(configBuilder::sslServerTrustCertificates);
-
-        Optional.ofNullable(line.getOptionValues("tlsclientchain"))
-                .map(Arrays::asList)
-                .ifPresent(configBuilder::sslClientTrustCertificates);
-
-        Optional.ofNullable(line.getOptionValue("tlsserverkey"))
-                .ifPresent(configBuilder::sslServerTlsKeyPath);
-
-        Optional.ofNullable(line.getOptionValue("tlsclientkey"))
-                .ifPresent(configBuilder::sslClientTlsKeyPath);
-
-        Optional.ofNullable(line.getOptionValue("tlsknownservers"))
-                .ifPresent(configBuilder::sslKnownServersFile);
-
-        Optional.ofNullable(line.getOptionValue("tlsknownclients"))
-                .ifPresent(configBuilder::sslKnownClientsFile);
+        Optional.ofNullable(overrides.tls).ifPresent(configBuilder::sslAuthenticationMode);
+        Optional.ofNullable(overrides.tlsservertrust).ifPresent(configBuilder::sslServerTrustMode);
+        Optional.ofNullable(overrides.tlsclienttrust).ifPresent(configBuilder::sslClientTrustMode);
+        Optional.ofNullable(overrides.tlsservercert).ifPresent(configBuilder::sslServerTlsCertificatePath);
+        Optional.ofNullable(overrides.tlsclientcert).ifPresent(configBuilder::sslClientTlsCertificatePath);
+        Optional.ofNullable(overrides.tlsserverchain).ifPresent(configBuilder::sslServerTrustCertificates);
+        Optional.ofNullable(overrides.tlsclientchain).ifPresent(configBuilder::sslClientTrustCertificates);
+        Optional.ofNullable(overrides.tlsserverkey).ifPresent(configBuilder::sslServerTlsKeyPath);
+        Optional.ofNullable(overrides.tlsclientkey).ifPresent(configBuilder::sslClientTlsKeyPath);
+        Optional.ofNullable(overrides.tlsknownservers).ifPresent(configBuilder::sslKnownServersFile);
+        Optional.ofNullable(overrides.tlsknownclients).ifPresent(configBuilder::sslKnownClientsFile);
 
         final KeyConfiguration keyConfiguration = keyDataBuilder.build();
 
         if (!keyConfiguration.getKeyData().isEmpty()) {
             configBuilder.keyData(keyConfiguration);
-        } else {
-            if (Optional.ofNullable(line.getOptionValue("passwords")).isPresent()) {
-                SystemAdapter.INSTANCE.err().println("Info: Public/Private key data not provided in overrides.  Overriden password file has not been added to config.");
-            }
+        } else if (overrides.passwords != null) {
+            SystemAdapter.INSTANCE
+                    .err()
+                    .println(
+                            "Info: Public/Private key data not provided in overrides. Overriden password file has not been added to config.");
         }
 
         return configBuilder;
     }
 
-    static Options buildOptions() {
-
-        Options options = new Options();
-        options.addOption(
-                Option.builder()
-                        .longOpt("url")
-                        .desc("URL for this node (i.e. the address advertised to other nodes)")
-                        .hasArg(true)
-                        .optionalArg(false)
-                        .numberOfArgs(1)
-                        .argName("URL")
-                        .build());
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("port")
-                        .desc("Port to listen on for the public API")
-                        .hasArg(true)
-                        .optionalArg(false)
-                        .numberOfArgs(1)
-                        .argName("NUM")
-                        .valueSeparator('=')
-                        .build());
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("workdir")
-                        .desc("Working directory to use (relative paths specified for other options are relative to the working directory)")
-                        .hasArg(true)
-                        .optionalArg(false)
-                        .numberOfArgs(1)
-                        .argName("DIR")
-                        .build());
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("socket")
-                        .desc("Path to IPC socket file to create for private API access")
-                        .hasArg(true)
-                        .optionalArg(false)
-                        .numberOfArgs(1)
-                        .argName("FILE")
-                        .build());
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("othernodes")
-                        .desc("Comma-separated list of other node URLs to connect to on startup (this list may be incomplete)")
-                        .hasArg(true)
-                        .optionalArg(false)
-                        .hasArgs()
-                        .argName("URL...")
-                        .valueSeparator(',')
-                        .build());
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("publickeys")
-                        .desc("Comma-separated list of paths to public keys to advertise")
-                        .optionalArg(false)
-                        .argName("FILE...")
-                        .hasArgs()
-                        .valueSeparator(',')
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("privatekeys")
-                        .desc("Comma-separated list of paths to private keys (these must be given in the same corresponding order as --publickeys)")
-                        .optionalArg(false)
-                        .argName("FILE...")
-                        .hasArgs()
-                        .valueSeparator(',')
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("passwords")
-                        .desc("A file containing the passwords for the specified --privatekeys, one per line, in the same order (if one key is not locked, add an empty line)")
-                        .optionalArg(false)
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("alwayssendto")
-                        .desc("Comma-separated list of paths to public keys that are always included as recipients (these must be advertised somewhere)")
-                        .optionalArg(false)
-                        .argName("FILE...")
-                        .hasArgs()
-                        .valueSeparator(',')
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("storage")
-                        .optionalArg(false)
-                        .argName("STRING")
-                        .desc("Storage string specifying a storage engine and/or storage path")
-                        .hasArg()
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("tls")
-                        .desc("TLS status (strict, off)")
-                        .optionalArg(false)
-                        .argName("STATUS")
-                        .hasArg()
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsservercert")
-                        .desc("TLS certificate file to use for the public API")
-                        .argName("FILE")
-                        .numberOfArgs(1)
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsserverchain")
-                        .desc("Comma separated list of TLS chain certificate files to use for the public API")
-                        .argName("FILE...")
-                        .hasArgs()
-                        .valueSeparator(',')
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsserverkey")
-                        .desc("TLS key file to use for the public API")
-                        .optionalArg(false)
-                        .hasArg()
-                        .argName("FILE")
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsservertrust")
-                        .optionalArg(false)
-                        .hasArg()
-                        .argName("STRING")
-                        .desc("TLS server trust mode (whitelist, ca-or-tofu, ca, tofu, insecure-no-validation)")
-                        .build()
-        );
-
-        //           --tlsknownclients[=FILE]    TLS server known clients file for the ca-or-tofu, tofu and whitelist trust modes
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsknownclients")
-                        .desc("TLS server known clients file for the ca-or-tofu, tofu and whitelist trust modes")
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        //           --tlsclientcert[=FILE]      TLS client certificate file to use for connections to other nodes
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsclientcert")
-                        .desc("TLS client certificate file to use for connections to other nodes")
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        //           --tlsclientchain[=FILE...]  Comma separated list of TLS chain certificates to use for connections to other nodes
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsclientchain")
-                        .desc("Comma separated list of TLS chain certificate files to use for connections to other nodes")
-                        .argName("FILE...")
-                        .hasArgs()
-                        .valueSeparator(',')
-                        .build()
-        );
-
-        //           --tlsclientkey[=FILE]       TLS key to use for connections to other nodes
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsclientkey")
-                        .desc("TLS key file to use for connections to other nodes")
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        //           --tlsclienttrust[=STRING]   TLS client trust mode (whitelist, ca-or-tofu, ca, tofu, insecure-no-validation)
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsclienttrust")
-                        .desc("TLS client trust mode (whitelist, ca-or-tofu, ca, tofu, insecure-no-validation)")
-                        .argName("STRING")
-                        .hasArg()
-                        .build()
-        );
-
-        //
-        options.addOption(
-                Option.builder()
-                        .longOpt("tlsknownservers")
-                        .desc("TLS client known servers file for the ca-or-tofu, tofu and whitelist trust modes")
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("tomlfile")
-                        .desc("TOML configuration input file.")
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("outputfile")
-                        .desc("Location to save generated Tessera configuration file.")
-                        .argName("FILE")
-                        .hasArg()
-                        .build()
-        );
-
-        options.addOption(
-                Option.builder()
-                        .longOpt("ipwhitelist")
-                        .desc("If provided, Tessera will use the othernodes as a whitelist.")
-                        .hasArg(false)
-                        .build()
-        );
-
-        return options;
+    // TODO: remove. Here for testing
+    public void setOverrides(final LegacyOverridesMixin overrides) {
+        this.overrides = overrides;
     }
 }

--- a/config-migration/src/main/java/com/quorum/tessera/config/migration/LegacyOverridesMixin.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/migration/LegacyOverridesMixin.java
@@ -1,0 +1,114 @@
+package com.quorum.tessera.config.migration;
+
+import com.quorum.tessera.config.SslAuthenticationMode;
+import com.quorum.tessera.config.SslTrustMode;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+
+public class LegacyOverridesMixin {
+
+    @Option(
+            names = "--workdir",
+            arity = "1",
+            description =
+                    "Working directory to use (relative paths specified for other options are relative to the working directory)")
+    public String workdir;
+
+    @Option(names = "--url", arity = "1", description = "URL for this node (i.e. the address you want advertised)")
+    public String url;
+
+    @Option(names = "--port", arity = "1", description = "Port to listen on for the public API")
+    public Integer port;
+
+    @Option(names = "--socket", arity = "1", description = "Path to IPC socket file to create for private API access")
+    public String socket;
+
+    @Option(
+            names = "--othernodes",
+            split = ",",
+            description = "Comma-separated list of other node URLs to connect at startup")
+    public List<String> othernodes;
+
+    @Option(
+            names = "--publickeys",
+            split = ",",
+            description = "Comma-separated list of paths to public keys to advertise")
+    public List<String> publickeys;
+
+    @Option(
+            names = "--privatekeys",
+            split = ",",
+            description =
+                    "Comma-separated list of paths to private keys (these must be given in the same corresponding order as --publickeys)")
+    public List<String> privatekeys;
+
+    @Option(names = "--passwords", arity = "1", description = "The file containing the passwords for the privatekeys")
+    public String passwords;
+
+    @Option(
+            names = "--alwayssendto",
+            split = ",",
+            description = "Comma-separated list of paths to public keys that are always included as recipients")
+    public List<String> alwayssendto;
+
+    @Option(names = "--storage", arity = "1", description = "Storage string specifying a storage engine and/or path")
+    public String storage;
+
+    @Option(names = "--tls", arity = "1", description = "TLS status (strict, off)")
+    public SslAuthenticationMode tls;
+
+    @Option(names = "--tlsservercert", arity = "1", description = "TLS certificate file to use for the public API")
+    public String tlsservercert;
+
+    @Option(
+            names = "--tlsserverchain",
+            split = ",",
+            description = "Comma separated list of TLS chain certificate files to use for the public API")
+    public List<String> tlsserverchain;
+
+    @Option(names = "--tlsserverkey", arity = "1", description = "TLS key file to use for the public API")
+    public String tlsserverkey;
+
+    @Option(
+            names = "--tlsservertrust",
+            arity = "1",
+            description = "TLS server trust mode (whitelist, ca-or-tofu, ca, tofu, insecure-no-validation)")
+    public SslTrustMode tlsservertrust;
+
+    @Option(
+            names = "--tlsknownclients",
+            arity = "1",
+            description = "TLS server known clients file for the ca-or-tofu, tofu and whitelist trust modes")
+    public String tlsknownclients;
+
+    @Option(
+            names = "--tlsclientcert",
+            arity = "1",
+            description = "TLS client certificate file to use for connections to other nodes")
+    public String tlsclientcert;
+
+    @Option(
+            names = "--tlsclientchain",
+            split = ",",
+            description = "Comma separated list of TLS chain certificate files to use for connections to other nodes")
+    public List<String> tlsclientchain;
+
+    @Option(names = "--tlsclientkey", arity = "1", description = "TLS key file to use for connections to other nodes")
+    public String tlsclientkey;
+
+    @Option(
+            names = "--tlsclienttrust",
+            arity = "1",
+            description = "TLS client trust mode (whitelist, ca-or-tofu, ca, tofu, insecure-no-validation)")
+    public SslTrustMode tlsclienttrust;
+
+    @Option(
+            names = "--tlsknownservers",
+            arity = "1",
+            description = "TLS client known servers file for the ca-or-tofu, tofu and whitelist trust modes")
+    public String tlsknownservers;
+
+    @Option(names = "--ipwhitelist", description = "If provided, Tessera will use the othernodes as a whitelist.")
+    public boolean whitelist;
+}

--- a/config-migration/src/main/java/com/quorum/tessera/config/migration/Main.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/migration/Main.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.config.migration;
 
+import com.quorum.tessera.cli.CliDelegate;
 import com.quorum.tessera.cli.CliResult;
 
 public class Main {
@@ -8,9 +9,8 @@ public class Main {
         System.setProperty("javax.xml.bind.JAXBContextFactory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
         System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
 
-        LegacyCliAdapter adapter = new LegacyCliAdapter();
         try {
-            CliResult result = adapter.execute(args);
+            final CliResult result = CliDelegate.instance().execute(args);
             System.exit(result.getStatus());
         } catch (final Exception ex) {
             System.err.println(ex.toString());

--- a/config-migration/src/main/resources/META-INF/services/com.quorum.tessera.cli.CliAdapter
+++ b/config-migration/src/main/resources/META-INF/services/com.quorum.tessera.cli.CliAdapter
@@ -1,0 +1,1 @@
+com.quorum.tessera.config.migration.LegacyCliAdapter

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/LegacyCliAdapterTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/LegacyCliAdapterTest.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.config.migration;
 
+import com.quorum.tessera.cli.CliDelegate;
 import com.quorum.tessera.cli.CliResult;
 import com.quorum.tessera.cli.CliType;
 import com.quorum.tessera.config.*;
@@ -8,7 +9,6 @@ import com.quorum.tessera.config.builder.KeyDataBuilder;
 import com.quorum.tessera.config.migration.test.FixtureUtil;
 import com.quorum.tessera.io.SystemAdapter;
 import com.quorum.tessera.test.util.ElUtil;
-import org.apache.commons.cli.CommandLine;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -24,15 +24,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class LegacyCliAdapterTest {
 
-    @Rule
-    public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    @Rule public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
     private final ConfigBuilder builderWithValidValues = FixtureUtil.builderWithValidValues();
 
@@ -54,10 +55,7 @@ public class LegacyCliAdapterTest {
     public void onTearDown() throws IOException {
         Files.deleteIfExists(Paths.get("tessera-config.json"));
 
-        Files.walk(dataDirectory)
-                .sorted(Comparator.reverseOrder())
-                .map(Path::toFile)
-                .forEach(File::delete);
+        Files.walk(dataDirectory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     }
 
     @Test
@@ -66,29 +64,15 @@ public class LegacyCliAdapterTest {
     }
 
     @Test
-    public void help() throws Exception {
-        CliResult result = instance.execute("help");
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
-        assertThat(result.getStatus()).isEqualTo(0);
-    }
-
-    @Test
-    public void noArgs() throws Exception {
-        CliResult result = instance.execute();
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
-        assertThat(result.getStatus()).isEqualTo(1);
-    }
-
-    @Test
     public void withoutCliArgsAllConfigIsSetFromTomlFile() throws Exception {
         dataDirectory = Paths.get("data");
         Files.createDirectory(dataDirectory);
 
         Path alwaysSendTo1 = Files.createFile(dataDirectory.resolve("alwayssendto1"));
-        Files.write(alwaysSendTo1, ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n"
-                                    + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=").getBytes());
+        Files.write(
+                alwaysSendTo1,
+                ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n" + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=")
+                        .getBytes());
 
         Path alwaysSendTo2 = Files.createFile(dataDirectory.resolve("alwayssendto2"));
         Files.write(alwaysSendTo2, "yGcjkFyZklTTXrn8+WIkYwicA2EGBn9wZFkctAad4X0=".getBytes());
@@ -103,7 +87,7 @@ public class LegacyCliAdapterTest {
         Path configFile = Files.createTempFile("noOptions", ".txt");
         Files.write(configFile, data.getBytes());
 
-        CliResult result = instance.execute("--tomlfile=" + configFile.toString());
+        CliResult result = CliDelegate.instance().execute("--tomlfile", configFile.toString());
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
@@ -117,10 +101,18 @@ public class LegacyCliAdapterTest {
         assertThat(config.getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
         assertThat(config.getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
         assertThat(config.getKeys().getKeyData().size()).isEqualTo(2);
-        assertThat(config.getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("data/foo.pub"));
-        assertThat(config.getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("data/foo.key"));
-        assertThat(config.getKeys().getKeyData().get(1)).extracting("publicKeyPath").containsExactly(Paths.get("data/foo2.pub"));
-        assertThat(config.getKeys().getKeyData().get(1)).extracting("privateKeyPath").containsExactly(Paths.get("data/foo2.key"));
+        assertThat(config.getKeys().getKeyData().get(0))
+                .extracting("publicKeyPath")
+                .containsExactly(Paths.get("data/foo.pub"));
+        assertThat(config.getKeys().getKeyData().get(0))
+                .extracting("privateKeyPath")
+                .containsExactly(Paths.get("data/foo.key"));
+        assertThat(config.getKeys().getKeyData().get(1))
+                .extracting("publicKeyPath")
+                .containsExactly(Paths.get("data/foo2.pub"));
+        assertThat(config.getKeys().getKeyData().get(1))
+                .extracting("privateKeyPath")
+                .containsExactly(Paths.get("data/foo2.key"));
         assertThat(config.getAlwaysSendTo().size()).isEqualTo(3);
         assertThat(config.getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
         assertThat(config.getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
@@ -129,20 +121,31 @@ public class LegacyCliAdapterTest {
         assertThat(config.getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
         assertThat(config.isUseWhiteList()).isTrue();
         assertThat(config.getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.STRICT);
-        assertThat(config.getServer().getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("data/tls-server-cert.pem");
+        assertThat(config.getServer().getSslConfig().getServerTlsCertificatePath().toString())
+                .isEqualTo("data/tls-server-cert.pem");
         assertThat(config.getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(2);
-        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("data/chain1");
-        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().get(1).toString()).isEqualTo("data/chain2");
-        assertThat(config.getServer().getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("data/tls-server-key.pem");
+        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().get(0).toString())
+                .isEqualTo("data/chain1");
+        assertThat(config.getServer().getSslConfig().getServerTrustCertificates().get(1).toString())
+                .isEqualTo("data/chain2");
+        assertThat(config.getServer().getSslConfig().getServerTlsKeyPath().toString())
+                .isEqualTo("data/tls-server-key.pem");
         assertThat(config.getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(config.getServer().getSslConfig().getKnownClientsFile().toString()).isEqualTo("data/tls-known-clients");
-        assertThat(config.getServer().getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("data/tls-client-cert.pem");
+        assertThat(config.getServer().getSslConfig().getKnownClientsFile().toString())
+                .isEqualTo("data/tls-known-clients");
+        assertThat(config.getServer().getSslConfig().getClientTlsCertificatePath().toString())
+                .isEqualTo("data/tls-client-cert.pem");
         assertThat(config.getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(2);
-        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("data/clientchain1");
-        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().get(1).toString()).isEqualTo("data/clientchain2");
-        assertThat(config.getServer().getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("data/tls-client-key.pem");
-        assertThat(config.getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
-        assertThat(config.getServer().getSslConfig().getKnownServersFile().toString()).isEqualTo("data/tls-known-servers");
+        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().get(0).toString())
+                .isEqualTo("data/clientchain1");
+        assertThat(config.getServer().getSslConfig().getClientTrustCertificates().get(1).toString())
+                .isEqualTo("data/clientchain2");
+        assertThat(config.getServer().getSslConfig().getClientTlsKeyPath().toString())
+                .isEqualTo("data/tls-client-key.pem");
+        assertThat(config.getServer().getSslConfig().getClientTrustMode())
+                .isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
+        assertThat(config.getServer().getSslConfig().getKnownServersFile().toString())
+                .isEqualTo("data/tls-known-servers");
     }
 
     @Test
@@ -150,56 +153,74 @@ public class LegacyCliAdapterTest {
 
         Path sampleFile = Paths.get(getClass().getResource("/sample.conf").toURI());
 
-        String data = Files.readAllLines(sampleFile)
-            .stream()
-            .collect(Collectors.joining(System.lineSeparator()));
+        String data = Files.readAllLines(sampleFile).stream().collect(Collectors.joining(System.lineSeparator()));
 
         Path configFile = Files.createTempFile("noOptions", ".txt");
         Files.write(configFile, data.getBytes());
 
         Path workdir = Paths.get("override");
 
-        if(Files.exists(workdir)) {
-            Files.walk(workdir)
-                .sorted(Comparator.reverseOrder())
-                .map(Path::toFile)
-                .forEach(File::delete);
+        if (Files.exists(workdir)) {
+            Files.walk(workdir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
         }
         Files.createDirectory(workdir);
         Files.createFile(workdir.resolve("new.pub"));
         Files.createFile(workdir.resolve("new.key"));
         Path alwaysSendToFile = Files.createFile(workdir.resolve("alwayssendto"));
-        Files.write(alwaysSendToFile, ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n"
-            + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=").getBytes());
+        Files.write(
+                alwaysSendToFile,
+                ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n" + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=")
+                        .getBytes());
 
         String[] args = {
-            "--tomlfile=" + configFile.toString(),
-            "--url=http://override",
-            "--port=1111",
-            "--workdir=override",
-            "--socket=cli.ipc",
-            "--othernodes=http://others",
-            "--publickeys=new.pub",
-            "--privatekeys=new.key",
-            "--alwayssendto=alwayssendto",
-            "--passwords=pw.txt",
-            "--storage=jdbc:test",
+            "--tomlfile",
+            configFile.toString(),
+            "--url",
+            "http://override",
+            "--port",
+            "1111",
+            "--workdir",
+            "override",
+            "--socket",
+            "cli.ipc",
+            "--othernodes",
+            "http://others",
+            "--publickeys",
+            "new.pub",
+            "--privatekeys",
+            "new.key",
+            "--alwayssendto",
+            "alwayssendto",
+            "--passwords",
+            "pw.txt",
+            "--storage",
+            "jdbc:test",
             "--ipwhitelist",
-            "--socket=cli.ipc",
-            "--tls=off",
-            "--tlsservercert=over-server-cert.pem",
-            "--tlsserverchain=serverchain.file",
-            "--tlsserverkey=over-server-key.pem",
-            "--tlsservertrust=whitelist",
-            "--tlsknownclients=over-known-clients",
-            "--tlsclientcert=over-client-cert.pem",
-            "--tlsclientchain=clientchain.file",
-            "--tlsclientkey=over-client-key.pem",
-            "--tlsclienttrust=tofu",
-            "--tlsknownservers=over-known-servers"
+            "--tls",
+            "off",
+            "--tlsservercert",
+            "over-server-cert.pem",
+            "--tlsserverchain",
+            "serverchain.file",
+            "--tlsserverkey",
+            "over-server-key.pem",
+            "--tlsservertrust",
+            "whitelist",
+            "--tlsknownclients",
+            "over-known-clients",
+            "--tlsclientcert",
+            "over-client-cert.pem",
+            "--tlsclientchain",
+            "clientchain.file",
+            "--tlsclientkey",
+            "over-client-key.pem",
+            "--tlsclienttrust",
+            "tofu",
+            "--tlsknownservers",
+            "over-known-servers"
         };
 
-        CliResult result = instance.execute(args);
+        CliResult result = CliDelegate.instance().execute(args);
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
@@ -211,32 +232,48 @@ public class LegacyCliAdapterTest {
         assertThat(result.getConfig().get().getPeers().size()).isEqualTo(1);
         assertThat(result.getConfig().get().getPeers().get(0).getUrl()).isEqualTo("http://others");
         assertThat(result.getConfig().get().getKeys().getKeyData().size()).isEqualTo(1);
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0))
+                .extracting("publicKeyPath")
+                .containsExactly(Paths.get("override/new.pub"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0))
+                .extracting("privateKeyPath")
+                .containsExactly(Paths.get("override/new.key"));
         assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(2);
-        assertThat(result.getConfig().get().getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        assertThat(result.getConfig().get().getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(0))
+                .isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(1))
+                .isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
         assertThat(result.getConfig().get().getKeys().getPasswordFile().toString()).isEqualTo("override/pw.txt");
         assertThat(result.getConfig().get().getJdbcConfig().getUrl()).isEqualTo("jdbc:test");
         assertThat(result.getConfig().get().isUseWhiteList()).isTrue();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("override/over-server-cert.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(1);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("override/serverchain.file");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("override/over-server-key.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.WHITELIST);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile().toString()).isEqualTo("override/over-known-clients");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("override/over-client-cert.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(1);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("override/clientchain.file");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("override/over-client-key.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile().toString()).isEqualTo("override/over-known-servers");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getTls())
+                .isEqualByComparingTo(SslAuthenticationMode.OFF);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath().toString())
+                .isEqualTo("override/over-server-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size())
+                .isEqualTo(1);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(0).toString())
+                .isEqualTo("override/serverchain.file");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath().toString())
+                .isEqualTo("override/over-server-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode())
+                .isEqualByComparingTo(SslTrustMode.WHITELIST);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile().toString())
+                .isEqualTo("override/over-known-clients");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath().toString())
+                .isEqualTo("override/over-client-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size())
+                .isEqualTo(1);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(0).toString())
+                .isEqualTo("override/clientchain.file");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath().toString())
+                .isEqualTo("override/over-client-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode())
+                .isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile().toString())
+                .isEqualTo("override/over-known-servers");
 
-        Files.walk(workdir)
-            .sorted(Comparator.reverseOrder())
-            .map(Path::toFile)
-            .forEach(File::delete);
+        Files.walk(workdir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     }
 
     @Test
@@ -244,41 +281,46 @@ public class LegacyCliAdapterTest {
 
         Path configFile = Files.createTempFile("emptyConfig", ".txt");
         Path keysFile = Files.createTempFile("key", ".tmp").toAbsolutePath();
-        Files.write(keysFile, Arrays.asList("SOMEDATA"));
+        Files.write(keysFile, Collections.singletonList("SOMEDATA"));
 
         String[] requiredParams = {
-            "--tomlfile=" + configFile.toString(),
-            "--url=http://127.0.0.1",
-            "--port=9001",
-            "--othernodes=localhost:1111",
-            "--socket=myipcfile.ipc",
-            "--publickeys=" + keysFile.toString(),
-            "--privatekeys=" + keysFile.toString()
+            "--tomlfile", configFile.toString(),
+            "--url", "http://127.0.0.1",
+            "--port", "9001",
+            "--othernodes", "localhost:1111",
+            "--socket", "myipcfile.ipc",
+            "--publickeys", keysFile.toString(),
+            "--privatekeys", keysFile.toString()
         };
 
-        CliResult result = instance.execute(requiredParams);
+        CliResult result = CliDelegate.instance().execute(requiredParams);
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
         assertThat(result.getStatus()).isEqualTo(0);
 
         assertThat(result.getConfig().get().getUnixSocketFile().toString()).isEqualTo("myipcfile.ipc");
-        //Empty List
+        // Empty List
         assertThat(Optional.ofNullable(result.getConfig().get().getKeys().getKeyData()).isPresent()).isEqualTo(true);
         assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(0);
         assertThat(result.getConfig().get().getKeys().getPasswordFile()).isNull();
         assertThat(result.getConfig().get().getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
         assertThat(result.getConfig().get().isUseWhiteList()).isFalse();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getTls())
+                .isEqualByComparingTo(SslAuthenticationMode.OFF);
         assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath()).isNull();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(0);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size())
+                .isEqualTo(0);
         assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath()).isNull();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode())
+                .isEqualByComparingTo(SslTrustMode.TOFU);
         assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile()).isNull();
         assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath()).isNull();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(0);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size())
+                .isEqualTo(0);
         assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath()).isNull();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode())
+                .isEqualByComparingTo(SslTrustMode.TOFU);
         assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile()).isNull();
     }
 
@@ -287,18 +329,17 @@ public class LegacyCliAdapterTest {
 
         Path workdir = Paths.get("override");
 
-        if(Files.exists(workdir)) {
-            Files.walk(workdir)
-                .sorted(Comparator.reverseOrder())
-                .map(Path::toFile)
-                .forEach(File::delete);
+        if (Files.exists(workdir)) {
+            Files.walk(workdir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
         }
         Files.createDirectory(workdir);
         Files.createFile(workdir.resolve("new.pub"));
         Files.createFile(workdir.resolve("new.key"));
         Path alwaysSendToFile = Files.createFile(workdir.resolve("alwayssendto"));
-        Files.write(alwaysSendToFile, ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n"
-            + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=").getBytes());
+        Files.write(
+                alwaysSendToFile,
+                ("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=\n" + "jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=")
+                        .getBytes());
 
         Path sampleFile = Paths.get(getClass().getResource("/sample-toml-no-nulls-tls-off.conf").toURI());
         Map<String, Object> params = new HashMap<>();
@@ -311,13 +352,13 @@ public class LegacyCliAdapterTest {
         Files.write(configFile, data.getBytes());
 
         String[] args = {
-            "--tomlfile=" + configFile.toString(),
-            "--workdir=override",
-            "--publickeys=" + "new.pub",
-            "--privatekeys=" + "new.key"
+            "--tomlfile", configFile.toString(),
+            "--workdir", "override",
+            "--publickeys", "new.pub",
+            "--privatekeys", "new.key"
         };
 
-        CliResult result = instance.execute(args);
+        CliResult result = CliDelegate.instance().execute(args);
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
@@ -330,31 +371,54 @@ public class LegacyCliAdapterTest {
         assertThat(result.getConfig().get().getPeers().get(0).getUrl()).isEqualTo("http://127.0.0.1:9001/");
         assertThat(result.getConfig().get().getPeers().get(1).getUrl()).isEqualTo("http://127.0.0.1:9002/");
         assertThat(result.getConfig().get().getKeys().getKeyData().size()).isEqualTo(1);
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("publicKeyPath").containsExactly(Paths.get("override/new.pub"));
-        assertThat(result.getConfig().get().getKeys().getKeyData().get(0)).extracting("privateKeyPath").containsExactly(Paths.get("override/new.key"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0))
+                .extracting("publicKeyPath")
+                .containsExactly(Paths.get("override/new.pub"));
+        assertThat(result.getConfig().get().getKeys().getKeyData().get(0))
+                .extracting("privateKeyPath")
+                .containsExactly(Paths.get("override/new.key"));
         assertThat(result.getConfig().get().getAlwaysSendTo().size()).isEqualTo(4);
-        assertThat(result.getConfig().get().getAlwaysSendTo().get(0)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        assertThat(result.getConfig().get().getAlwaysSendTo().get(1)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
-        assertThat(result.getConfig().get().getAlwaysSendTo().get(2)).isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
-        assertThat(result.getConfig().get().getAlwaysSendTo().get(3)).isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(0))
+                .isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(1))
+                .isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(2))
+                .isEqualTo("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");
+        assertThat(result.getConfig().get().getAlwaysSendTo().get(3))
+                .isEqualTo("jWKqelS4XjJ67JBbuKE7x9CVGFJ706wRYy/ev/OCOzk=");
         assertThat(result.getConfig().get().getKeys().getPasswordFile().toString()).isEqualTo("override/passwords");
         assertThat(result.getConfig().get().getJdbcConfig().getUrl()).isEqualTo("jdbc:h2:mem:tessera");
         assertThat(result.getConfig().get().isUseWhiteList()).isTrue();
-        assertThat(result.getConfig().get().getServer().getSslConfig().getTls()).isEqualByComparingTo(SslAuthenticationMode.OFF);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath().toString()).isEqualTo("override/tls-server-cert.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size()).isEqualTo(2);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(0).toString()).isEqualTo("override/chain1");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(1).toString()).isEqualTo("override/chain2");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath().toString()).isEqualTo("override/tls-server-key.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode()).isEqualByComparingTo(SslTrustMode.TOFU);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile().toString()).isEqualTo("override/tls-known-clients");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath().toString()).isEqualTo("override/tls-client-cert.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size()).isEqualTo(2);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(0).toString()).isEqualTo("override/clientchain1");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(1).toString()).isEqualTo("override/clientchain2");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath().toString()).isEqualTo("override/tls-client-key.pem");
-        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode()).isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
-        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile().toString()).isEqualTo("override/tls-known-servers");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getTls())
+                .isEqualByComparingTo(SslAuthenticationMode.OFF);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsCertificatePath().toString())
+                .isEqualTo("override/tls-server-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().size())
+                .isEqualTo(2);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(0).toString())
+                .isEqualTo("override/chain1");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustCertificates().get(1).toString())
+                .isEqualTo("override/chain2");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTlsKeyPath().toString())
+                .isEqualTo("override/tls-server-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getServerTrustMode())
+                .isEqualByComparingTo(SslTrustMode.TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownClientsFile().toString())
+                .isEqualTo("override/tls-known-clients");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsCertificatePath().toString())
+                .isEqualTo("override/tls-client-cert.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().size())
+                .isEqualTo(2);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(0).toString())
+                .isEqualTo("override/clientchain1");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustCertificates().get(1).toString())
+                .isEqualTo("override/clientchain2");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTlsKeyPath().toString())
+                .isEqualTo("override/tls-client-key.pem");
+        assertThat(result.getConfig().get().getServer().getSslConfig().getClientTrustMode())
+                .isEqualByComparingTo(SslTrustMode.CA_OR_TOFU);
+        assertThat(result.getConfig().get().getServer().getSslConfig().getKnownServersFile().toString())
+                .isEqualTo("override/tls-known-servers");
     }
 
     @Test
@@ -363,9 +427,7 @@ public class LegacyCliAdapterTest {
         Path configFile = Files.createTempFile("emptyConfig", ".txt");
 
         String[] requiredParams = {
-            "--tomlfile=" + configFile.toString(),
-            "--port=9001",
-            "--othernodes=localhost:1111",
+            "--tomlfile=" + configFile.toString(), "--port=9001", "--othernodes=localhost:1111",
         };
 
         CliResult result = instance.execute(requiredParams);
@@ -382,12 +444,10 @@ public class LegacyCliAdapterTest {
         Path configFile = Files.createTempFile("emptyConfig", ".txt");
 
         String[] requiredParams = {
-            "--tomlfile=" + configFile.toString(),
-            "--url=http://127.0.0.1:9001",
-            "--port=9001",
+            "--tomlfile", configFile.toString(), "--url", "http://127.0.0.1:9001", "--port", "9001",
         };
 
-        CliResult result = instance.execute(requiredParams);
+        CliResult result = CliDelegate.instance().execute(requiredParams);
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
@@ -400,17 +460,13 @@ public class LegacyCliAdapterTest {
 
         Path configFile = Files.createTempFile("emptyConfig", ".txt");
 
-        String[] requiredParams = {
-            "--tomlfile=" + configFile.toString(),
-            "--url=htt://invalidHost",
-            "--port=9001",
-        };
+        String[] requiredParams = {"--tomlfile", configFile.toString(), "--url", "htt://invalidHost", "--port", "9001"};
 
-        final Throwable throwable = catchThrowable(() -> instance.execute(requiredParams));
+        final Throwable throwable = catchThrowable(() -> CliDelegate.instance().execute(requiredParams));
 
         assertThat(throwable)
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Bad server url given: unknown protocol: htt");
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Bad server url given: unknown protocol: htt");
     }
 
     @Test
@@ -425,9 +481,7 @@ public class LegacyCliAdapterTest {
         params.put("passwordFile", passwordFile);
         params.put("serverKeyStorePath", serverKeyStorePath);
 
-        String data = Files.readAllLines(sampleFile)
-                .stream()
-                .collect(Collectors.joining(System.lineSeparator()));
+        String data = Files.readAllLines(sampleFile).stream().collect(Collectors.joining(System.lineSeparator()));
 
         Path configFile = Files.createTempFile("noOptions", ".txt");
         Files.write(configFile, data.getBytes());
@@ -436,9 +490,9 @@ public class LegacyCliAdapterTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getConfig()).isPresent();
-        //TODO assert that value of config is as expected from sample config
+        // TODO assert that value of config is as expected from sample config
 
-//        assertThat(result.getStatus()).isEqualTo(0);
+        //        assertThat(result.getStatus()).isEqualTo(0);
     }
 
     @Test
@@ -472,33 +526,33 @@ public class LegacyCliAdapterTest {
         MockSystemAdapter systemAdapter = (MockSystemAdapter) SystemAdapter.INSTANCE;
         systemAdapter.setErrPrintStream(errStream);
 
-        CommandLine line = mock(CommandLine.class);
-        when(line.getOptionValue("passwords")).thenReturn("override/path");
-
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
-        LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.passwords = "override/path";
+        instance.setOverrides(mixin);
+
+        instance.applyOverrides(configBuilder, KeyDataBuilder.create());
 
         assertThat(errContent.toString())
-                .isEqualTo("Info: Public/Private key data not provided in overrides.  Overriden password file has not been added to config.\n");
-
+                .isEqualTo(
+                        "Info: Public/Private key data not provided in overrides. Overriden password file has not been added to config.\n");
     }
 
     @Test
     public void noPasswordOrKeyDataOverrideProvidedThenNoMessagePrintedToConsole() {
-        CommandLine line = mock(CommandLine.class);
-
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
-        LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
+        instance.applyOverrides(configBuilder, KeyDataBuilder.create());
 
         assertThat(systemErrRule.getLog()).isEmpty();
     }
 
     @Test
     public void keyDataProvidedButNoPasswordProvidedThenNoMessagePrintedToConsole() {
-        CommandLine line = mock(CommandLine.class);
-        when(line.getOptionValue("passwords")).thenReturn("override/path");
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.passwords = "override/path";
+        instance.setOverrides(mixin);
 
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
@@ -507,20 +561,15 @@ public class LegacyCliAdapterTest {
         List<String> privateKeys = new ArrayList<>();
         privateKeys.add("priv");
 
-        KeyDataBuilder keyDataBuilder = KeyDataBuilder
-            .create()
-            .withPublicKeys(publicKeys)
-            .withPrivateKeys(privateKeys);
+        KeyDataBuilder keyDataBuilder = KeyDataBuilder.create().withPublicKeys(publicKeys).withPrivateKeys(privateKeys);
 
-        LegacyCliAdapter.applyOverrides(line, configBuilder, keyDataBuilder);
+        instance.applyOverrides(configBuilder, keyDataBuilder);
 
         assertThat(systemErrRule.getLog()).isEmpty();
     }
 
     @Test
     public void passwordAndKeyDataProvidedAsOverrideThenNoMessagePrintedToConsole() {
-        CommandLine line = mock(CommandLine.class);
-
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
         List<String> publicKeys = new ArrayList<>();
@@ -528,27 +577,25 @@ public class LegacyCliAdapterTest {
         List<String> privateKeys = new ArrayList<>();
         privateKeys.add("priv");
 
-        KeyDataBuilder keyDataBuilder = KeyDataBuilder.create()
-            .withPublicKeys(publicKeys)
-            .withPrivateKeys(privateKeys);
+        KeyDataBuilder keyDataBuilder = KeyDataBuilder.create().withPublicKeys(publicKeys).withPrivateKeys(privateKeys);
 
-        LegacyCliAdapter.applyOverrides(line, configBuilder, keyDataBuilder);
+        instance.applyOverrides(configBuilder, keyDataBuilder);
 
         assertThat(systemErrRule.getLog()).isEmpty();
     }
 
     @Test
     public void ifTomlWorkDirProvidedWithoutOverrideWorkDirThenTomlWorkDirUsedOnOverridenValues() {
-        CommandLine line = mock(CommandLine.class);
-        when(line.getOptionValue("workdir")).thenReturn(null);
         String socketFilepath = "path/to/socket.ipc";
-        when(line.getOptionValue("socket")).thenReturn(socketFilepath);
+
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.socket = socketFilepath;
+        instance.setOverrides(mixin);
 
         String tomlWorkDir = "toml";
-        ConfigBuilder configBuilder = ConfigBuilder.create()
-                                                .workdir(tomlWorkDir);
+        ConfigBuilder configBuilder = ConfigBuilder.create().workdir(tomlWorkDir);
 
-        ConfigBuilder result = LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
+        ConfigBuilder result = instance.applyOverrides(configBuilder, KeyDataBuilder.create());
 
         Path expected = Paths.get(tomlWorkDir, socketFilepath);
 
@@ -557,16 +604,17 @@ public class LegacyCliAdapterTest {
 
     @Test
     public void ifTomlWorkDirProvidedWithOverrideWorkDirThenOverrideWorkDirUsedOnOverridenValues() {
-        CommandLine line = mock(CommandLine.class);
         String overrideWorkDir = "override";
-        when(line.getOptionValue("workdir")).thenReturn(overrideWorkDir);
-        when(line.getOptionValue("workdir", ".")).thenReturn(overrideWorkDir);
         String socketFilepath = "path/to/socket.ipc";
-        when(line.getOptionValue("socket")).thenReturn(socketFilepath);
+
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.socket = socketFilepath;
+        mixin.workdir = overrideWorkDir;
+        instance.setOverrides(mixin);
 
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
-        ConfigBuilder result = LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
+        ConfigBuilder result = instance.applyOverrides(configBuilder, KeyDataBuilder.create());
 
         Path expected = Paths.get(overrideWorkDir, socketFilepath);
 
@@ -575,14 +623,15 @@ public class LegacyCliAdapterTest {
 
     @Test
     public void ifTomlWorkDirNotProvidedWithoutOverrideWorkDirThenDefaultWorkDirUsedOnOverridenValues() {
-        CommandLine line = mock(CommandLine.class);
-        when(line.getOptionValue("workdir")).thenReturn(null);
         String socketFilepath = "path/to/socket.ipc";
-        when(line.getOptionValue("socket")).thenReturn(socketFilepath);
+
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.socket = socketFilepath;
+        instance.setOverrides(mixin);
 
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
-        ConfigBuilder result = LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
+        ConfigBuilder result = instance.applyOverrides(configBuilder, KeyDataBuilder.create());
 
         Path expected = Paths.get(socketFilepath);
 
@@ -591,16 +640,17 @@ public class LegacyCliAdapterTest {
 
     @Test
     public void ifTomlWorkDirNotProvidedButOverrideWorkDirIsThenOverrideWorkDirUsedOnOverridenValues() {
-        CommandLine line = mock(CommandLine.class);
         String overrideWorkDir = "override";
-        when(line.getOptionValue("workdir")).thenReturn(overrideWorkDir);
-        when(line.getOptionValue("workdir", ".")).thenReturn(overrideWorkDir);
         String socketFilepath = "path/to/socket.ipc";
-        when(line.getOptionValue("socket")).thenReturn(socketFilepath);
+
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.socket = socketFilepath;
+        mixin.workdir = overrideWorkDir;
+        instance.setOverrides(mixin);
 
         ConfigBuilder configBuilder = ConfigBuilder.create();
 
-        ConfigBuilder result = LegacyCliAdapter.applyOverrides(line, configBuilder, KeyDataBuilder.create());
+        ConfigBuilder result = instance.applyOverrides(configBuilder, KeyDataBuilder.create());
 
         Path expected = Paths.get(overrideWorkDir, socketFilepath);
 
@@ -609,86 +659,55 @@ public class LegacyCliAdapterTest {
 
     @Test
     public void applyOverrides() throws Exception {
+        final int portOverride = 9999;
+        final String unixSocketFileOverride = "unixSocketFileOverride.ipc";
+        final String workdirOverride = "workdirOverride";
+        final List<Peer> overridePeers =
+                Arrays.asList(new Peer("http://otherone.com:9188/other"), new Peer("http://yetanother.com:8829/other"));
 
-        String urlOverride = "http://junit.com:8989";
-        int portOverride = 9999;
-        String unixSocketFileOverride = "unixSocketFileOverride.ipc";
-        String workdirOverride = "workdirOverride";
-        List<Peer> overridePeers = Arrays.asList(new Peer("http://otherone.com:9188/other"), new Peer("http://yetanother.com:8829/other"));
-
-        CommandLine commandLine = mock(CommandLine.class);
-
-        //TODO check all CLI options have assertions here
-        when(commandLine.getOptionValue("url")).thenReturn(urlOverride);
-        when(commandLine.getOptionValue("port")).thenReturn(String.valueOf(portOverride));
-        when(commandLine.getOptionValue("workdir")).thenReturn(workdirOverride);
-        when(commandLine.getOptionValue("socket")).thenReturn(unixSocketFileOverride);
-
-        when(commandLine.getOptionValues("othernodes"))
-                .thenReturn(
-                        overridePeers.stream().map(Peer::getUrl).toArray(String[]::new)
-                );
-
-        when(commandLine.getOptionValues("publickeys"))
-                .thenReturn(new String[]{"ONE", "TWO"});
-
-        when(commandLine.getOptionValue("storage")).thenReturn("sqlite:somepath");
-
-        when(commandLine.getOptionValue("tlsservertrust")).thenReturn("whitelist");
-
-        when(commandLine.getOptionValue("tlsclienttrust")).thenReturn("ca");
-
-        when(commandLine.getOptionValue("tlsservercert")).thenReturn("tlsservercert.cert");
-
-        when(commandLine.getOptionValue("tlsclientcert")).thenReturn("tlsclientcert.cert");
-
-        when(commandLine.getOptionValues("tlsserverchain")).thenReturn(new String[]{
-            "server1.crt", "server2.crt", "server3.crt"
-        });
-
-        when(commandLine.getOptionValues("tlsclientchain")).thenReturn(new String[]{
-            "client1.crt", "client2.crt", "client3.crt"
-        });
-
-        when(commandLine.getOptionValue("tlsserverkey"))
-                .thenReturn("tlsserverkey.key");
-
-        when(commandLine.getOptionValue("tlsclientkey"))
-                .thenReturn("tlsclientkey.key");
-
-        doReturn(new String[]{}).when(commandLine).getOptionValues("alwayssendto");
-
-        List<Path> privateKeyPaths = Arrays.asList(
-                Files.createTempFile("applyOverrides1", ".txt"),
-                Files.createTempFile("applyOverrides2", ".txt")
-        );
-
-        when(commandLine.getOptionValue("tlsknownservers")).thenReturn("tlsknownservers.file");
-
-        when(commandLine.getOptionValue("tlsknownclients")).thenReturn("tlsknownclients.file");
+        final List<Path> privateKeyPaths =
+                Arrays.asList(
+                        Files.createTempFile("applyOverrides1", ".txt"),
+                        Files.createTempFile("applyOverrides2", ".txt"));
 
         final byte[] privateKeyData = FixtureUtil.createLockedPrivateKey().toString().getBytes();
         for (Path p : privateKeyPaths) {
             Files.write(p, privateKeyData);
         }
 
-        final String[] privateKeyPathStrings = privateKeyPaths
-                .stream()
-                .map(Path::toString)
-                .toArray(String[]::new);
-
-        when(commandLine.getOptionValues("privatekeys")).thenReturn(privateKeyPathStrings);
-
         final List<String> privateKeyPasswords = Arrays.asList("SECRET1", "SECRET2");
-
         final Path privateKeyPasswordFile = Files.createTempFile("applyOverridesPasswords", ".txt");
         Files.write(privateKeyPasswordFile, privateKeyPasswords);
 
-        when(commandLine.getOptionValue("passwords")).thenReturn(privateKeyPasswordFile.toString());
+        final LegacyOverridesMixin mixin = new LegacyOverridesMixin();
+        mixin.url = "http://junit.com:8989";
+        mixin.port = portOverride;
+        mixin.socket = unixSocketFileOverride;
+        mixin.workdir = workdirOverride;
+        mixin.othernodes = overridePeers.stream().map(Peer::getUrl).collect(toList());
+        mixin.publickeys = Stream.of("ONE", "TWO").collect(toList());
+        mixin.storage = "sqlite:somepath";
+        mixin.tlsservertrust = SslTrustMode.WHITELIST;
+        mixin.tlsclienttrust = SslTrustMode.CA;
+        mixin.tlsservercert = "tlsservercert.cert";
+        mixin.tlsclientcert = "tlsclientcert.cert";
+        mixin.tlsserverchain = Stream.of("server1.crt", "server2.crt", "server3.crt").collect(toList());
+        mixin.tlsclientchain = Stream.of("client1.crt", "client2.crt", "client3.crt").collect(toList());
+        mixin.tlsserverkey = "tlsserverkey.key";
+        mixin.tlsclientkey = "tlsclientkey.key";
+        mixin.privatekeys = privateKeyPaths.stream().map(Path::toString).collect(toList());
+        mixin.passwords = privateKeyPasswordFile.toString();
+        mixin.tlsknownclients = "tlsknownclients.file";
+        mixin.tlsknownservers = "tlsknownservers.file";
+        mixin.alwayssendto = new ArrayList<>();
+        instance.setOverrides(mixin);
 
-        Config result = LegacyCliAdapter.applyOverrides(commandLine, builderWithValidValues, KeyDataBuilder.create()).build();
+        final Config result = instance.applyOverrides(builderWithValidValues, KeyDataBuilder.create()).build();
 
         assertThat(result).isNotNull();
+
+        final SslConfig sslConfig = result.getServer().getSslConfig();
+
         assertThat(result.getServer().getHostName()).isEqualTo("http://junit.com");
         assertThat(result.getServer().getPort()).isEqualTo(portOverride);
         assertThat(result.getServer().getBindingAddress()).isEqualTo("http://junit.com:" + portOverride);
@@ -698,37 +717,34 @@ public class LegacyCliAdapterTest {
         assertThat(result.getJdbcConfig()).isNotNull();
         assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:sqlite:somepath");
 
-        assertThat(result.getServer().getSslConfig().getServerTrustMode()).isEqualTo(SslTrustMode.WHITELIST);
-        assertThat(result.getServer().getSslConfig().getClientTrustMode()).isEqualTo(SslTrustMode.CA);
+        assertThat(sslConfig.getServerTrustMode()).isEqualTo(SslTrustMode.WHITELIST);
+        assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA);
+        assertThat(sslConfig.getClientTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsclientcert.cert"));
+        assertThat(sslConfig.getServerTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsservercert.cert"));
 
-        assertThat(result.getServer().getSslConfig().getClientTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsclientcert.cert"));
+        assertThat(sslConfig.getServerTrustCertificates())
+                .containsExactly(
+                        Paths.get(workdirOverride, "server1.crt"),
+                        Paths.get(workdirOverride, "server2.crt"),
+                        Paths.get(workdirOverride, "server3.crt"));
 
-        assertThat(result.getServer().getSslConfig().getServerTlsCertificatePath()).isEqualTo(Paths.get("workdirOverride/tlsservercert.cert"));
+        assertThat(sslConfig.getClientTrustCertificates())
+                .containsExactly(
+                        Paths.get(workdirOverride, "client1.crt"),
+                        Paths.get(workdirOverride, "client2.crt"),
+                        Paths.get(workdirOverride, "client3.crt"));
 
-        assertThat(result.getServer().getSslConfig().getServerTrustCertificates())
-                .containsExactly(Paths.get(workdirOverride, "server1.crt"), Paths.get(workdirOverride, "server2.crt"), Paths.get(workdirOverride, "server3.crt"));
-
-        assertThat(result.getServer().getSslConfig().getClientTrustCertificates())
-                .containsExactly(Paths.get(workdirOverride, "client1.crt"), Paths.get(workdirOverride, "client2.crt"), Paths.get(workdirOverride, "client3.crt"));
-
-        assertThat(result.getServer().getSslConfig().getServerKeyStore())
-                .isEqualTo(Paths.get("workdirOverride/sslServerKeyStorePath"));
-        assertThat(result.getServer().getSslConfig().getClientKeyStore())
-                .isEqualTo(Paths.get("workdirOverride/sslClientKeyStorePath"));
-        assertThat(result.getServer().getSslConfig().getKnownServersFile())
-                .isEqualTo(Paths.get("workdirOverride/tlsknownservers.file"));
-        assertThat(result.getServer().getSslConfig().getKnownClientsFile())
-                .isEqualTo(Paths.get(workdirOverride, "tlsknownclients.file"));
+        assertThat(sslConfig.getServerKeyStore()).isEqualTo(Paths.get("workdirOverride/sslServerKeyStorePath"));
+        assertThat(sslConfig.getClientKeyStore()).isEqualTo(Paths.get("workdirOverride/sslClientKeyStorePath"));
+        assertThat(sslConfig.getKnownServersFile()).isEqualTo(Paths.get("workdirOverride/tlsknownservers.file"));
+        assertThat(sslConfig.getKnownClientsFile()).isEqualTo(Paths.get(workdirOverride, "tlsknownclients.file"));
     }
 
     @Test
     public void applyOverridesNullValues() {
-
         Config expectedValues = builderWithValidValues.build();
 
-        CommandLine commandLine = mock(CommandLine.class);
-
-        Config result = LegacyCliAdapter.applyOverrides(commandLine, builderWithValidValues, KeyDataBuilder.create()).build();
+        Config result = instance.applyOverrides(builderWithValidValues, KeyDataBuilder.create()).build();
 
         assertThat(result).isNotNull();
 
@@ -766,5 +782,4 @@ public class LegacyCliAdapterTest {
 
         assertThat(result.getStatus()).isEqualTo(2);
     }
-
 }

--- a/data-migration/pom.xml
+++ b/data-migration/pom.xml
@@ -52,12 +52,12 @@
             <artifactId>ddls</artifactId>
         </dependency>
 
-        <!-- Apache Commons -->
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
+            <groupId>com.jpmorgan.quorum</groupId>
+            <artifactId>cli-api</artifactId>
         </dependency>
 
+        <!-- Apache Commons -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/data-migration/src/main/java/com/quorum/tessera/data/migration/Main.java
+++ b/data-migration/src/main/java/com/quorum/tessera/data/migration/Main.java
@@ -1,18 +1,21 @@
 package com.quorum.tessera.data.migration;
 
+import com.quorum.tessera.cli.CliDelegate;
+import com.quorum.tessera.cli.CliResult;
+
 import java.util.Arrays;
 
 public class Main {
-    
+
     private Main() {
         throw new UnsupportedOperationException("");
     }
-    
+
     public static void main(final String... args) {
 
         try {
-            final int result = new CmdLineExecutor().execute(args);
-            System.exit(result);
+            final CliResult cliResult = CliDelegate.instance().execute(args);
+            System.exit(cliResult.getStatus());
         } catch (final Exception ex) {
             System.err.println("An error has occurred: " + ex.getMessage());
 
@@ -24,7 +27,5 @@ public class Main {
 
             System.exit(1);
         }
-
     }
-    
 }

--- a/data-migration/src/main/resources/META-INF/services/com.quorum.tessera.cli.CliAdapter
+++ b/data-migration/src/main/resources/META-INF/services/com.quorum.tessera.cli.CliAdapter
@@ -1,0 +1,1 @@
+com.quorum.tessera.data.migration.CmdLineExecutor

--- a/data-migration/src/test/java/com/quorum/tessera/data/migration/MainTest.java
+++ b/data-migration/src/test/java/com/quorum/tessera/data/migration/MainTest.java
@@ -4,27 +4,53 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public class MainTest {
 
-    @Rule
-    public final ExpectedSystemExit expectedSystemExit = ExpectedSystemExit.none();
+    @Rule public final ExpectedSystemExit expectedSystemExit = ExpectedSystemExit.none();
 
     @Test
-    public void doStuff() {
+    public void performValidMigration() throws IOException, URISyntaxException {
         expectedSystemExit.expectSystemExitWithStatus(0);
-        Main.main("help");
+
+        final Path inputFile = Paths.get(getClass().getResource("/bdb/single-entry.txt").toURI());
+        final Path outputPath = Files.createTempFile("db", ".db");
+
+        Main.main(
+                "-storetype",
+                "bdb",
+                "-inputpath",
+                inputFile.toString(),
+                "-exporttype",
+                "h2",
+                "-outputfile",
+                outputPath.toString(),
+                "-dbpass",
+                "-dbuser");
     }
 
     @Test
-    public void doStuffAndBreak() {
+    public void outputDebugInformationWithNullCause() throws IOException {
         expectedSystemExit.expectSystemExitWithStatus(1);
-        Main.main();
-    }
 
-    @Test
-    public void outputDebugInformationWithNullCause() {
-        expectedSystemExit.expectSystemExitWithStatus(1);
-        Main.main("debug");
-    }
+        final Path outputPath = Files.createTempFile("db", ".db");
 
+        Main.main(
+                "-storetype",
+                "bdb",
+                "-inputpath",
+                "non-existent",
+                "-exporttype",
+                "h2",
+                "-outputfile",
+                outputPath.toString(),
+                "-dbpass",
+                "-dbuser",
+                "debug");
+    }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/migration/config/ConfigMigrationIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/migration/config/ConfigMigrationIT.java
@@ -2,19 +2,10 @@ package com.quorum.tessera.test.migration.config;
 
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    features = "classpath:features/migration/config-migration.feature",
-    plugin = {"pretty"}
-)
-public class ConfigMigrationIT {
-
-    @BeforeClass
-    public static void onSetup() {
-        //    only needed when running outside of maven build process
-//        System.setProperty("config-migration-app.jar", "/Users/chris/jpmc-tessera/config-migration/target/config-migration-0.9-SNAPSHOT-cli.jar");
-    }
-}
+        features = "classpath:features/migration/config-migration.feature",
+        plugin = {"pretty"})
+public class ConfigMigrationIT {}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/migration/config/ConfigMigrationSteps.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/migration/config/ConfigMigrationSteps.java
@@ -5,18 +5,13 @@ import com.quorum.tessera.config.keypairs.FilesystemKeyPair;
 import com.quorum.tessera.config.util.JaxbUtil;
 import cucumber.api.java8.En;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
-import java.net.URL;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,124 +23,124 @@ public class ConfigMigrationSteps implements En {
 
     public ConfigMigrationSteps() {
 
-        Given("^(.+) exists$", (String filePath) -> {
-            URL url = getClass().getResource(filePath);
-            assertThat(url).isNotNull();
-        });
+        Given("^(.+) exists$", (String filePath) -> assertThat(getClass().getResource(filePath)).isNotNull());
 
-        Given("^the outputfile is created$", () -> {
-            assertThat(Files.exists(outputFile)).isTrue();
-        });
+        Given("^the outputfile is created$", () -> assertThat(Files.exists(outputFile)).isTrue());
 
-        When("the Config Migration Utility is run with tomlfile (.+) and --outputfile option", (String toml) -> {
-            final String jarfile = System.getProperty("config-migration-app.jar");
+        When(
+                "the Config Migration Utility is run with tomlfile (.+) and --outputfile option",
+                (String toml) -> {
+                    final String jarfile = System.getProperty("config-migration-app.jar");
 
-            outputFile = Paths.get("target", UUID.randomUUID().toString());
+                    outputFile = Paths.get("target", UUID.randomUUID().toString());
 
-            assertThat(Files.exists(outputFile)).isFalse();
+                    assertThat(Files.exists(outputFile)).isFalse();
 
-            List<String> args = new ArrayList<>();
-            args.addAll(
-                Arrays.asList(
-                    "java",
-                    "-jar",
-                    jarfile,
-                    "--tomlfile=" + getAbsolutePath(toml).toString(),
-                    "--outputfile=" + outputFile.toAbsolutePath().toString()
-                )
-            );
-            System.out.println(String.join(" ", args));
+                    List<String> args =
+                            new ArrayList<>(
+                                    Arrays.asList(
+                                            "java",
+                                            "-jar",
+                                            jarfile,
+                                            "--tomlfile",
+                                            getAbsolutePath(toml).toString(),
+                                            "--outputfile",
+                                            outputFile.toAbsolutePath().toString()));
+                    System.out.println(String.join(" ", args));
 
-            ProcessBuilder configMigrationProcessBuilder = new ProcessBuilder(args);
+                    ProcessBuilder configMigrationProcessBuilder = new ProcessBuilder(args);
 
-            final Process configMigrationProcess = configMigrationProcessBuilder
-                .redirectErrorStream(true)
-                .start();
+                    final Process configMigrationProcess =
+                            configMigrationProcessBuilder.redirectErrorStream(true).start();
 
-            executorService.submit(() -> {
+                    executorService.submit(
+                            () -> {
+                                final InputStream inputStream = configMigrationProcess.getInputStream();
+                                try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+                                    String line;
+                                    while ((line = reader.readLine()) != null) {
+                                        System.out.println(line);
+                                    }
+                                } catch (IOException ex) {
+                                    throw new UncheckedIOException(ex);
+                                }
+                            });
 
-                try(BufferedReader reader = Stream.of(configMigrationProcess.getInputStream())
-                    .map(InputStreamReader::new)
-                    .map(BufferedReader::new)
-                    .findAny().get()) {
+                    configMigrationProcess.waitFor();
 
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        System.out.println(line);
+                    if (configMigrationProcess.isAlive()) {
+                        configMigrationProcess.destroy();
                     }
+                });
 
-                } catch (IOException ex) {
-                    throw new UncheckedIOException(ex);
-                }
-            });
+        Then(
+                "(.+) and the outputfile are equivalent",
+                (String legacyPath) -> {
+                    final Config migratedConfig = JaxbUtil.unmarshal(Files.newInputStream(outputFile), Config.class);
 
-            configMigrationProcess.waitFor();
+                    // TODO These values were retrieved from legacy.toml.  Ideally legacyConfig would be generated by
+                    // unmarshalling legacy.toml but didn't want to use the toml unmarshalling production code in the
+                    // test
+                    final SslConfig sslConfig = new SslConfig();
+                    sslConfig.setTls(SslAuthenticationMode.STRICT);
+                    sslConfig.setServerTlsCertificatePath(Paths.get("data", "tls-server-cert.pem").toAbsolutePath());
+                    sslConfig.setServerTlsKeyPath(Paths.get("data", "tls-server-key.pem").toAbsolutePath());
+                    sslConfig.setServerTrustCertificates(Collections.emptyList());
+                    sslConfig.setServerTrustMode(SslTrustMode.TOFU);
+                    sslConfig.setKnownClientsFile(Paths.get("data", "tls-known-clients").toAbsolutePath());
+                    sslConfig.setClientTlsCertificatePath(Paths.get("data", "tls-client-cert.pem").toAbsolutePath());
+                    sslConfig.setClientTlsKeyPath(Paths.get("data", "tls-client-key.pem").toAbsolutePath());
+                    sslConfig.setClientTrustCertificates(Collections.emptyList());
+                    sslConfig.setClientTrustMode(SslTrustMode.CA_OR_TOFU);
+                    sslConfig.setKnownServersFile(Paths.get("data", "tls-known-servers").toAbsolutePath());
 
-            if(configMigrationProcess.isAlive()) {
-                configMigrationProcess.destroy();
-            }
-        });
+                    final DeprecatedServerConfig server = new DeprecatedServerConfig();
+                    server.setSslConfig(sslConfig);
+                    server.setHostName("http://127.0.0.1");
+                    server.setPort(9001);
+                    server.setCommunicationType(CommunicationType.REST);
 
-        Then("(.+) and the outputfile are equivalent", (String legacyPath) -> {
-            final Config migratedConfig = JaxbUtil.unmarshal(Files.newInputStream(outputFile), Config.class);
+                    final KeyConfiguration keys = new KeyConfiguration();
+                    keys.setKeyData(
+                            Arrays.asList(
+                                    new FilesystemKeyPair(
+                                            Paths.get("data", "foo.pub").toAbsolutePath(),
+                                            Paths.get("data", "foo.key").toAbsolutePath())));
+                    keys.setPasswordFile(Paths.get("data", "passwords").toAbsolutePath());
 
-            //TODO These values were retrieved from legacy.toml.  Ideally legacyConfig would be generated by unmarshalling legacy.toml but didn't want to use the toml unmarshalling production code in the test
-            final SslConfig sslConfig = new SslConfig();
-            sslConfig.setTls(SslAuthenticationMode.STRICT);
-            sslConfig.setServerTlsCertificatePath(Paths.get("data", "tls-server-cert.pem").toAbsolutePath());
-            sslConfig.setServerTlsKeyPath(Paths.get("data", "tls-server-key.pem").toAbsolutePath());
-            sslConfig.setServerTrustCertificates(Collections.emptyList());
-            sslConfig.setServerTrustMode(SslTrustMode.TOFU);
-            sslConfig.setKnownClientsFile(Paths.get("data", "tls-known-clients").toAbsolutePath());
-            sslConfig.setClientTlsCertificatePath(Paths.get("data", "tls-client-cert.pem").toAbsolutePath());
-            sslConfig.setClientTlsKeyPath(Paths.get("data", "tls-client-key.pem").toAbsolutePath());
-            sslConfig.setClientTrustCertificates(Collections.emptyList());
-            sslConfig.setClientTrustMode(SslTrustMode.CA_OR_TOFU);
-            sslConfig.setKnownServersFile(Paths.get("data", "tls-known-servers").toAbsolutePath());
+                    final JdbcConfig jdbcConfig = new JdbcConfig();
+                    jdbcConfig.setUrl("jdbc:h2:mem:tessera");
 
-            final DeprecatedServerConfig server = new DeprecatedServerConfig();
-            server.setSslConfig(sslConfig);
-            server.setHostName("http://127.0.0.1");
-            server.setPort(9001);
-            server.setCommunicationType(CommunicationType.REST);
+                    final Config legacyConfig = new Config();
+                    legacyConfig.setServer(server);
+                    legacyConfig.setPeers(Arrays.asList(new Peer("http://127.0.0.1:9000/")));
+                    legacyConfig.setKeys(keys);
+                    legacyConfig.setJdbcConfig(jdbcConfig);
+                    legacyConfig.setUnixSocketFile(Paths.get("data", "constellation.ipc").toAbsolutePath());
+                    legacyConfig.setAlwaysSendTo(Collections.emptyList());
 
-            final KeyConfiguration keys = new KeyConfiguration();
-            keys.setKeyData(Arrays.asList(
-                new FilesystemKeyPair(
-                    Paths.get("data", "foo.pub").toAbsolutePath(),
-                    Paths.get("data", "foo.key").toAbsolutePath())
-            ));
-            keys.setPasswordFile(Paths.get("data", "passwords").toAbsolutePath());
-
-            final JdbcConfig jdbcConfig = new JdbcConfig();
-            jdbcConfig.setUrl("jdbc:h2:mem:tessera");
-
-            final Config legacyConfig = new Config();
-            legacyConfig.setServer(server);
-            legacyConfig.setPeers(Arrays.asList(new Peer("http://127.0.0.1:9000/")));
-            legacyConfig.setKeys(keys);
-            legacyConfig.setJdbcConfig(jdbcConfig);
-            legacyConfig.setUnixSocketFile(Paths.get("data", "constellation.ipc").toAbsolutePath());
-            legacyConfig.setAlwaysSendTo(Collections.emptyList());
-
-            assertThat(migratedConfig.getServer()).isEqualToComparingFieldByFieldRecursively(legacyConfig.getServer());
-            assertThat(migratedConfig.getKeys()).isEqualToComparingFieldByFieldRecursively(legacyConfig.getKeys());
-            assertThat(migratedConfig.getUnixSocketFile()).isEqualTo(legacyConfig.getUnixSocketFile());
-            assertThat(migratedConfig.getJdbcConfig()).isEqualToComparingFieldByField(legacyConfig.getJdbcConfig());
-            assertThat(migratedConfig.getP2PServerConfig()).isEqualToComparingFieldByFieldRecursively(legacyConfig.getP2PServerConfig());
-            assertThat(migratedConfig.getAlwaysSendTo()).isEqualTo(legacyConfig.getAlwaysSendTo());
-            assertThat(migratedConfig.getServerConfigs().size()).isEqualTo(legacyConfig.getServerConfigs().size());
-            assertThat(migratedConfig.getServerConfigs()).hasSize(2);
-            assertThat(migratedConfig.getServerConfigs()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(legacyConfig.getServerConfigs().get(0), legacyConfig.getServerConfigs().get(1));
-            assertThat(migratedConfig.getPeers()).isEqualTo(legacyConfig.getPeers());
-        });
-
+                    assertThat(migratedConfig.getServer())
+                            .isEqualToComparingFieldByFieldRecursively(legacyConfig.getServer());
+                    assertThat(migratedConfig.getKeys())
+                            .isEqualToComparingFieldByFieldRecursively(legacyConfig.getKeys());
+                    assertThat(migratedConfig.getUnixSocketFile()).isEqualTo(legacyConfig.getUnixSocketFile());
+                    assertThat(migratedConfig.getJdbcConfig())
+                            .isEqualToComparingFieldByField(legacyConfig.getJdbcConfig());
+                    assertThat(migratedConfig.getP2PServerConfig())
+                            .isEqualToComparingFieldByFieldRecursively(legacyConfig.getP2PServerConfig());
+                    assertThat(migratedConfig.getAlwaysSendTo()).isEqualTo(legacyConfig.getAlwaysSendTo());
+                    assertThat(migratedConfig.getServerConfigs().size())
+                            .isEqualTo(legacyConfig.getServerConfigs().size());
+                    assertThat(migratedConfig.getServerConfigs()).hasSize(2);
+                    assertThat(migratedConfig.getServerConfigs())
+                            .usingRecursiveFieldByFieldElementComparator()
+                            .containsExactlyInAnyOrder(
+                                    legacyConfig.getServerConfigs().get(0), legacyConfig.getServerConfigs().get(1));
+                    assertThat(migratedConfig.getPeers()).isEqualTo(legacyConfig.getPeers());
+                });
     }
 
     private Path getAbsolutePath(String filePath) throws Exception {
-        URL url = getClass().getResource(filePath);
-
-        return Paths.get(url.toURI()).toAbsolutePath();
+        return Paths.get(getClass().getResource(filePath).toURI()).toAbsolutePath();
     }
-
 }


### PR DESCRIPTION
This PR removes `commons-cli` from the data and config migration tools and replaces it with PicoCLI, in line with other changes recently made.

It enforces standard usage of CLI adapters, by making them go through the `CliDelegate`, as the main applications do; this also means that they must implement the `CliAdapter` interface and be loaded via the Service Loader like everything else.

I decided to use public variables for the override options to save boilerplate; both in the main code (no getters) and for test code (no setters). Although, if desired, I can work around this.

---

- Add a `DATA_MIGRATION` CLI adapter type, which was erroneously missing before.
- Fixes using `=` as the CLI separator for the `port` override.
- Enforces spacing as the only separator in general for overrides. Previously, both spaces or `=` were accepted, and specifically `=` was used in tests. This is out of line from what the other tools/applications accept.