### PR TITLE
Bump spring versions in response to CVE-2020-5398 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 def jettyVersion = "9.4.25.v20191220"
-
+def springVersion = "5.2.3.RELEASE";
 allprojects {
     group = 'com.jpmorgan.quorum'
     //version = '0.11-SNAPSHOT'
@@ -77,15 +77,18 @@ allprojects {
                 compile "org.eclipse.jetty:jetty-unixsocket:"+ jettyVersion
                 compile "org.eclipse.jetty:jetty-server:"+ jettyVersion
                 compile "org.eclipse.jetty.websocket:javax-websocket-server-impl:"+ jettyVersion
-                compile "org.springframework:spring-core:5.1.2.RELEASE"
-                compile "org.springframework:spring-beans:5.1.2.RELEASE"
-                compile "org.springframework:spring-context:5.1.2.RELEASE"
-                compile "org.springframework:spring-orm:5.1.2.RELEASE"
+
                 compile "io.swagger:swagger-annotations:1.5.4"
                 compile "javax.transaction:javax.transaction-api:1.3"
                 compile "org.bouncycastle:bcpkix-jdk15on:1.61"
-                compile "org.springframework:spring-orm:5.1.2.RELEASE"
-                compile "org.springframework:spring-test:5.1.2.RELEASE"
+
+                compile "org.springframework:spring-orm:"+ springVersion
+                compile "org.springframework:spring-test:"+ springVersion
+                compile "org.springframework:spring-core:"+ springVersion
+                compile "org.springframework:spring-beans:"+ springVersion
+                compile "org.springframework:spring-context:"+ springVersion
+                compile "org.springframework:spring-orm:"+ springVersion
+
                 compile "javax.inject:javax.inject:1"
                 compile "org.bouncycastle:bcprov-jdk15on:1.61"
                 compile "com.h2database:h2:1.4.200"

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring.version>5.1.2.RELEASE</spring.version>
+        <spring.version>5.2.3.RELEASE</spring.version>
         <slf4j.version>1.7.5</slf4j.version>
         <eclipselink.version>2.7.3</eclipselink.version>
         <h2.version>1.4.200</h2.version>


### PR DESCRIPTION
fix for "[WARNING] Rule 3: org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies failed with message:

Detected 1 vulnerable components:
 org.springframework:spring-core:jar:5.1.2.RELEASE:test; https://ossindex.sonatype.org/component/pkg:maven/org.springframework/spring-core@5.1.2.RELEASE

* [CVE-2020-5398] In Spring Framework, versions 5.2.x prior to 5.2.3, versions 5.1.x prior to 5.1.... (7.5); https://ossindex.sonatype.org/vuln/07e93ccb-05c0-405d-9df8-56a5acf32070"
