### PR TITLE
Use resource class for logger name in logging request filter 

### DIFF
--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/jaxrs/LoggingFilter.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/jaxrs/LoggingFilter.java
@@ -4,15 +4,22 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
 public class LoggingFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    private Logger getLogger() {
+        return Optional.ofNullable(resourceInfo)
+            .map(r -> LoggerFactory.getLogger(r.getResourceClass()))
+            .orElse(LOGGER);
+    }
 
     @Override
     public void filter(final ContainerRequestContext request) {
@@ -23,12 +30,12 @@ public class LoggingFilter implements ContainerRequestFilter, ContainerResponseF
     public void filter(final ContainerRequestContext request, final ContainerResponseContext response) {
         log("Exit", request);
         String path = Optional.ofNullable(request.getUriInfo()).map(UriInfo::getPath).orElse(null);
-        Optional.ofNullable(response.getStatusInfo()).ifPresent(statusType -> LOGGER.info("Response for {} : {} {}", path, statusType.getStatusCode(), statusType.getReasonPhrase()));
+        Optional.ofNullable(response.getStatusInfo()).ifPresent(statusType -> getLogger().info("Response for {} : {} {}", path, statusType.getStatusCode(), statusType.getReasonPhrase()));
     }
 
-    private static void log(String prefix, ContainerRequestContext request) {
+    private void log(String prefix, ContainerRequestContext request) {
         String path = Optional.ofNullable(request.getUriInfo()).map(UriInfo::getPath).orElse(null);
-        LOGGER.info("{} Request : {} : {}", prefix, request.getMethod(), "/" + path);
+        getLogger().info("{} Request : {} : {}", prefix, request.getMethod(), "/" + path);
 
     }
     


### PR DESCRIPTION
Fixes #996.  Use resourceinfo if available via jaxrs runtime to create loggername using resource class rather than LoggingFilter name.