### PR TITLE
Bump jetty version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
 
 }
 
+def jettyVersion = "9.4.25.v20191220"
+
 allprojects {
     group = 'com.jpmorgan.quorum'
     //version = '0.11-SNAPSHOT'
@@ -68,12 +70,13 @@ allprojects {
                 compile "org.glassfish.jersey.containers:jersey-container-servlet-core:2.27"
                 compile "javax.servlet:javax.servlet-api:4.0.1"
                 compile "com.sun.mail:javax.mail:1.6.2"
-                compile "org.eclipse.jetty:jetty-servlet:9.4.17.v20190418"
+
+                compile "org.eclipse.jetty:jetty-servlet:"+ jettyVersion
                 compile "org.glassfish.jersey.inject:jersey-hk2:2.27"
                 compile "org.glassfish.jersey.core:jersey-common:2.27"
-                compile "org.eclipse.jetty:jetty-unixsocket:9.4.17.v20190418"
-                compile "org.eclipse.jetty:jetty-server:9.4.17.v20190418"
-                compile "org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.17.v20190418"
+                compile "org.eclipse.jetty:jetty-unixsocket:"+ jettyVersion
+                compile "org.eclipse.jetty:jetty-server:"+ jettyVersion
+                compile "org.eclipse.jetty.websocket:javax-websocket-server-impl:"+ jettyVersion
                 compile "org.springframework:spring-core:5.1.2.RELEASE"
                 compile "org.springframework:spring-beans:5.1.2.RELEASE"
                 compile "org.springframework:spring-context:5.1.2.RELEASE"

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <jersey.version>2.27</jersey.version>
-        <jetty.version>9.4.17.v20190418</jetty.version>
+        <jetty.version>9.4.25.v20191220</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/tessera-jaxrs/common-jaxrs/pom.xml
+++ b/tessera-jaxrs/common-jaxrs/pom.xml
@@ -37,7 +37,7 @@
         
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jetty</artifactId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
         </dependency>
         
         <dependency>

--- a/tessera-jaxrs/pom.xml
+++ b/tessera-jaxrs/pom.xml
@@ -103,15 +103,15 @@
         
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jetty</artifactId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
             <scope>test</scope>
             <type>jar</type>
-            <exclusions>
+<!--            <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-util</artifactId>
                 </exclusion>
-            </exclusions>
+            </exclusions>-->
         </dependency>
         
     </dependencies>

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -62,7 +62,8 @@ test {
     systemProperty 'jdbc.sqlite.jar',project.configurations.testCompileClasspath.find { it.name.startsWith("sqlite-jdbc") }
     systemProperty 'jdbc.dir',"${buildDir}/ext"
 
-    include '**/AdminRestSuite.class','**/RestSuiteHttpHSQL.class',
+    include '**/AdminRestSuite.class',
+            '**/RestSuiteHttpHSQL.class',
             '**/RestSuiteHttpSqllite.class',
             '**/RestSuiteHttpH2.class',
             '**/RestSuiteHttpH2RemoteEnclave.class',
@@ -72,8 +73,10 @@ test {
             '**/ConfigMigrationIT.class',
             '**/AdminRestSuite.class',
             '**/RestSuiteUnixH2.class',
-            '**/P2pTestSuite.class'
-            '**/CucumberFileKeyGenerationIT.class'
+            '**/P2pTestSuite.class',
+            '**/CucumberFileKeyGenerationIT.class',
+            '**/RunAwsIT.class',
+            '**/RunAzureIT.class'
 
 //    '**/RestSuite.class',
 //            '**/P2pTestSuite.class',

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
-            <version>2.24.1</version>
+            <version>2.25.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -294,6 +294,9 @@
 
         <profile>
             <id>azure-vault-acceptance-tests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -311,6 +314,9 @@
 
         <profile>
             <id>aws-vault-acceptance-tests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -294,9 +294,6 @@
 
         <profile>
             <id>azure-vault-acceptance-tests</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -314,9 +311,6 @@
 
         <profile>
             <id>aws-vault-acceptance-tests</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Fixes #958 . Change jersey tests to use grizzly as we need to migrate… all former javax prefixed group ids to use newer jakarta ones.