### PR TITLE
update jnr-unixsocket version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
                 testCompile "com.openpojo:openpojo:0.8.10"
                 testCompile "com.github.stefanbirkner:system-rules:1.18.0"
                 testCompile "nl.jqno.equalsverifier:equalsverifier:3.1.5"
-
+                compile "com.github.jnr:jnr-unixsocket:0.28"
                 compile "de.mkammerer:argon2-jvm:2.5"
                 compile "javax.validation:validation-api:2.0.1.Final"
                 compile "javax.ws.rs:javax.ws.rs-api:2.1"

--- a/pom.xml
+++ b/pom.xml
@@ -1091,7 +1091,7 @@
             <dependency>
                 <groupId>com.github.jnr</groupId>
                 <artifactId>jnr-unixsocket</artifactId>
-                <version>0.25</version>
+                <version>0.28</version>
             </dependency>
 
             <dependency>
@@ -1105,43 +1105,6 @@
                 <groupId>org.eclipse.jetty.websocket</groupId>
                 <artifactId>javax-websocket-client-impl</artifactId>
                 <version>${jetty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jnr-constants</artifactId>
-                <version>0.9.12</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jnr-posix</artifactId>
-                <version>3.0.49</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jnr-enxio</artifactId>
-                <version>0.20</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jnr-ffi</artifactId>
-                <version>2.1.9</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jffi</artifactId>
-                <version>1.2.17</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jffi</artifactId>
-                <version>1.2.17</version>
-                <classifier>native</classifier>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
which in turn updates to the latest jffi version

fixes #1024 