### PR TITLE
Updating bzip2 version to 1.0.8-r1 to resolve critical vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN cd /tessera && mvn clean -Dmaven.repo.local=/tessera/.m2/repository -DskipTe
 # Create docker image with only distribution jar
 FROM openjdk:8-jre-alpine
 
+# Update bzip2 version to 1.0.8-r1 as the bundled version 1.0.6 has critical vulnerability https://nvd.nist.gov/vuln/detail/CVE-2019-12900
+RUN apk add bzip2=1.0.8-r1 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
+
 COPY --from=builder /tessera/tessera-dist/tessera-app/target/*-app.jar /tessera/tessera-app.jar
 
 ENTRYPOINT ["java", "-jar", "/tessera/tessera-app.jar"]


### PR DESCRIPTION
Alpine images ship with bzip2 1.0.6 which has [critical vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-12900). Update the version of bzip2 to 1.0.8-r1