### PR TITLE
Disallow CORS to be configured on anything but ThirdParty server

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.config.constraints;
 
+import com.quorum.tessera.config.AppType;
 import com.quorum.tessera.config.ServerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,18 +15,37 @@ public class ServerConfigValidator implements ConstraintValidator<ValidServerCon
     @Override
     public boolean isValid(ServerConfig serverConfig, ConstraintValidatorContext constraintContext) {
 
-        if(serverConfig == null) {
+        if (serverConfig == null) {
             return true;
         }
-        
+
         if (!serverConfig.getApp().getAllowedCommunicationTypes().contains(serverConfig.getCommunicationType())) {
-            LOGGER.debug("Invalid communicationType '" + serverConfig.getCommunicationType() +
-                "' specified for serverConfig with app " + serverConfig.getApp());
+            LOGGER.debug(
+                    "Invalid communicationType '"
+                            + serverConfig.getCommunicationType()
+                            + "' specified for serverConfig with app "
+                            + serverConfig.getApp());
             constraintContext.disableDefaultConstraintViolation();
-            constraintContext.buildConstraintViolationWithTemplate("Invalid communicationType '" +
-                serverConfig.getCommunicationType() + "' specified for serverConfig with app " + serverConfig.getApp())
-                .addConstraintViolation();
+            constraintContext
+                    .buildConstraintViolationWithTemplate(
+                            "Invalid communicationType '"
+                                    + serverConfig.getCommunicationType()
+                                    + "' specified for serverConfig with app "
+                                    + serverConfig.getApp())
+                    .addConstraintViolation();
             return false;
+        }
+
+        if (serverConfig.getApp() != AppType.THIRD_PARTY) {
+            if (serverConfig.getCrossDomainConfig() != null) {
+                LOGGER.debug("Invalid server config. CrossDomainConfig is only allowed in ThirdParty server");
+                constraintContext.disableDefaultConstraintViolation();
+                constraintContext
+                        .buildConstraintViolationWithTemplate(
+                                "Invalid server config. CrossDomainConfig is only allowed in ThirdParty server")
+                        .addConstraintViolation();
+                return false;
+            }
         }
 
         return true;

--- a/config/src/test/java/com/quorum/tessera/config/constraints/ServerConfigValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/ServerConfigValidatorTest.java
@@ -68,4 +68,19 @@ public class ServerConfigValidatorTest {
         verify(cvc).disableDefaultConstraintViolation();
         verify(cvc).buildConstraintViolationWithTemplate(anyString());
     }
+
+    @Test
+    public void allowCorsOnlyInThirdPartyServer() {
+
+        serverConfig.setApp(AppType.P2P);
+
+        CrossDomainConfig cors = new CrossDomainConfig();
+        cors.setAllowCredentials(true);
+
+        serverConfig.setCrossDomainConfig(cors);
+
+        assertThat(validator.isValid(serverConfig, cvc)).isFalse();
+        verify(cvc).disableDefaultConstraintViolation();
+        verify(cvc).buildConstraintViolationWithTemplate(anyString());
+    }
 }


### PR DESCRIPTION
Allowing CORS config on other types of server such as P2P carry potential security issues