### PR TITLE
Simplify CLI execution result handling

### DIFF
--- a/cli/cli-api/pom.xml
+++ b/cli/cli-api/pom.xml
@@ -1,23 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cli-api</artifactId>
+    <name>cli-api</name>
+    <packaging>jar</packaging>
+
     <parent>
         <artifactId>cli</artifactId>
         <groupId>com.jpmorgan.quorum</groupId>
         <version>0.11-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>cli-api</artifactId>
 
     <dependencies>
 
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.4</version>
         </dependency>
 
     </dependencies>
-
 
 </project>

--- a/cli/cli-api/src/test/java/com/quorum/tessera/cli/CliDelegateTest.java
+++ b/cli/cli-api/src/test/java/com/quorum/tessera/cli/CliDelegateTest.java
@@ -60,12 +60,6 @@ public class CliDelegateTest {
 
     // PicoCLI tests
     @Test
-    public void nullResultReturnsDefaultCliResult() {
-        final CliResult result = instance.getResult(null);
-        assertThat(result).isEqualToComparingFieldByField(new CliResult(1, true, null));
-    }
-
-    @Test
     public void nonnullResultReturnsResult() throws Exception {
         final CliResult result = new CliResult(0, true, null);
         MockSubcommandCliAdapter.setResult(result);


### PR DESCRIPTION
Update PicoCLI dependency to latest release version.

Simplifies the retrieval of the CliResult from the execution of CLI args by gathering all executed subcommands and seeing if any had a result, picking the first (we only ever do at most 1 execution anyway).