### PR TITLE
Minor swagger annotation cleanup

### DIFF
--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
@@ -29,7 +29,7 @@ public class UpCheckResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @ApiResponses({@ApiResponse(code = 200, message = UPCHECK_RESPONSE)})
-    @ApiOperation(value = "Check if local P2PRestApp Node is up", produces = "I'm up")
+    @ApiOperation(value = "Check if local P2PRestApp Node is up")
     public String upCheck() {
 
         LOGGER.info("GET upcheck");

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
@@ -28,7 +28,7 @@ public class VersionResource {
      */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Request current version of P2PRestApp", produces = "current version number")
+    @ApiOperation(value = "Request current version of P2PRestApp")
     @ApiResponses({@ApiResponse(code = 200, message = "Current application version ", response = String.class)})
     public String getVersion() {
 

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
@@ -83,7 +83,7 @@ public class PartyInfoResource {
     @POST
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = "Request public key/url of other nodes", produces = "public keylist/url")
+    @ApiOperation(value = "Request public key/url of other nodes")
     @ApiResponses({@ApiResponse(code = 200, message = "Encoded PartyInfo Data", response = byte[].class)})
     public Response partyInfo(@ApiParam(required = true) final byte[] payload) {
 
@@ -163,7 +163,7 @@ public class PartyInfoResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Fetch network/peer information", produces = "public list of peers/publickey mappings")
+    @ApiOperation(value = "Fetch network/peer information")
     @ApiResponses({@ApiResponse(code = 200, message = "Peer/Network information", response = PartyInfo.class)})
     public Response getPartyInfo() {
 

--- a/tessera-jaxrs/thirdparty-jaxrs/pom.xml
+++ b/tessera-jaxrs/thirdparty-jaxrs/pom.xml
@@ -41,7 +41,7 @@
                             </info>
 
                             <locations>
-                                <location>com.quorum.tessera.thridparty</location>
+                                <location>com.quorum.tessera.thirdparty</location>
    
                             </locations>
                             <templatePath>${project.parent.basedir}/src/main/swagger/strapdown.html.hbs</templatePath>

--- a/tessera-jaxrs/thirdparty-jaxrs/src/main/java/com/quorum/tessera/thirdparty/RawTransactionResource.java
+++ b/tessera-jaxrs/thirdparty-jaxrs/src/main/java/com/quorum/tessera/thirdparty/RawTransactionResource.java
@@ -40,7 +40,7 @@ public class RawTransactionResource {
         this.delegate = Objects.requireNonNull(delegate);
     }
 
-    @ApiOperation(value = "Store raw private transaction payload", produces = "Encrypted payload")
+    @ApiOperation(value = "Store raw private transaction payload")
     @ApiResponses({
         @ApiResponse(code = 200, response = StoreRawResponse.class, message = "Store response"),
         @ApiResponse(code = 400, message = "For unknown sender")

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
@@ -47,7 +47,7 @@ public class TransactionResource {
         this.delegate = Objects.requireNonNull(delegate);
     }
 
-    @ApiOperation(value = "Send private transaction payload", produces = "Encrypted payload")
+    @ApiOperation(value = "Send private transaction payload")
     @ApiResponses({
         @ApiResponse(code = 200, response = SendResponse.class, message = "Send response"),
         @ApiResponse(code = 400, message = "For unknown and unknown keys")
@@ -69,7 +69,7 @@ public class TransactionResource {
         return Response.status(Status.CREATED).type(APPLICATION_JSON).location(location).entity(response).build();
     }
 
-    @ApiOperation(value = "Send private raw transaction payload", produces = "Encrypted payload hash")
+    @ApiOperation(value = "Send private raw transaction payload")
     @ApiResponses({
         @ApiResponse(code = 200, response = SendResponse.class, message = "Send response"),
         @ApiResponse(code = 400, message = "For unknown and unknown keys")
@@ -106,7 +106,7 @@ public class TransactionResource {
         return Response.status(Status.OK).entity(encodedKey).location(location).build();
     }
 
-    @ApiOperation(value = "Send private transaction payload", produces = "Encrypted payload")
+    @ApiOperation(value = "Send private transaction payload")
     @ApiResponses({
         @ApiResponse(code = 200, message = "Encoded Key", response = String.class),
         @ApiResponse(code = 500, message = "Unknown server error")
@@ -175,7 +175,7 @@ public class TransactionResource {
         return Response.status(Status.OK).type(APPLICATION_JSON).entity(response).build();
     }
 
-    @ApiOperation(value = "Submit keys to retrieve payload and decrypt it", produces = "Unencrypted payload")
+    @ApiOperation(value = "Submit keys to retrieve payload and decrypt it")
     @ApiResponses({@ApiResponse(code = 200, message = "Raw payload", response = byte[].class)})
     @GET
     @Path("receiveraw")


### PR DESCRIPTION
Wrong usage of swagger ApiOperation "produces". See http://docs.swagger.io/swagger-core/v1.5.X/apidocs/index.html?io/swagger/annotations/ApiOperation.html

It should automatically inherits the value of the `@Produces` annotation