### PR TITLE
Fix config validation for ADMIN and invalid server types

### DIFF
--- a/cli/cli-api/src/test/resources/sample-config-no-keyconfig.json
+++ b/cli/cli-api/src/test/resources/sample-config-no-keyconfig.json
@@ -14,12 +14,6 @@
             "communicationType": "REST"
         },
         {
-            "app": "ADMIN",
-            "enabled": true,
-            "serverAddress": "http://localhost:18090",
-            "communicationType": "REST"
-        },
-        {
             "app": "Q2T",
             "enabled": true,
             "serverAddress": "unix:/tmp/test.ipc",

--- a/cli/cli-api/src/test/resources/sample-config-password-file-only.json
+++ b/cli/cli-api/src/test/resources/sample-config-password-file-only.json
@@ -14,12 +14,6 @@
             "communicationType": "REST"
         },
         {
-            "app": "ADMIN",
-            "enabled": true,
-            "serverAddress": "http://localhost:18090",
-            "communicationType": "REST"
-        },
-        {
             "app": "Q2T",
             "enabled": true,
             "serverAddress": "unix:/tmp/test.ipc",

--- a/cli/cli-api/src/test/resources/sample-config-password-file.json
+++ b/cli/cli-api/src/test/resources/sample-config-password-file.json
@@ -14,12 +14,6 @@
             "communicationType": "REST"
         },
         {
-            "app": "ADMIN",
-            "enabled": true,
-            "serverAddress": "http://localhost:18090",
-            "communicationType": "REST"
-        },
-        {
             "app": "Q2T",
             "enabled": true,
             "serverAddress": "unix:/tmp/test.ipc",

--- a/cli/cli-api/src/test/resources/sample-config.json
+++ b/cli/cli-api/src/test/resources/sample-config.json
@@ -14,12 +14,6 @@
             "communicationType": "REST"
         },
         {
-            "app": "ADMIN",
-            "enabled": true,
-            "serverAddress": "http://localhost:18090",
-            "communicationType": "REST"
-        },
-        {
             "app": "Q2T",
             "enabled": true,
             "serverAddress": "unix:/tmp/test.ipc",

--- a/cli/config-cli/src/test/resources/sample-config.json
+++ b/cli/config-cli/src/test/resources/sample-config.json
@@ -17,12 +17,6 @@
             "communicationType": "REST"
         },
         {
-            "app": "ADMIN",
-            "enabled": true,
-            "serverAddress": "http://localhost:18090",
-            "communicationType": "REST"
-        },
-        {
             "app": "Q2T",
             "enabled": true,
             "serverAddress": "unix:/tmp/test.ipc",

--- a/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
@@ -22,9 +22,10 @@ public class ServerConfigValidator implements ConstraintValidator<ValidServerCon
             return true;
         }
 
-        if (serverConfig.getApp() == null) {
+        if (serverConfig.getApp() == null || AppType.ADMIN.toString().equals(serverConfig.getApp().toString())) {
             List<String> supportedAppTypes = Arrays.stream(AppType.values())
                 .map(AppType::toString)
+                .filter(t -> !t.equals(AppType.ADMIN.toString()))
                 .collect(Collectors.toList());
 
             constraintContext.disableDefaultConstraintViolation();

--- a/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class ServerConfigValidator implements ConstraintValidator<ValidServerConfig, ServerConfig> {
@@ -23,14 +22,17 @@ public class ServerConfigValidator implements ConstraintValidator<ValidServerCon
         }
 
         if (serverConfig.getApp() == null || AppType.ADMIN.toString().equals(serverConfig.getApp().toString())) {
-            List<String> supportedAppTypes = Arrays.stream(AppType.values())
-                .map(AppType::toString)
-                .filter(t -> !t.equals(AppType.ADMIN.toString()))
-                .collect(Collectors.toList());
+            String supportedAppTypes =
+                    Arrays.stream(AppType.values())
+                            .filter(t -> t != AppType.ADMIN)
+                            .map(AppType::name)
+                            .collect(Collectors.joining(", "));
 
             constraintContext.disableDefaultConstraintViolation();
-            constraintContext.buildConstraintViolationWithTemplate("app must be provided for serverConfig and be one of " + String.join(", ", supportedAppTypes))
-                .addConstraintViolation();
+            constraintContext
+                    .buildConstraintViolationWithTemplate(
+                            "app must be provided for serverConfig and be one of " + supportedAppTypes)
+                    .addConstraintViolation();
             return false;
         }
 

--- a/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
+++ b/config/src/main/java/com/quorum/tessera/config/constraints/ServerConfigValidator.java
@@ -7,6 +7,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ServerConfigValidator implements ConstraintValidator<ValidServerConfig, ServerConfig> {
 
@@ -17,6 +20,17 @@ public class ServerConfigValidator implements ConstraintValidator<ValidServerCon
 
         if (serverConfig == null) {
             return true;
+        }
+
+        if (serverConfig.getApp() == null) {
+            List<String> supportedAppTypes = Arrays.stream(AppType.values())
+                .map(AppType::toString)
+                .collect(Collectors.toList());
+
+            constraintContext.disableDefaultConstraintViolation();
+            constraintContext.buildConstraintViolationWithTemplate("app must be provided for serverConfig and be one of " + String.join(", ", supportedAppTypes))
+                .addConstraintViolation();
+            return false;
         }
 
         if (!serverConfig.getApp().getAllowedCommunicationTypes().contains(serverConfig.getCommunicationType())) {

--- a/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
@@ -249,8 +249,6 @@ public class ValidationTest {
         assertThat(violation.getMessageTemplate()).isEqualTo("{javax.validation.constraints.NotNull.message}");
     }
 
-
-
     @Test
     public void serverAddressValidations() {
 
@@ -272,8 +270,7 @@ public class ValidationTest {
     }
 
     @Test
-    public void serverTypeValidationsFullValidation() {
-
+    public void unknownServerType() {
         final ServerConfig serverConfig = new ServerConfig();
         serverConfig.setApp(null);
 
@@ -282,23 +279,27 @@ public class ValidationTest {
 
         final Set<ConstraintViolation<Config>> invalidresult = validator.validate(config);
         final List<ConstraintViolation<Config>> invalidServerAppTypeResults = invalidresult.stream()
-            .filter(v -> v.getMessageTemplate().contains("app must be provided for serverConfig and be one of P2P, Q2T, THIRD_PARTY, ENCLAVE, ADMIN"))
+            .filter(v -> v.getMessageTemplate().contains("app must be provided for serverConfig and be one of P2P, Q2T, THIRD_PARTY, ENCLAVE"))
             .collect(Collectors.toList());
 
         assertThat(invalidServerAppTypeResults).hasSize(1);
-
-
-        config.getServerConfigs().get(0).setApp(AppType.P2P);
-
-        final Set<ConstraintViolation<Config>> validresult = validator.validate(config);
-        List<ConstraintViolation<Config>> validServerAppTypeResults = validresult.stream()
-            .filter(v -> v.getMessageTemplate().contains("app must be provided for serverConfig and be one of P2P, Q2T, THIRD_PARTY, ENCLAVE, ADMIN"))
-            .collect(Collectors.toList());
-
-        assertThat(validServerAppTypeResults).isEmpty();
     }
 
+    @Test
+    public void adminServerTypeDeprecated() {
+        final ServerConfig serverConfig = new ServerConfig();
+        serverConfig.setApp(AppType.ADMIN);
 
+        final Config config = new Config();
+        config.setServerConfigs(Collections.singletonList(serverConfig));
+
+        final Set<ConstraintViolation<Config>> invalidresult = validator.validate(config);
+        final List<ConstraintViolation<Config>> invalidServerAppTypeResults = invalidresult.stream()
+            .filter(v -> v.getMessageTemplate().contains("app must be provided for serverConfig and be one of P2P, Q2T, THIRD_PARTY, ENCLAVE"))
+            .collect(Collectors.toList());
+
+        assertThat(invalidServerAppTypeResults).hasSize(1);
+    }
 
     @Test
     public void configHasKeysOrIsRemoteEnclaveNiether() {

--- a/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/ValidationTest.java
@@ -272,6 +272,35 @@ public class ValidationTest {
     }
 
     @Test
+    public void serverTypeValidationsFullValidation() {
+
+        final ServerConfig serverConfig = new ServerConfig();
+        serverConfig.setApp(null);
+
+        final Config config = new Config();
+        config.setServerConfigs(Collections.singletonList(serverConfig));
+
+        final Set<ConstraintViolation<Config>> invalidresult = validator.validate(config);
+        final List<ConstraintViolation<Config>> invalidServerAppTypeResults = invalidresult.stream()
+            .filter(v -> v.getMessageTemplate().contains("app must be provided for serverConfig and be one of P2P, Q2T, THIRD_PARTY, ENCLAVE, ADMIN"))
+            .collect(Collectors.toList());
+
+        assertThat(invalidServerAppTypeResults).hasSize(1);
+
+
+        config.getServerConfigs().get(0).setApp(AppType.P2P);
+
+        final Set<ConstraintViolation<Config>> validresult = validator.validate(config);
+        List<ConstraintViolation<Config>> validServerAppTypeResults = validresult.stream()
+            .filter(v -> v.getMessageTemplate().contains("app must be provided for serverConfig and be one of P2P, Q2T, THIRD_PARTY, ENCLAVE, ADMIN"))
+            .collect(Collectors.toList());
+
+        assertThat(validServerAppTypeResults).isEmpty();
+    }
+
+
+
+    @Test
     public void configHasKeysOrIsRemoteEnclaveNiether() {
 
         Config config = new Config();


### PR DESCRIPTION
Fixes #1016 

* As `ADMIN` server has been deprecated for the time being, this change will mean validation exceptions are thrown if the `ADMIN` server type is configured
* Invalid server types will be handled and throw validation exceptions