### PR TITLE
Warn if unknown config element found

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/ConfigItem.java
+++ b/config/src/main/java/com/quorum/tessera/config/ConfigItem.java
@@ -1,12 +1,24 @@
 package com.quorum.tessera.config;
 
-import java.lang.reflect.Field;
+import com.quorum.tessera.config.constraints.NoUnmatchedElements;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.XmlAnyElement;
+import java.lang.reflect.Field;
+import java.util.List;
+
+@NoUnmatchedElements
 public abstract class ConfigItem {
+
+    @XmlAnyElement
+    private List<Object> unmatched;
+
+    public List<Object> getUnmatched() {
+        return unmatched;
+    }
 
     @Override
     public boolean equals(Object obj) {

--- a/config/src/main/java/com/quorum/tessera/config/ConfigItem.java
+++ b/config/src/main/java/com/quorum/tessera/config/ConfigItem.java
@@ -13,8 +13,7 @@ import java.util.List;
 @NoUnmatchedElements
 public abstract class ConfigItem {
 
-    @XmlAnyElement
-    private List<Object> unmatched;
+    @XmlAnyElement private List<Object> unmatched;
 
     public List<Object> getUnmatched() {
         return unmatched;
@@ -32,12 +31,11 @@ public abstract class ConfigItem {
 
     @Override
     public String toString() {
-        return new ReflectionToStringBuilder(this,ToStringStyle.MULTI_LINE_STYLE) {
+        return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE) {
             @Override
             protected boolean accept(Field f) {
                 return super.accept(f) && !f.getName().toLowerCase().contains("password");
             }
         }.toString();
     }
-
 }

--- a/config/src/main/java/com/quorum/tessera/config/Peer.java
+++ b/config/src/main/java/com/quorum/tessera/config/Peer.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import java.util.Objects;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Peer extends ConfigItem {
@@ -16,9 +17,7 @@ public class Peer extends ConfigItem {
         this.url = url;
     }
 
-    public Peer() {
-        
-    }
+    public Peer() {}
 
     public String getUrl() {
         return url;
@@ -28,4 +27,21 @@ public class Peer extends ConfigItem {
         this.url = url;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+
+        if (obj == null) return false;
+
+        if (getClass() != obj.getClass()) return false;
+
+        final Peer other = (Peer) obj;
+
+        return Objects.equals(this.url, other.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.url);
+    }
 }

--- a/config/src/main/java/com/quorum/tessera/config/constraints/NoUnmatchedElements.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/NoUnmatchedElements.java
@@ -1,0 +1,22 @@
+package com.quorum.tessera.config.constraints;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NoUnmatchedElementsValidator.class)
+@Documented
+public @interface NoUnmatchedElements {
+    String message() default "{NoUnmatchedElements.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/config/src/main/java/com/quorum/tessera/config/constraints/NoUnmatchedElementsValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/NoUnmatchedElementsValidator.java
@@ -1,0 +1,38 @@
+package com.quorum.tessera.config.constraints;
+
+import com.quorum.tessera.config.ConfigItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Optional;
+
+public class NoUnmatchedElementsValidator
+        implements ConstraintValidator<NoUnmatchedElements, ConfigItem> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoUnmatchedElementsValidator.class);
+
+    private NoUnmatchedElements config;
+
+    @Override
+    public void initialize(NoUnmatchedElements config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean isValid(ConfigItem configItem, ConstraintValidatorContext constraintValidatorContext) {
+        Optional.ofNullable(configItem.getUnmatched()).ifPresent(
+            list -> {
+                list.forEach(e -> {
+                    if (Element.class.isAssignableFrom(e.getClass())) {
+                        Element element = Element.class.cast(e);
+                        LOGGER.warn("Ignoring unknown/unmatched json element: {}", element.getTagName());
+                    }
+                });
+            }
+        );
+        return true; // just log a warning, don't stop startup
+    }
+}

--- a/config/src/main/resources/ValidationMessages.properties
+++ b/config/src/main/resources/ValidationMessages.properties
@@ -12,6 +12,7 @@ javax.validation.constraints.Past.message        = must be in the past
 javax.validation.constraints.Pattern.message     = must match "{regexp}"
 javax.validation.constraints.Size.message        = size must be between {min} and {max}
 
+NoUnmatchedElements.message=Ignoring unknown/unmatched json element
 UnsupportedKeyPair.message=Invalid key-pair. Ensure that the public and private keys for the key-pair are of the same type (i.e. inline, filepaths, etc...).
 UnsupportedKeyPair.bothDirectKeysRequired.message=Invalid direct key-pair. Ensure that both the public and private keys for the key-pair have been provided.
 UnsupportedKeyPair.bothInlineKeysRequired.message=Invalid inline key-pair. Ensure that both the public key and private key config for the key-pair have been provided.

--- a/config/src/test/java/com/quorum/tessera/config/constraints/NoUnmatchedElementsValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/NoUnmatchedElementsValidatorTest.java
@@ -1,0 +1,39 @@
+package com.quorum.tessera.config.constraints;
+
+import com.quorum.tessera.config.ConfigItem;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+import javax.validation.ConstraintValidatorContext;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NoUnmatchedElementsValidatorTest {
+
+    private NoUnmatchedElementsValidator validator;
+
+    private ConstraintValidatorContext cvc;
+
+    private NoUnmatchedElements config;
+
+    @Before
+    public void setUp() {
+        validator = new NoUnmatchedElementsValidator();
+        cvc = mock(ConstraintValidatorContext.class);
+        config = mock(NoUnmatchedElements.class);
+        validator.initialize(config);
+    }
+
+    @Test
+    public void isValid() {
+        ConfigItem configItem = mock(ConfigItem.class);
+        Element dummy = mock(Element.class);
+        when(configItem.getUnmatched()).thenReturn(Collections.singletonList(dummy));
+
+        assertThat(validator.isValid(configItem, cvc)).isTrue();
+    }
+}

--- a/tessera-dist/tessera-app/build.gradle
+++ b/tessera-dist/tessera-app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile project(':server:jersey-server')
     compile project(':key-vault:azure-key-vault')
     compile project(':key-vault:hashicorp-key-vault')
+    compile project(':key-vault:aws-key-vault')
     compile 'org.glassfish.jersey.media:jersey-media-json-processing:2.27'
     compile project(':encryption:encryption-jnacl')
 


### PR DESCRIPTION
Produces `WARN` logs of the following format if an unsupported json element is provided in the configfile (either due to typo, or misconfiguration):
```
2020-01-29 14:36:55.158 [main] WARN  c.q.t.c.c.NoUnmatchedElementsValidator - Ignoring unknown/unmatched json element: <element name>
```
This does not impact the startup of the node.

Also fixes a bug where the AWS key vault module was not added to the classpath when building with Gradle.