### PR TITLE
Increase the partyinfo timeout in acceptance tests

### DIFF
--- a/tests/acceptance-test/src/test/java/config/ConfigBuilder.java
+++ b/tests/acceptance-test/src/test/java/config/ConfigBuilder.java
@@ -47,6 +47,8 @@ public class ConfigBuilder {
 
     private Integer p2pPort;
 
+    private Integer partyInfoInterval;
+
     private Integer adminPort;
 
     private Integer enclavePort;
@@ -99,6 +101,11 @@ public class ConfigBuilder {
 
     public ConfigBuilder withP2pPort(Integer p2pPort) {
         this.p2pPort = p2pPort;
+        return this;
+    }
+
+    public ConfigBuilder withPartyInfoInterval(Integer partyInfoInterval) {
+        this.partyInfoInterval = partyInfoInterval;
         return this;
     }
 
@@ -172,6 +179,10 @@ public class ConfigBuilder {
         p2pServerConfig.setCommunicationType(executionContext.getCommunicationType());
         p2pServerConfig.setServerAddress("http://localhost:" + p2pPort);
         p2pServerConfig.setBindingAddress("http://0.0.0.0:" + p2pPort);
+        if (Objects.nonNull(partyInfoInterval)) {
+            p2pServerConfig.setProperties(
+                    Collections.singletonMap("partyInfoInterval", Integer.toString(partyInfoInterval)));
+        }
         servers.add(p2pServerConfig);
 
         if (executionContext.getCommunicationType() == CommunicationType.REST && Objects.nonNull(adminPort)) {

--- a/tests/acceptance-test/src/test/java/config/ConfigGenerator.java
+++ b/tests/acceptance-test/src/test/java/config/ConfigGenerator.java
@@ -169,6 +169,8 @@ public class ConfigGenerator {
         final FeatureToggles toggles = new FeatureToggles();
         toggles.setEnableRemoteKeyValidation(true);
 
+        final Integer partyInfoInterval = 10000;
+
         EncryptorType encryptorType = executionContext.getEncryptorType();
         EncryptorConfig encryptorConfig =
                 new EncryptorConfig() {
@@ -188,6 +190,7 @@ public class ConfigGenerator {
                         .withP2pPort(port.nextPort())
                         .withAdminPort(port.nextPort())
                         .withEnclavePort(port.nextPort())
+                        .withPartyInfoInterval(partyInfoInterval)
                         .withKeys(keyLookUp.get(1))
                         .withFeatureToggles(toggles)
                         .withEncryptorConfig(encryptorConfig)
@@ -202,6 +205,7 @@ public class ConfigGenerator {
                         .withP2pPort(port.nextPort())
                         .withAdminPort(port.nextPort())
                         .withEnclavePort(port.nextPort())
+                        .withPartyInfoInterval(partyInfoInterval)
                         .withKeys(keyLookUp.get(2))
                         .withFeatureToggles(toggles)
                         .withEncryptorConfig(encryptorConfig)
@@ -216,6 +220,7 @@ public class ConfigGenerator {
                         .withP2pPort(port.nextPort())
                         .withAdminPort(port.nextPort())
                         .withEnclavePort(port.nextPort())
+                        .withPartyInfoInterval(partyInfoInterval)
                         .withAlwaysSendTo(keyLookUp.get(1).keySet().iterator().next())
                         .withKeys(keyLookUp.get(3))
                         .withFeatureToggles(toggles)
@@ -231,6 +236,7 @@ public class ConfigGenerator {
                         .withP2pPort(port.nextPort())
                         .withAdminPort(port.nextPort())
                         .withEnclavePort(port.nextPort())
+                        .withPartyInfoInterval(partyInfoInterval)
                         .withKeys(keyLookUp.get(4))
                         .withFeatureToggles(toggles)
                         .withEncryptorConfig(encryptorConfig)


### PR DESCRIPTION
This is an attempt to account for longer execution times when running acceptance tests on Travis that may be the cause of repeatedly failing builds