### PR TITLE
Only prompt for key passwords on CLI if the pwd is not already given

### DIFF
--- a/cli/cli-api/build.gradle
+++ b/cli/cli-api/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.4'
     implementation project(':config')
     implementation project(':shared')
+    implementation project(':encryption:encryption-api')
     testImplementation project(':tests:test-util')
 }
 

--- a/cli/cli-api/src/main/java/com/quorum/tessera/cli/keypassresolver/CliKeyPasswordResolver.java
+++ b/cli/cli-api/src/main/java/com/quorum/tessera/cli/keypassresolver/CliKeyPasswordResolver.java
@@ -91,7 +91,8 @@ public class CliKeyPasswordResolver implements KeyPasswordResolver {
         if (isLocked) {
             int currentAttemptNumber = MAX_PASSWORD_ATTEMPTS;
             while (currentAttemptNumber > 0) {
-                if (Objects.nonNull(keyPair.getPassword()) && !keyPair.getPassword().isEmpty()
+                if (Objects.isNull(keyPair.getPassword())
+                        || keyPair.getPassword().isEmpty()
                         || keyPair.getPrivateKey() == null
                         || keyPair.getPrivateKey().contains("NACL_FAILURE")) {
 


### PR DESCRIPTION
This fixes a bug in the current 0.11-SNAPSHOT master, introduced during refactoring, which caused the password CLI prompt to occur regardless of whether pwds had already been provided in the configfile.

* Add test verifying CLI pwd resolver is not used if pwd already provided
* Update an existing test that was a false positive before the bugfix.  After the fix, mock encryptor behaviour must be added.

Resolves #938 