### PR TITLE
Ensure each node in admin acceptance tests has a unique ID

### DIFF
--- a/tests/acceptance-test/src/test/java/suite/NodeId.java
+++ b/tests/acceptance-test/src/test/java/suite/NodeId.java
@@ -16,10 +16,11 @@ public class NodeId {
     }
 
     public static String generate(ExecutionContext executionContext, NodeAlias alias) {
-        if (executionContext.isAdmin()) {
-            return "admin";
-        }
         List<String> tokens = new ArrayList<>();
+
+        if (executionContext.isAdmin()) {
+            tokens.add("admin");
+        }
         executionContext.getPrefix().ifPresent(v -> tokens.add(v));
         tokens.add(executionContext.getCommunicationType().name().toLowerCase());
         tokens.add(executionContext.getSocketType().name().toLowerCase());


### PR DESCRIPTION
When each node has the same ID the generated log files (as determined by logback-node.xml) for each node have the same destination and overwrite one another leading to incomplete logs.  This change ensures each node writes logs to a distinct file, making debugging easier.

Existing log file name: `node-admin.log`
New log files names: `node-admin-rest-http-local-[a-d].log`