### PR TITLE
Deduplicate recipients list

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -125,9 +125,12 @@ public class TransactionManagerImpl implements TransactionManager {
 
         recipientList.addAll(enclave.getForwardingKeys());
 
+        final List<PublicKey> recipientListNoDuplicate =
+            recipientList.stream().distinct().collect(Collectors.toList());
+
         final byte[] raw = sendRequest.getPayload();
 
-        final EncodedPayload payload = enclave.encryptPayload(raw, senderPublicKey, recipientList);
+        final EncodedPayload payload = enclave.encryptPayload(raw, senderPublicKey, recipientListNoDuplicate);
 
         final MessageHash transactionHash =
                 Optional.of(payload)
@@ -140,7 +143,7 @@ public class TransactionManagerImpl implements TransactionManager {
 
         this.encryptedTransactionDAO.save(newTransaction);
 
-        recipientList.forEach(
+        recipientListNoDuplicate.forEach(
                 recipient -> {
                     final EncodedPayload outgoing = payloadEncoder.forRecipient(payload, recipient);
                     partyInfoService.publishPayload(outgoing, recipient);

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -183,15 +183,18 @@ public class TransactionManagerImpl implements TransactionManager {
 
         recipientList.add(PublicKey.from(encryptedRawTransaction.getSender()));
 
+        final List<PublicKey> recipientListNoDuplicate =
+            recipientList.stream().distinct().collect(Collectors.toList());
+
         final EncodedPayload payload =
-                enclave.encryptPayload(encryptedRawTransaction.toRawTransaction(), recipientList);
+                enclave.encryptPayload(encryptedRawTransaction.toRawTransaction(), recipientListNoDuplicate);
 
         final EncryptedTransaction newTransaction =
                 new EncryptedTransaction(messageHash, this.payloadEncoder.encode(payload));
 
         this.encryptedTransactionDAO.save(newTransaction);
 
-        recipientList.forEach(
+        recipientListNoDuplicate.forEach(
                 recipient -> {
                     final EncodedPayload toPublish = payloadEncoder.forRecipient(payload, recipient);
                     partyInfoService.publishPayload(toPublish, recipient);


### PR DESCRIPTION
De-duplicate recipient list before pushing transaction to Tessera peers - this will avoid unnecessary transaction failures.

Fixes #923