### PR TITLE
Transactional boundary issue for resend

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -202,7 +202,6 @@ public class TransactionManagerImpl implements TransactionManager {
     }
 
     @Override
-    @Transactional
     public ResendResponse resend(ResendRequest request) {
 
         final byte[] publicKeyData = base64Decoder.decode(request.getPublicKey());


### PR DESCRIPTION
The transactional boundary was incorrectly set (via transactional annotation) at the TransactionManager method level (there was already one at the DAO layer).

In resend method, when recovery needs to be done for large datasets, due to db results pagination, 
the resultSet was listed multiple times within this transactional boundary, which results in an increase in memory used that can potentially cause OutOfMemory exception