### PR TITLE
Remove leftover GRPC references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -702,25 +702,6 @@
 
             <dependency>
                 <groupId>com.jpmorgan.quorum</groupId>
-                <artifactId>grpc-server</artifactId>
-                <version>0.11-SNAPSHOT</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.jpmorgan.quorum</groupId>
-                <artifactId>grpc</artifactId>
-                <version>0.11-SNAPSHOT</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.jpmorgan.quorum</groupId>
-                <artifactId>grpc-api</artifactId>
-                <version>0.11-SNAPSHOT</version>
-            </dependency>
-
-
-            <dependency>
-                <groupId>com.jpmorgan.quorum</groupId>
                 <artifactId>encryption-ec</artifactId>
                 <version>0.11-SNAPSHOT</version>
             </dependency>


### PR DESCRIPTION
Removes last references to GRPC, as these modules have been removed from the project.