### PR TITLE
Reduce number of automatic resend retries

### DIFF
--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/ResendPartyStoreImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/ResendPartyStoreImpl.java
@@ -33,7 +33,6 @@ public class ResendPartyStoreImpl implements ResendPartyStore {
 
     @Override
     public void incrementFailedAttempt(final SyncableParty attemptedParty) {
-
         if (attemptedParty.getAttempts() < MAX_ATTEMPTS) {
             final SyncableParty updatedParty =
                     new SyncableParty(attemptedParty.getParty(), attemptedParty.getAttempts() + 1);

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/TransactionRequester.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/TransactionRequester.java
@@ -7,8 +7,6 @@ package com.quorum.tessera.sync;
  */
 public interface TransactionRequester {
 
-    int MAX_ATTEMPTS = 5;
-
     /**
      * Makes a request to the given node to resend transactions for
      *

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/TransactionRequesterImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/TransactionRequesterImpl.java
@@ -1,13 +1,12 @@
 package com.quorum.tessera.sync;
 
-import com.quorum.tessera.partyinfo.ResendRequest;
-import com.quorum.tessera.partyinfo.ResendRequestType;
 import com.quorum.tessera.enclave.Enclave;
 import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.partyinfo.ResendRequest;
+import com.quorum.tessera.partyinfo.ResendRequestType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Base64;
 import java.util.Objects;
 
 public class TransactionRequesterImpl implements TransactionRequester {
@@ -25,9 +24,6 @@ public class TransactionRequesterImpl implements TransactionRequester {
 
     @Override
     public boolean requestAllTransactionsFromNode(final String uri) {
-
-        LOGGER.debug("Requesting transactions get resent for {}", uri);
-
         return this.enclave.getPublicKeys().stream()
                 .map(this::createRequestAllEntity)
                 .allMatch(req -> this.makeRequest(uri, req));
@@ -40,25 +36,14 @@ public class TransactionRequesterImpl implements TransactionRequester {
      * @param request the request object to send
      */
     private boolean makeRequest(final String uri, final ResendRequest request) {
-        LOGGER.debug("Requesting a resend for key {}", request.getPublicKey());
+        LOGGER.debug("Requesting a resend to {} for key {}", uri, request.getPublicKey());
 
-        boolean success;
-        int numberOfTries = 0;
-
-        do {
-
-            try {
-                success = client.makeResendRequest(uri, request);
-            } catch (final Exception ex) {
-                success = false;
-                LOGGER.debug("Failed to make resend request to node {} for key {}", uri, request.getPublicKey());
-            }
-
-            numberOfTries++;
-
-        } while (!success && (numberOfTries < MAX_ATTEMPTS));
-
-        return success;
+        try {
+            return client.makeResendRequest(uri, request);
+        } catch (final Exception ex) {
+            LOGGER.warn("Failed to make resend request to node {} for key {}", uri, request.getPublicKey());
+            return false;
+        }
     }
 
     /**
@@ -70,7 +55,7 @@ public class TransactionRequesterImpl implements TransactionRequester {
     private ResendRequest createRequestAllEntity(final PublicKey key) {
 
         final ResendRequest request = new ResendRequest();
-        String encoded = Base64.getEncoder().encodeToString(key.getKeyBytes());
+        final String encoded = key.encodeToBase64();
         request.setPublicKey(encoded);
         request.setType(ResendRequestType.ALL);
 

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/model/RecipientTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/model/RecipientTest.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.partyinfo.model;
 
-import com.quorum.tessera.partyinfo.model.Recipient;
 import com.quorum.tessera.encryption.PublicKey;
 import org.junit.Test;
 

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/sync/TransactionRequesterTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/sync/TransactionRequesterTest.java
@@ -1,19 +1,18 @@
 package com.quorum.tessera.sync;
 
-import com.quorum.tessera.partyinfo.ResendRequest;
 import com.quorum.tessera.enclave.Enclave;
 import com.quorum.tessera.encryption.PublicKey;
-import java.util.Base64;
+import com.quorum.tessera.partyinfo.ResendRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.util.Set;
-
 import java.util.Collections;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -31,7 +30,6 @@ public class TransactionRequesterTest {
 
     @Before
     public void init() {
-
         this.enclave = mock(Enclave.class);
         this.resendClient = mock(ResendClient.class);
 
@@ -49,7 +47,9 @@ public class TransactionRequesterTest {
     public void noPublicKeysMakesNoCalls() {
         when(enclave.getPublicKeys()).thenReturn(Collections.emptySet());
 
-        this.transactionRequester.requestAllTransactionsFromNode("fakeurl.com");
+        final boolean success = this.transactionRequester.requestAllTransactionsFromNode("fakeurl.com");
+
+        assertThat(success).isTrue();
 
         verifyZeroInteractions(resendClient);
         verify(enclave).getPublicKeys();
@@ -57,47 +57,34 @@ public class TransactionRequesterTest {
 
     @Test
     public void multipleKeysMakesCorrectCalls() {
-
         final Set<PublicKey> allKeys = Stream.of(KEY_ONE, KEY_TWO).collect(Collectors.toSet());
 
         when(enclave.getPublicKeys()).thenReturn(allKeys);
 
-        this.transactionRequester.requestAllTransactionsFromNode("fakeurl1.com");
+        final boolean success = this.transactionRequester.requestAllTransactionsFromNode("fakeurl1.com");
+
+        assertThat(success).isTrue();
 
         final ArgumentCaptor<ResendRequest> captor = ArgumentCaptor.forClass(ResendRequest.class);
         verify(resendClient, times(2)).makeResendRequest(eq("fakeurl1.com"), captor.capture());
         verify(enclave).getPublicKeys();
 
-        String encodedKeyOne = Base64.getEncoder().encodeToString(KEY_ONE.getKeyBytes());
-        String encodedKeyTwo = Base64.getEncoder().encodeToString(KEY_TWO.getKeyBytes());
-
         assertThat(captor.getAllValues())
                 .hasSize(2)
                 .extracting("publicKey")
-                .containsExactlyInAnyOrder(encodedKeyOne, encodedKeyTwo);
+                .containsExactlyInAnyOrder(KEY_ONE.encodeToBase64(), KEY_TWO.encodeToBase64());
     }
 
     @Test
-    public void failedCallRetries() {
-        when(enclave.getPublicKeys()).thenReturn(Collections.singleton(KEY_ONE));
-
-        when(resendClient.makeResendRequest(anyString(), any(ResendRequest.class))).thenReturn(false);
-
-        this.transactionRequester.requestAllTransactionsFromNode("fakeurl.com");
-
-        verify(resendClient, times(5)).makeResendRequest(eq("fakeurl.com"), any(ResendRequest.class));
-        verify(enclave).getPublicKeys();
-    }
-
-    @Test
-    public void calltoPostDelegateThrowsException() {
-
+    public void callToPostDelegateThrowsException() {
         when(enclave.getPublicKeys()).thenReturn(Collections.singleton(KEY_ONE));
         when(resendClient.makeResendRequest(anyString(), any(ResendRequest.class))).thenThrow(RuntimeException.class);
 
-        this.transactionRequester.requestAllTransactionsFromNode("fakeurl.com");
+        final boolean success = this.transactionRequester.requestAllTransactionsFromNode("fakeurl.com");
 
-        verify(resendClient, times(5)).makeResendRequest(eq("fakeurl.com"), any(ResendRequest.class));
+        assertThat(success).isFalse();
+
+        verify(resendClient).makeResendRequest(eq("fakeurl.com"), any(ResendRequest.class));
         verify(enclave).getPublicKeys();
     }
 }


### PR DESCRIPTION
There are two loops that occurs when perform a resend. The first will try 20 times, with a backoff period set by the poller rate (user configurable). The intention is that a resend will occur eventually if one of the nodes was offline, but not to try indefinitely.

The second loop occurs 5 times *for each* of the 20 iterations mentioned prior. This was intended to catch ephemeral issues, but causes more harm than good. Any ephemeral issue will be caught during the 20-loop, and even so, after 5 failed attempts it would be pretty clear the issue is persistent.

This PR removes the 5 attempts per loop, greatly reducing the number of retries made from 100 to 20, and simplifying the flow.