### PR TITLE
Update the JNR Unixsocket library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1096,7 +1096,7 @@
             <dependency>
                 <groupId>com.github.jnr</groupId>
                 <artifactId>jnr-unixsocket</artifactId>
-                <version>0.22</version>
+                <version>0.25</version>
             </dependency>
 
             <dependency>

--- a/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/SampleResource.java
+++ b/server/jaxrs-client-unixsocket/src/test/java/com/quorum/tessera/jaxrs/unixsocket/SampleResource.java
@@ -8,9 +8,7 @@ import javax.ws.rs.core.UriInfo;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 
@@ -47,7 +45,6 @@ public class SampleResource {
         URI location = uriInfo.getBaseUriBuilder().path("find").path(URLEncoder.encode(id, "UTF-8")).build();
         System.out.println("CREATE " + location);
         return Response.status(Response.Status.CREATED).location(location).build();
-
     }
 
     @Path("{id}")
@@ -64,27 +61,43 @@ public class SampleResource {
     public Response sendRaw(
             @HeaderParam("c11n-from") final String sender,
             @HeaderParam("c11n-to") final String recipientKeys,
-            final byte[] payload, @Context UriInfo uriInfo) throws UnsupportedEncodingException {
+            final byte[] payload,
+            @Context UriInfo uriInfo)
+            throws UnsupportedEncodingException {
 
         String id = UUID.randomUUID().toString();
-        URI location = uriInfo.getBaseUriBuilder()
-                .path("raw")
-                .path(URLEncoder.encode(id, "UTF-8"))
-                .build();
+        URI location = uriInfo.getBaseUriBuilder().path("raw").path(URLEncoder.encode(id, "UTF-8")).build();
 
         return Response.created(location).build();
     }
-    
+
     @Path("param")
     @GET
-    public Response withparam(
-            @HeaderParam("headerParam") String headerParam,
-            @QueryParam("queryParam") String qparam) {
+    public Response withparam(@HeaderParam("headerParam") String headerParam, @QueryParam("queryParam") String qparam) {
 
-        System.out.println("headerParam: "+ headerParam);
-        System.out.println("QueryParam: "+ qparam);
+        System.out.println("headerParam: " + headerParam);
+        System.out.println("QueryParam: " + qparam);
 
         return Response.ok().build();
     }
 
+    @GET
+    @Path("largefile")
+    public Response largeFile() {
+        final byte[] b = new byte[1024 * 1024 * 100]; // 100 MB
+        new Random().nextBytes(b);
+        final String base64randomBytes = Base64.getEncoder().encodeToString(b);
+
+        return Response.ok(base64randomBytes).build();
+    }
+
+    @GET
+    @Path("smallfile")
+    public Response smallFile() {
+        final byte[] b = new byte[1024 * 10]; // 10 KB
+        new Random().nextBytes(b);
+        final String base64randomBytes = Base64.getEncoder().encodeToString(b);
+
+        return Response.ok(base64randomBytes).build();
+    }
 }

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile 'javax.ws.rs:javax.ws.rs-api:2.1'
     testCompile 'org.assertj:assertj-core:3.9.1'
     testCompile 'javax.ws.rs:javax.ws.rs-api:2.1'
-    testCompile 'com.github.jnr:jnr-unixsocket:0.22'
+    testCompile 'com.github.jnr:jnr-unixsocket:0.25'
     testCompile 'org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.3'
 }
 


### PR DESCRIPTION
Update the JNR unix socket library to fix an issue with writing to the socket when the OS buffer is full.

Details of the fix at https://github.com/jnr/jnr-unixsocket/pull/70

Added some extra test endpoints to the test Jetty server for manual testing with large payloads.