### PR TITLE
Close hibernate validator vulnerability 

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/constraints/PathValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/PathValidator.java
@@ -39,7 +39,8 @@ public class PathValidator implements ConstraintValidator<ValidPath, Path> {
                 LOGGER.debug(null, ex);
                 constraintContext.disableDefaultConstraintViolation();
 
-                String sanitised = Objects.toString(t).replaceAll(Pattern.quote("$"),"");
+                String sanitised = Objects.toString(t).replaceAll(Pattern.quote("$"),"")
+                    .replaceAll(Pattern.quote("#"),"");
                 String message = String.format("Unable to create file %s",sanitised);
                 constraintContext.buildConstraintViolationWithTemplate(message)
                     .addConstraintViolation();

--- a/config/src/main/java/com/quorum/tessera/config/constraints/PathValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/PathValidator.java
@@ -5,8 +5,11 @@ import com.quorum.tessera.io.FilesDelegate;
 import java.io.UncheckedIOException;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +40,10 @@ public class PathValidator implements ConstraintValidator<ValidPath, Path> {
             } catch (UncheckedIOException ex) {
                 LOGGER.debug(null, ex);
                 constraintContext.disableDefaultConstraintViolation();
-                constraintContext.buildConstraintViolationWithTemplate("Unable to create file " + t)
+
+                String sanitised = Objects.toString(t).replaceAll(Pattern.quote("$"),"");
+                String message = String.format("Unable to create file %s",sanitised);
+                constraintContext.buildConstraintViolationWithTemplate(message)
                     .addConstraintViolation();
                 return false;
             } finally {

--- a/config/src/main/java/com/quorum/tessera/config/constraints/PathValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/PathValidator.java
@@ -5,8 +5,6 @@ import com.quorum.tessera.io.FilesDelegate;
 import java.io.UncheckedIOException;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
@@ -211,7 +211,34 @@ public class PathValidatorTest {
             return mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
         }).when(context).buildConstraintViolationWithTemplate(anyString());
 
-        pathValidator.isValid(path,context);
+        assertThat(pathValidator.isValid(path,context)).isFalse();
+
+        assertThat(messages).containsExactly("Unable to create file /somepath/{somethingbad}/somefile.file");
+
+    }
+
+    @Test
+    public void steathElExpressionHashPrefix() throws Exception {
+
+        final String evilPathWithElExpression = "/somepath/#{somethingbad}/somefile.file";
+
+        ValidPath validPath = mock(ValidPath.class);
+        when(validPath.checkCanCreate()).thenReturn(true);
+        when(validPath.checkExists()).thenReturn(false);
+        PathValidator pathValidator = new PathValidator();
+        pathValidator.initialize(validPath);
+
+        Path path = Paths.get(evilPathWithElExpression);
+
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+        List<String> messages = new ArrayList<>();
+        doAnswer(invocation -> {
+            messages.add(invocation.getArgument(0));
+            return mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        }).when(context).buildConstraintViolationWithTemplate(anyString());
+
+        assertThat(pathValidator.isValid(path,context)).isFalse();
 
         assertThat(messages).containsExactly("Unable to create file /somepath/{somethingbad}/somefile.file");
 

--- a/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/constraints/PathValidatorTest.java
@@ -9,6 +9,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,5 +187,33 @@ public class PathValidatorTest {
         assertThat(pathValidator.isValid(path, context)).isTrue();
 
         verifyNoMoreInteractions(context);
+    }
+
+
+    @Test
+    public void steathElExpression() throws Exception {
+
+        final String evilPathWithElExpression = "/somepath/${somethingbad}/somefile.file";
+
+        ValidPath validPath = mock(ValidPath.class);
+        when(validPath.checkCanCreate()).thenReturn(true);
+        when(validPath.checkExists()).thenReturn(false);
+        PathValidator pathValidator = new PathValidator();
+        pathValidator.initialize(validPath);
+
+        Path path = Paths.get(evilPathWithElExpression);
+
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+        List<String> messages = new ArrayList<>();
+        doAnswer(invocation -> {
+            messages.add(invocation.getArgument(0));
+            return mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        }).when(context).buildConstraintViolationWithTemplate(anyString());
+
+        pathValidator.isValid(path,context);
+
+        assertThat(messages).containsExactly("Unable to create file /somepath/{somethingbad}/somefile.file");
+
     }
 }


### PR DESCRIPTION
Sanitise potential nested el expressions in configuration path values. Remove dollar signs from path values before creating validation message, 