### PR TITLE
No longer enforcing whitelist feature when discovery is disabled

### DIFF
--- a/tessera-admin/src/main/java/com/quorum/tessera/admin/ConfigServiceImpl.java
+++ b/tessera-admin/src/main/java/com/quorum/tessera/admin/ConfigServiceImpl.java
@@ -6,8 +6,6 @@ import com.quorum.tessera.config.Peer;
 import com.quorum.tessera.config.util.ConfigFileStore;
 import com.quorum.tessera.enclave.Enclave;
 import com.quorum.tessera.encryption.PublicKey;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.List;
@@ -15,8 +13,6 @@ import java.util.Objects;
 import java.util.Set;
 
 public class ConfigServiceImpl implements ConfigService {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigServiceImpl.class);
 
     private final Config config;
 
@@ -43,12 +39,6 @@ public class ConfigServiceImpl implements ConfigService {
 
     @Override
     public boolean isUseWhiteList() {
-        if (isDisablePeerDiscovery()) {
-            LOGGER.warn(
-                    "As peer discovery is being disabled, the use of peer whitelist restriction will be switched on."
-                            + "This is to prevent unauthorized attempt to push transactions from unknown peers.");
-            return true;
-        }
         return config.isUseWhiteList();
     }
 

--- a/tessera-admin/src/test/java/com/quorum/tessera/admin/ConfigServiceTest.java
+++ b/tessera-admin/src/test/java/com/quorum/tessera/admin/ConfigServiceTest.java
@@ -42,7 +42,7 @@ public class ConfigServiceTest {
 
     @Test
     public void isUseWhileList() {
-        when(config.isDisablePeerDiscovery()).thenReturn(false);
+
         when(config.isUseWhiteList()).thenReturn(false);
 
         assertThat(configService.isUseWhiteList()).isFalse();
@@ -50,23 +50,7 @@ public class ConfigServiceTest {
         when(config.isUseWhiteList()).thenReturn(true);
         assertThat(configService.isUseWhiteList()).isTrue();
 
-        verify(config, times(2)).isDisablePeerDiscovery();
         verify(config, times(2)).isUseWhiteList();
-    }
-
-    @Test
-    public void useWhiteListIsEnforcedWhenAutoDiscoveryIsOff() {
-
-        when(config.isDisablePeerDiscovery()).thenReturn(true);
-        when(config.isUseWhiteList()).thenReturn(true);
-
-        assertThat(configService.isUseWhiteList()).isTrue();
-
-        when(config.isUseWhiteList()).thenReturn(false);
-
-        assertThat(configService.isUseWhiteList()).isTrue();
-
-        verify(config, times(2)).isDisablePeerDiscovery();
     }
 
     @Test


### PR DESCRIPTION
The change to enforce the use of whitelist is to prevent a security incident where there is a mixed setup of auto-discovery feature in a Tessera network; however, this change does have an impact on some other use cases.

This PR is to revert the change.

We will re-evaluate the usage of "whitelist" feature