### PR TITLE
Update h2 version to 1.4.200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <slf4j.version>1.7.5</slf4j.version>
         <eclipselink.version>2.7.3</eclipselink.version>
         <grpc.version>1.14.0</grpc.version>
-        <h2.version>1.4.199</h2.version>
+        <h2.version>1.4.200</h2.version>
         <owasp.plugin.version>5.0.0-M2</owasp.plugin.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
pick up reliability fix to MVStore that deals with partial chunks in a
graceful way:

ref: https://h2database.com/html/changelog.html (PR #2049)
https://github.com/h2database/h2database/pull/2049/files

Prior to this, we were seeing multiple instances of H2 unable to recover from partial writes when Tessera running in docker is stopped (even gracefully). One other symptom in our tests was a large payload being written to the DB