### PR TITLE
Fix CLI overrides of encryptor config and map fields

### DIFF
--- a/cli/config-cli/src/main/java/com/quorum/tessera/config/cli/OverrideUtil.java
+++ b/cli/config-cli/src/main/java/com/quorum/tessera/config/cli/OverrideUtil.java
@@ -159,6 +159,11 @@ public interface OverrideUtil {
             return;
         }
 
+        if (Map.class.isAssignableFrom(rootType)) {
+            Map.class.cast(root).put(path,value);
+            return;
+        }
+
         while (pathTokens.hasNext()) {
 
             final String token = pathTokens.next();
@@ -298,6 +303,10 @@ public interface OverrideUtil {
 
     static <T> T createInstance(Class<T> type) {
 
+        if (Map.class.isAssignableFrom(type)) {
+            return (T) new LinkedHashMap<>();
+        }
+
         if (type.isInterface()) {
             return null;
         }
@@ -332,6 +341,10 @@ public interface OverrideUtil {
 
                         if (Collection.class.isAssignableFrom(fieldType)) {
                             setValue(obj, field, new ArrayList<>());
+                            continue;
+                        }
+
+                        if (Map.class.isAssignableFrom(fieldType)) {
                             continue;
                         }
 

--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/OverrideUtilTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/OverrideUtilTest.java
@@ -1,10 +1,7 @@
 package com.quorum.tessera.config.cli;
 
 import com.quorum.tessera.cli.CliException;
-import com.quorum.tessera.config.Config;
-import com.quorum.tessera.config.KeyConfiguration;
-import com.quorum.tessera.config.Peer;
-import com.quorum.tessera.config.SslAuthenticationMode;
+import com.quorum.tessera.config.*;
 import com.quorum.tessera.config.util.JaxbUtil;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -18,18 +15,15 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.*;
 
 public class OverrideUtilTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OverrideUtilTest.class);
 
+    // TODO(cjh) can we remove this now we've got rid of apache commons-cli?
     @Test
     public void buildOptions() {
 
@@ -265,6 +259,13 @@ public class OverrideUtilTest {
     public void createInstance() {
         Peer result = OverrideUtil.createInstance(Peer.class);
         assertThat(result).isNotNull();
+    }
+
+    @Test
+    public void createInstanceMapCreatesLinkedHashMap() {
+        Map<Object, Object> result = OverrideUtil.createInstance(Map.class);
+        assertThat(result).isNotNull();
+        assertThat(result).isExactlyInstanceOf(LinkedHashMap.class);
     }
 
     @Test
@@ -715,6 +716,46 @@ public class OverrideUtilTest {
 
         assertThat(toOverride.getSomeList().get(0).getOtherList().get(0)).isEqualTo("otherElement1");
         assertThat(toOverride.getSomeList().get(0).getOtherList().get(1)).isEqualTo(overriddenValue);
+    }
+
+    @Test
+    public void setValueMapPropertyAdded() {
+        final HashMap<String, String> toOverride = new HashMap<>();
+
+        OverrideUtil.setValue(toOverride, "property", "value");
+
+        assertThat(toOverride).hasSize(1);
+        assertThat(toOverride).contains(entry("property", "value"));
+    }
+
+    @Test
+    public void setValueMapPeriodSeparatedPropertyAdded() {
+        final HashMap<String, String> toOverride = new HashMap<>();
+
+        OverrideUtil.setValue(toOverride, "property.subproperty", "value");
+
+        assertThat(toOverride).hasSize(1);
+        assertThat(toOverride).contains(entry("property.subproperty", "value"));
+    }
+
+    @Test
+    public void setValueMapPropertyReplaced() {
+        final HashMap<String, String> toOverride = new HashMap<>();
+        toOverride.put("property", "initial value");
+
+        assertThat(toOverride).hasSize(1);
+        assertThat(toOverride).contains(entry("property", "initial value"));
+
+        OverrideUtil.setValue(toOverride, "property", "updated value");
+
+        assertThat(toOverride).hasSize(1);
+        assertThat(toOverride).contains(entry("property", "updated value"));
+    }
+
+    @Test
+    public void mapsAreNullByDefault() {
+        Config config = OverrideUtil.createInstance(Config.class);
+        assertThat(config.getEncryptor().getProperties()).isNull();
     }
 
     @Ignore

--- a/config/src/main/java/com/quorum/tessera/config/JaxbConfigFactory.java
+++ b/config/src/main/java/com/quorum/tessera/config/JaxbConfigFactory.java
@@ -3,18 +3,19 @@ package com.quorum.tessera.config;
 import com.quorum.tessera.config.keys.KeyEncryptorFactory;
 import com.quorum.tessera.config.util.JaxbUtil;
 
-import java.io.InputStream;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class JaxbConfigFactory implements ConfigFactory {
 
     private final KeyEncryptorFactory keyEncryptorFactory;
+
+    private static final EncryptorConfig DEFAULT_ENCRYPTOR_CONFIG = defaultEncryptorConfig();
 
     protected JaxbConfigFactory(KeyEncryptorFactory keyEncryptorFactory) {
         this.keyEncryptorFactory = keyEncryptorFactory;
@@ -23,13 +24,6 @@ public class JaxbConfigFactory implements ConfigFactory {
     public JaxbConfigFactory() {
         this(KeyEncryptorFactory.newFactory());
     }
-
-    private static final EncryptorConfig DEFAULT_ENCRYPTOR_CONFIG =
-            new EncryptorConfig() {
-                {
-                    setType(EncryptorType.NACL);
-                }
-            };
 
     @Override
     public Config create(final InputStream configData) {
@@ -53,5 +47,11 @@ public class JaxbConfigFactory implements ConfigFactory {
         config.setEncryptor(encryptorConfig);
 
         return config;
+    }
+
+    private static EncryptorConfig defaultEncryptorConfig() {
+        final EncryptorConfig encryptorConfig = new EncryptorConfig();
+        encryptorConfig.setType(EncryptorType.NACL);
+        return encryptorConfig;
     }
 }


### PR DESCRIPTION
Resolves #961 

* Fixes a bug that meant no fields in the `EncryptorConfig` could be overriden.  
* Updates OverrideUtil to also support Maps meaning the `keyVaultConfig.properties` and `encryptor.properties` fields can now be overriden with the CLI