### PR TITLE
Fix bug where validation fails even when defaultKeyVaultConfig is set

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/constraints/KeyVaultConfigurationValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/KeyVaultConfigurationValidator.java
@@ -1,42 +1,55 @@
 package com.quorum.tessera.config.constraints;
 
 import com.quorum.tessera.config.KeyConfiguration;
+import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.keypairs.AzureVaultKeyPair;
 import com.quorum.tessera.config.keypairs.HashicorpVaultKeyPair;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.util.Optional;
 
-public class KeyVaultConfigurationValidator implements ConstraintValidator<ValidKeyVaultConfiguration, KeyConfiguration> {
+public class KeyVaultConfigurationValidator
+        implements ConstraintValidator<ValidKeyVaultConfiguration, KeyConfiguration> {
 
     @Override
     public boolean isValid(KeyConfiguration keyConfiguration, ConstraintValidatorContext cvc) {
 
-        //return true so that only NotNull annotation creates violation
-        if(keyConfiguration == null) {
+        // return true so that only NotNull annotation creates violation
+        if (keyConfiguration == null) {
             return true;
         }
 
-        boolean isUsingAzureVaultKeys = keyConfiguration.getKeyData()
-            .stream()
-            .anyMatch(keyPair -> keyPair instanceof AzureVaultKeyPair);
+        boolean isUsingAzureVaultKeys =
+                keyConfiguration.getKeyData().stream().anyMatch(keyPair -> keyPair instanceof AzureVaultKeyPair);
 
-        if(isUsingAzureVaultKeys && keyConfiguration.getAzureKeyVaultConfig() == null) {
+        boolean hasAzureKeyVaultConfig =
+                keyConfiguration.getAzureKeyVaultConfig() != null
+                        || Optional.ofNullable(keyConfiguration.getKeyVaultConfig())
+                                .filter((c) -> c.getKeyVaultType().equals(KeyVaultType.AZURE))
+                                .isPresent();
+
+        if (isUsingAzureVaultKeys && !hasAzureKeyVaultConfig) {
             cvc.disableDefaultConstraintViolation();
             cvc.buildConstraintViolationWithTemplate("{ValidKeyVaultConfiguration.azure.message}")
-                .addConstraintViolation();
+                    .addConstraintViolation();
 
             return false;
         }
 
-        boolean isUsingHashicorpVaultKeys = keyConfiguration.getKeyData()
-            .stream()
-            .anyMatch(keyPair -> keyPair instanceof HashicorpVaultKeyPair);
+        boolean isUsingHashicorpVaultKeys =
+                keyConfiguration.getKeyData().stream().anyMatch(keyPair -> keyPair instanceof HashicorpVaultKeyPair);
 
-        if(isUsingHashicorpVaultKeys && keyConfiguration.getHashicorpKeyVaultConfig() == null) {
+        boolean hasHashicorpKeyVaultConfig =
+                keyConfiguration.getHashicorpKeyVaultConfig() != null
+                        || Optional.ofNullable(keyConfiguration.getKeyVaultConfig())
+                                .filter((c) -> c.getKeyVaultType().equals(KeyVaultType.HASHICORP))
+                                .isPresent();
+
+        if (isUsingHashicorpVaultKeys && !hasHashicorpKeyVaultConfig) {
             cvc.disableDefaultConstraintViolation();
             cvc.buildConstraintViolationWithTemplate("{ValidKeyVaultConfiguration.hashicorp.message}")
-                .addConstraintViolation();
+                    .addConstraintViolation();
 
             return false;
         }

--- a/config/src/test/java/com/quorum/tessera/config/constraints/KeyVaultConfigurationValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/KeyVaultConfigurationValidatorTest.java
@@ -1,8 +1,6 @@
 package com.quorum.tessera.config.constraints;
 
-import com.quorum.tessera.config.AzureKeyVaultConfig;
-import com.quorum.tessera.config.HashicorpKeyVaultConfig;
-import com.quorum.tessera.config.KeyConfiguration;
+import com.quorum.tessera.config.*;
 import com.quorum.tessera.config.keypairs.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +24,8 @@ public class KeyVaultConfigurationValidatorTest {
     public void setUp() {
         context = mock(ConstraintValidatorContext.class);
 
-        ConstraintValidatorContext.ConstraintViolationBuilder builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder builder =
+                mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
         when(context.buildConstraintViolationWithTemplate(any(String.class))).thenReturn(builder);
 
         validator = new KeyVaultConfigurationValidator();
@@ -339,4 +338,55 @@ public class KeyVaultConfigurationValidatorTest {
         verify(context).buildConstraintViolationWithTemplate("{ValidKeyVaultConfiguration.azure.message}");
     }
 
+    @Test
+    public void noAzureConfigWithAzureDefaultKeyVaultConfigIsValid() {
+        KeyConfiguration keyConfiguration = mock(KeyConfiguration.class);
+        AzureVaultKeyPair keyPair = mock(AzureVaultKeyPair.class);
+        DefaultKeyVaultConfig keyVaultConfig = mock(DefaultKeyVaultConfig.class);
+        when(keyVaultConfig.getKeyVaultType()).thenReturn(KeyVaultType.AZURE);
+
+        when(keyConfiguration.getKeyData()).thenReturn(Collections.singletonList(keyPair));
+        when(keyConfiguration.getKeyVaultConfig()).thenReturn(keyVaultConfig);
+
+        assertThat(validator.isValid(keyConfiguration, context)).isTrue();
+    }
+
+    @Test
+    public void noAzureConfigWithHashicorpDefaultKeyVaultConfigIsInvalid() {
+        KeyConfiguration keyConfiguration = mock(KeyConfiguration.class);
+        AzureVaultKeyPair keyPair = mock(AzureVaultKeyPair.class);
+        DefaultKeyVaultConfig keyVaultConfig = mock(DefaultKeyVaultConfig.class);
+        when(keyVaultConfig.getKeyVaultType()).thenReturn(KeyVaultType.HASHICORP);
+
+        when(keyConfiguration.getKeyData()).thenReturn(Collections.singletonList(keyPair));
+        when(keyConfiguration.getKeyVaultConfig()).thenReturn(keyVaultConfig);
+
+        assertThat(validator.isValid(keyConfiguration, context)).isFalse();
+    }
+
+    @Test
+    public void noHashicorpConfigWithHashicorpDefaultKeyVaultConfigIsValid() {
+        KeyConfiguration keyConfiguration = mock(KeyConfiguration.class);
+        HashicorpVaultKeyPair keyPair = mock(HashicorpVaultKeyPair.class);
+        DefaultKeyVaultConfig keyVaultConfig = mock(DefaultKeyVaultConfig.class);
+        when(keyVaultConfig.getKeyVaultType()).thenReturn(KeyVaultType.HASHICORP);
+
+        when(keyConfiguration.getKeyData()).thenReturn(Collections.singletonList(keyPair));
+        when(keyConfiguration.getKeyVaultConfig()).thenReturn(keyVaultConfig);
+
+        assertThat(validator.isValid(keyConfiguration, context)).isTrue();
+    }
+
+    @Test
+    public void noHashicorpConfigWithAzureDefaultKeyVaultConfigIsInvalid() {
+        KeyConfiguration keyConfiguration = mock(KeyConfiguration.class);
+        HashicorpVaultKeyPair keyPair = mock(HashicorpVaultKeyPair.class);
+        DefaultKeyVaultConfig keyVaultConfig = mock(DefaultKeyVaultConfig.class);
+        when(keyVaultConfig.getKeyVaultType()).thenReturn(KeyVaultType.AZURE);
+
+        when(keyConfiguration.getKeyData()).thenReturn(Collections.singletonList(keyPair));
+        when(keyConfiguration.getKeyVaultConfig()).thenReturn(keyVaultConfig);
+
+        assertThat(validator.isValid(keyConfiguration, context)).isFalse();
+    }
 }


### PR DESCRIPTION
Resolves bug introduced by #948.

The validation of the `AzureKeyVaultConfig` and `HashicorpKeyVaultConfig` does not consider the presence of the generic `DefaultKeyVaultConfig` object which may be used as an alternative.  

Currently validation and startup fails even if the correct `keyVaultConfig` is provided.

This change adds the necessary checks to the `AzureKeyVaultConfig` and `HashicorpKeyVaultConfig` validation so that the presence of the correct `keyVaultConfig` is also considered.