### PR TITLE
Update config migration tool to use individual servers

### DIFF
--- a/config-migration/src/main/java/com/quorum/tessera/config/builder/ConfigBuilder.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/builder/ConfigBuilder.java
@@ -9,12 +9,14 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.quorum.tessera.config.AppType.P2P;
+import static com.quorum.tessera.config.AppType.Q2T;
+import static com.quorum.tessera.config.CommunicationType.REST;
 import static java.util.Collections.emptyList;
 
 public class ConfigBuilder {
 
-    private ConfigBuilder() {
-    }
+    private ConfigBuilder() {}
 
     public static ConfigBuilder create() {
         return new ConfigBuilder();
@@ -22,7 +24,7 @@ public class ConfigBuilder {
 
     private String serverHostname;
 
-    private Integer serverPort;
+    private Integer serverPort = 0;
 
     private JdbcConfig jdbcConfig;
 
@@ -206,75 +208,70 @@ public class ConfigBuilder {
         return this;
     }
 
-    static Path toPath(String workDir, String value) {
-        final Path path;
-
-        if(Optional.ofNullable(workDir).isPresent() && Optional.ofNullable(value).isPresent()) {
-            path = Paths.get(workDir, value);
-        } else if(Optional.ofNullable(value).isPresent()) {
-            path = Paths.get(value);
-        } else {
-            path = null;
+    static Path toPath(final String workDir, final String value) {
+        if (workDir != null && value != null) {
+            return Paths.get(workDir, value);
+        } else if (value != null) {
+            return Paths.get(value);
         }
-
-        return path;
+        return null;
     }
 
     public Config build() {
 
         boolean generateKeyStoreIfNotExisted = false;
 
-        SslConfig sslConfig = new SslConfig(
-                sslAuthenticationMode,
-                generateKeyStoreIfNotExisted,
-                toPath(workDir, sslServerKeyStorePath),
-                sslServerKeyStorePassword,
-                toPath(workDir, sslServerTrustStorePath),
-                sslServerTrustStorePassword,
-                sslServerTrustMode,
-                toPath(workDir, sslClientKeyStorePath),
-                sslClientKeyStorePassword,
-                toPath(workDir, sslClientTrustStorePath),
-                sslClientTrustStorePassword,
-                sslClientTrustMode,
-                toPath(workDir, sslKnownClientsFile),
-                toPath(workDir, sslKnownServersFile),
-                sslServerTrustCertificates.stream()
-                        .filter(Objects::nonNull)
-                        .map(v -> toPath(workDir, v))
-                        .collect(Collectors.toList()),
-                sslClientTrustCertificates.stream()
-                        .filter(Objects::nonNull)
-                        .map(v -> toPath(workDir, v))
-                        .collect(Collectors.toList()),
-                toPath(workDir, sslServerTlsKeyPath),
-                toPath(workDir, sslServerTlsCertificatePath),
-                toPath(workDir, sslClientTlsKeyPath),
-                toPath(workDir, sslClientTlsCertificatePath),
-                null
-        );
+        SslConfig sslConfig =
+                new SslConfig(
+                        sslAuthenticationMode,
+                        generateKeyStoreIfNotExisted,
+                        toPath(workDir, sslServerKeyStorePath),
+                        sslServerKeyStorePassword,
+                        toPath(workDir, sslServerTrustStorePath),
+                        sslServerTrustStorePassword,
+                        sslServerTrustMode,
+                        toPath(workDir, sslClientKeyStorePath),
+                        sslClientKeyStorePassword,
+                        toPath(workDir, sslClientTrustStorePath),
+                        sslClientTrustStorePassword,
+                        sslClientTrustMode,
+                        toPath(workDir, sslKnownClientsFile),
+                        toPath(workDir, sslKnownServersFile),
+                        sslServerTrustCertificates.stream()
+                                .filter(Objects::nonNull)
+                                .map(v -> toPath(workDir, v))
+                                .collect(Collectors.toList()),
+                        sslClientTrustCertificates.stream()
+                                .filter(Objects::nonNull)
+                                .map(v -> toPath(workDir, v))
+                                .collect(Collectors.toList()),
+                        toPath(workDir, sslServerTlsKeyPath),
+                        toPath(workDir, sslServerTlsCertificatePath),
+                        toPath(workDir, sslClientTlsKeyPath),
+                        toPath(workDir, sslClientTlsCertificatePath),
+                        null);
 
-        //TODO must add P2P and Q2T server configs. Maybe ThirdParty too - in disabled state.
-        //serverHostname, serverPort, 50521, CommunicationType.REST, sslConfig, null, null, null
-        final DeprecatedServerConfig serverConfig = new DeprecatedServerConfig();
-        serverConfig.setPort(serverPort);
-        serverConfig.setHostName(serverHostname);
-        serverConfig.setCommunicationType(CommunicationType.REST);
-        serverConfig.setSslConfig(sslConfig);
-        
+        final String unixPath =
+                Optional.ofNullable(toPath(workDir, unixSocketFile))
+                        .map(Path::toAbsolutePath)
+                        .map(Path::toString)
+                        .map("unix:"::concat)
+                        .orElse(null);
+        final ServerConfig q2tConfig = new ServerConfig(Q2T, true, unixPath, REST, null, null, null);
+
+        final String address = (serverHostname == null) ? null : serverHostname + ":" + serverPort;
+        final ServerConfig p2pConfig = new ServerConfig(P2P, true, address, REST, sslConfig, null, address);
+
         final List<Peer> peerList;
-        if(peers != null) {
-            peerList = peers.stream()
-                            .map(Peer::new)
-                            .collect(Collectors.toList());
+        if (peers != null) {
+            peerList = peers.stream().map(Peer::new).collect(Collectors.toList());
         } else {
             peerList = null;
         }
 
         final List<String> forwardingKeys = new ArrayList<>();
-        if(alwaysSendTo != null) {
-
-            for(String keyPath : alwaysSendTo) {
+        if (alwaysSendTo != null) {
+            for (String keyPath : alwaysSendTo) {
                 try {
                     List<String> keysFromFile = Files.readAllLines(toPath(workDir, keyPath));
                     forwardingKeys.addAll(keysFromFile);
@@ -284,16 +281,14 @@ public class ConfigBuilder {
             }
         }
 
-        Config config = new Config();
-        config.setServer(serverConfig);
+        final Config config = new Config();
+        config.setServerConfigs(Arrays.asList(q2tConfig, p2pConfig));
         config.setJdbcConfig(jdbcConfig);
         config.setPeers(peerList);
         config.setAlwaysSendTo(forwardingKeys);
-        config.setUnixSocketFile(toPath(workDir, unixSocketFile));
         config.setUseWhiteList(useWhiteList);
         config.setKeys(keyData);
         config.setDisablePeerDiscovery(false);
         return config;
     }
-
 }

--- a/config-migration/src/main/java/com/quorum/tessera/config/migration/TomlConfigFactory.java
+++ b/config-migration/src/main/java/com/quorum/tessera/config/migration/TomlConfigFactory.java
@@ -43,9 +43,7 @@ public class TomlConfigFactory {
             }).map(uri -> uri.getProtocol() + "://" + uri.getHost())
             .orElse(null);
 
-        final Integer port = Optional.ofNullable(toml.getLong("port"))
-            .map(Long::intValue)
-            .orElse(null);
+        final Integer port = Optional.ofNullable(toml.getLong("port")).map(Long::intValue).orElse(0);
 
         final String workdir = toml.getString("workdir", "");
         final String socket = toml.getString("socket");
@@ -61,18 +59,18 @@ public class TomlConfigFactory {
         final List<String> ipwhitelist = toml.getList("ipwhitelist", emptyList());
         final boolean useWhiteList = !ipwhitelist.isEmpty();
 
-        //Server side
+        // Server side
         final String tlsservertrust = toml.getString("tlsservertrust", "tofu");
         final Optional<String> tlsserverkey = Optional.ofNullable(toml.getString("tlsserverkey"));
         final Optional<String> tlsservercert = Optional.ofNullable(toml.getString("tlsservercert"));
-        final Optional<List<String>> tlsserverchainnames = Optional.ofNullable(toml.getList("tlsserverchain", emptyList()));
+        final Optional<List<String>> tlsserverchainnames = Optional.of(toml.getList("tlsserverchain", emptyList()));
         final Optional<String> tlsknownclients = Optional.ofNullable(toml.getString("tlsknownclients"));
 
-        //Client side
+        // Client side
         final String tlsclienttrust = toml.getString("tlsclienttrust", "tofu");
         final Optional<String> tlsclientkey = Optional.ofNullable(toml.getString("tlsclientkey"));
         final Optional<String> tlsclientcert = Optional.ofNullable(toml.getString("tlsclientcert"));
-        final Optional<List<String>> tlsclientchainnames = Optional.ofNullable(toml.getList("tlsclientchain", emptyList()));
+        final Optional<List<String>> tlsclientchainnames = Optional.of(toml.getList("tlsclientchain", emptyList()));
         final Optional<String> tlsknownservers = Optional.ofNullable(toml.getString("tlsknownservers"));
 
         ConfigBuilder configBuilder = ConfigBuilder.create()
@@ -120,5 +118,4 @@ public class TomlConfigFactory {
             .withPrivateKeyPasswordFile(pwd)
             .withWorkingDirectory(workdir);
     }
-
 }

--- a/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/builder/ConfigBuilderTest.java
@@ -1,7 +1,8 @@
 package com.quorum.tessera.config.builder;
 
+import com.quorum.tessera.config.AppType;
 import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.DeprecatedServerConfig;
+import com.quorum.tessera.config.ServerConfig;
 import com.quorum.tessera.config.SslConfig;
 import com.quorum.tessera.config.keypairs.ConfigKeyPair;
 import com.quorum.tessera.config.migration.test.FixtureUtil;
@@ -17,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigBuilderTest {
 
-    @Rule
-    public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    @Rule public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
     private final ConfigBuilder builderWithValidValues = FixtureUtil.builderWithValidValues();
 
@@ -34,22 +34,22 @@ public class ConfigBuilderTest {
 
         assertThat(result).isNotNull();
 
-        assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get("somepath.ipc"));
+        final ServerConfig unixServer =
+                result.getServerConfigs().stream().filter(s -> s.getApp() == AppType.Q2T).findAny().get();
+        assertThat(unixServer.getServerAddress()).isEqualTo("unix:" + Paths.get("somepath.ipc").toAbsolutePath());
 
         assertThat(result.getKeys().getKeyData()).hasSize(1);
         final ConfigKeyPair keyData = result.getKeys().getKeyData().get(0);
         assertThat(keyData).isNotNull().extracting("privateKeyPath").containsExactly(Paths.get("private"));
         assertThat(keyData).isNotNull().extracting("publicKeyPath").containsExactly(Paths.get("public"));
 
-        final DeprecatedServerConfig serverConfig = result.getServer();
+        final ServerConfig serverConfig = result.getP2PServerConfig();
         assertThat(serverConfig).isNotNull();
-        assertThat(serverConfig.getPort()).isEqualTo(892);
-        assertThat(serverConfig.getHostName()).isEqualTo("http://bogus.com");
+        assertThat(serverConfig.getServerAddress()).isEqualTo("http://bogus.com:892");
         assertThat(serverConfig.getBindingAddress()).isEqualTo("http://bogus.com:892");
 
         final SslConfig sslConfig = serverConfig.getSslConfig();
         assertThat(sslConfig).isNotNull();
-
         assertThat(sslConfig.getClientKeyStorePassword()).isEqualTo("sslClientKeyStorePassword");
         assertThat(sslConfig.getClientKeyStore()).isEqualTo(Paths.get("sslClientKeyStorePath"));
         assertThat(sslConfig.getClientTlsKeyPath()).isEqualTo(Paths.get("sslClientTlsKeyPath"));
@@ -58,14 +58,13 @@ public class ConfigBuilderTest {
         assertThat(result.getJdbcConfig().getUsername()).isEqualTo("jdbcUsername");
         assertThat(result.getJdbcConfig().getPassword()).isEqualTo("jdbcPassword");
         assertThat(result.getJdbcConfig().getUrl()).isEqualTo("jdbc:bogus");
-
     }
 
     @Test
     public void influxHostNameEmptyThenInfluxConfigIsNull() {
         final Config result = builderWithValidValues.build();
 
-        assertThat(result.getServer().getInfluxConfig()).isNull();
+        assertThat(result.getP2PServerConfig().getInfluxConfig()).isNull();
     }
 
     @Test
@@ -88,5 +87,4 @@ public class ConfigBuilderTest {
 
         assertThat(config).isNotNull();
     }
-
 }

--- a/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
+++ b/config-migration/src/test/java/com/quorum/tessera/config/migration/TomlConfigFactoryTest.java
@@ -12,6 +12,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.quorum.tessera.config.AppType.Q2T;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
@@ -22,44 +23,39 @@ public class TomlConfigFactoryTest {
 
     @Test
     public void createConfigFromSampleFile() throws IOException {
+        final Path passwordFile = Files.createTempFile("password", ".txt");
+        final InputStream template = getClass().getResourceAsStream("/sample-all-values.conf");
 
-        Path passwordFile = Files.createTempFile("password", ".txt");
-        InputStream template = getClass().getResourceAsStream("/sample-all-values.conf");
-
-        Map<String, Object> params = new HashMap<String, Object>() {
-            {
-                put("passwordFile", passwordFile);
-                put("serverKeyStorePath", "serverKeyStorePath");
-            }
-        };
+        final Map<String, Object> params = new HashMap<>();
+        params.put("passwordFile", passwordFile);
+        params.put("serverKeyStorePath", "serverKeyStorePath");
 
         try (InputStream configData = ElUtil.process(template, params)) {
-            Config result = tomlConfigFactory.create(configData, null).build();
+            final Config result = tomlConfigFactory.create(configData, null).build();
             assertThat(result).isNotNull();
-            assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get("data", "myipcfile.ipc"));
-            assertThat(result.getServer()).isNotNull();
-            assertThat(result.getServer().getSslConfig()).isNotNull();
 
-            SslConfig sslConfig = result.getServer().getSslConfig();
+            final String unixSocketAddress = this.getUnixSocketServerAddress(result);
+            assertThat(unixSocketAddress).isEqualTo("unix:" + Paths.get("data", "myipcfile.ipc").toAbsolutePath());
 
-            assertThat(result.getServer().getHostName()).isEqualTo("http://127.0.0.1");
-            assertThat(result.getServer().getPort()).isEqualTo(9001);
-            assertThat(result.getServer().getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
+            final ServerConfig p2pServer = result.getP2PServerConfig();
+            assertThat(p2pServer).isNotNull();
+            assertThat(p2pServer.getSslConfig()).isNotNull();
+            assertThat(p2pServer.getServerAddress()).isEqualTo("http://127.0.0.1:9001");
+            assertThat(p2pServer.getBindingAddress()).isEqualTo("http://127.0.0.1:9001");
 
+            final SslConfig sslConfig = p2pServer.getSslConfig();
             assertThat(sslConfig.getClientTlsKeyPath()).isEqualTo(Paths.get("data/tls-client-key.pem"));
             assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
-
         }
     }
 
     @Test
     public void urlPortNotSetInConfig() {
-
         InputStream template = getClass().getResourceAsStream("/sample-all-values-urlport-not-present.conf");
 
         Config result = tomlConfigFactory.create(template, null).build();
 
-        assertThat(result.getServer().getHostName()).isEqualTo("http://127.0.0.1");
+        assertThat(result.getP2PServerConfig().getServerAddress()).isEqualTo("http://127.0.0.1:0");
     }
 
     @Test
@@ -70,35 +66,27 @@ public class TomlConfigFactoryTest {
         } catch (RuntimeException ex) {
             assertThat(ex).hasMessage("Bad server url given: unknown protocol: ht");
         }
-
     }
 
     @Test
     public void createConfigFromSampleFileOnly() throws IOException {
-
-        Path passwordFile = Files.createTempFile("password", ".txt");
-        InputStream template = getClass().getResourceAsStream("/sample.conf");
-
-        try (InputStream configData = template) {
+        try (InputStream configData = getClass().getResourceAsStream("/sample.conf")) {
             Config result = tomlConfigFactory.create(configData, null).build();
             assertThat(result).isNotNull();
-            assertThat(result.getUnixSocketFile()).isEqualTo(Paths.get("data", "constellation.ipc"));
-            assertThat(result.getServer()).isNotNull();
-            assertThat(result.getServer().getSslConfig()).isNotNull();
 
-            SslConfig sslConfig = result.getServer().getSslConfig();
+            final String unixSocketAddress = this.getUnixSocketServerAddress(result);
+            assertThat(unixSocketAddress).isEqualTo("unix:" + Paths.get("data", "constellation.ipc").toAbsolutePath());
 
-            assertThat(sslConfig.getClientTlsKeyPath()).isEqualTo(Paths.get("data/tls-client-key.pem"));
-            assertThat(sslConfig.getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
-
+            final ServerConfig p2pServer = result.getP2PServerConfig();
+            assertThat(p2pServer).isNotNull();
+            assertThat(p2pServer.getSslConfig()).isNotNull();
+            assertThat(p2pServer.getSslConfig().getClientTlsKeyPath()).isEqualTo(Paths.get("data/tls-client-key.pem"));
+            assertThat(p2pServer.getSslConfig().getClientTrustMode()).isEqualTo(SslTrustMode.CA_OR_TOFU);
         }
-
-        Files.deleteIfExists(passwordFile);
     }
 
     @Test
     public void createConfigFromSampleFileAndAddedPasswordsFile() throws IOException {
-
         Path passwordsFile = Files.createTempFile("createConfigFromSampleFileAndAddedPasswordsFile", ".txt");
 
         List<String> passwordsFileLines = Arrays.asList("PASSWORD_1", "PASSWORD_2", "PASSWORD_3");
@@ -107,11 +95,12 @@ public class TomlConfigFactoryTest {
 
         try (InputStream configData = getClass().getResourceAsStream("/sample.conf")) {
 
-            List<String> lines = Stream.of(configData)
-                .map(InputStreamReader::new)
-                .map(BufferedReader::new)
-                .flatMap(BufferedReader::lines)
-                .collect(Collectors.toList());
+            final List<String> lines =
+                    Stream.of(configData)
+                            .map(InputStreamReader::new)
+                            .map(BufferedReader::new)
+                            .flatMap(BufferedReader::lines)
+                            .collect(Collectors.toList());
 
             lines.add(String.format("passwords = \"%s\"", passwordsFile.toString()));
 
@@ -119,10 +108,8 @@ public class TomlConfigFactoryTest {
             try (InputStream ammendedInput = new ByteArrayInputStream(data)) {
                 Config result = tomlConfigFactory.create(ammendedInput, null).build();
                 assertThat(result).isNotNull();
-
             }
         }
-
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -134,56 +121,47 @@ public class TomlConfigFactoryTest {
 
     @Test
     public void createConfigFromNoPasswordsFile() throws IOException {
-
         try (InputStream configData = getClass().getResourceAsStream("/sample.conf")) {
-
             Config result = tomlConfigFactory.create(configData, null).build();
             assertThat(result).isNotNull();
-
         }
-
     }
 
     @Test
     public void ifPublicAndPrivateKeyListAreEmptyThenKeyConfigurationIsAllNulls() throws IOException {
         try (InputStream configData = getClass().getResourceAsStream("/sample-no-keys.conf")) {
-
             KeyConfiguration result = tomlConfigFactory.createKeyDataBuilder(configData).build();
             assertThat(result).isNotNull();
 
             KeyConfiguration expected = new KeyConfiguration(null, null, Collections.emptyList(), null, null);
             assertThat(result).isEqualTo(expected);
-
         }
     }
 
     @Test
     public void ifPublicKeyListIsEmptyThenKeyConfigurationIsAllNulls() throws IOException {
         try (InputStream configData = getClass().getResourceAsStream("/sample-with-only-private-keys.conf")) {
-
             final Throwable throwable = catchThrowable(() -> tomlConfigFactory.createKeyDataBuilder(configData).build());
 
-            assertThat(throwable)
-                .isInstanceOf(ConfigException.class)
-                .hasCauseExactlyInstanceOf(RuntimeException.class);
+            assertThat(throwable).isInstanceOf(ConfigException.class).hasCauseExactlyInstanceOf(RuntimeException.class);
 
             assertThat(throwable.getCause()).hasMessage("Different amount of public and private keys supplied");
-
         }
     }
 
     @Test
     public void ifPrivateKeyListIsEmptyThenKeyConfigurationIsAllNulls() throws IOException {
         try (InputStream configData = getClass().getResourceAsStream("/sample-with-only-public-keys.conf")) {
+            final Throwable throwable =
+                    catchThrowable(() -> tomlConfigFactory.createKeyDataBuilder(configData).build());
 
-            final Throwable throwable = catchThrowable(() -> tomlConfigFactory.createKeyDataBuilder(configData).build());
-
-            assertThat(throwable)
-                .isInstanceOf(ConfigException.class)
-                .hasCauseExactlyInstanceOf(RuntimeException.class);
+            assertThat(throwable).isInstanceOf(ConfigException.class).hasCauseExactlyInstanceOf(RuntimeException.class);
 
             assertThat(throwable.getCause()).hasMessage("Different amount of public and private keys supplied");
-
         }
+    }
+
+    private String getUnixSocketServerAddress(final Config config) {
+        return config.getServerConfigs().stream().filter(s -> s.getApp() == Q2T).findAny().get().getServerAddress();
     }
 }

--- a/config-migration/src/test/resources/sample-all-values-urlport-not-present.conf
+++ b/config-migration/src/test/resources/sample-all-values-urlport-not-present.conf
@@ -1,6 +1,3 @@
 ## Externally accessible URL for this node's public API (this is what's
 ## advertised to other nodes on the network, and must be reachable by them.)
 url = "http://127.0.0.1"
-
-## Port to listen on for the public API.
-port = 9001


### PR DESCRIPTION
The config migration now directly creates the individual server configs instead of the deprecated style. It creates one Q2T server and one P2P server.

- Uses port 0 if not specified. This is in line with the default value used in older systems.
- Will not set the server address if hostname isn't set

Fixes https://github.com/jpmorganchase/tessera/issues/885