### PR TITLE
added release.yml allowing remote activation using api call.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ env:
   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   GPG_EXECUTABLE: ${{ secrets.GPG_EXECUTABLE }}
   GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
-  RELEASE_VERSION: ${{github.event.client_payload.version}}
 
 jobs:
   release:
@@ -22,46 +21,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Create release skip tests
-        if: ${{github.event.client_payload.skipTests}}
-
+      - name: Create release branch
         run: |
-          echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
-          echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
+          export now=`date +%Y%m%d%H%M%S`
+          git checkout -b "release-$now"
 
-          mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
-          mvn --settings .maven.xml release:perform -DdryRun=true -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
-
-          #     mvn --settings .maven.xml -B deploy -P release -pl \!tests/acceptance-test -DskipTests
-
-
-          #          mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
-
-          #              export now=`date +%Y%m%d%H%M%S`
-          #              git config user.email "melowe.quorum@gmail.com"
-          #              git config user.name "melowe"
-          #              git checkout -b release-$now
-          #              mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion}.$now versions:commit -B
-          #              export new_version=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`
-          #              git add \*/pom.xml
-          #             git commit -m "Change pom versions to $new_version"
-          #            export tag_version=tessera-$new_version
-          #            git tag -a $tag_version -m "Create $tag_version"
-          #             git push origin $tag_version
-          #             echo "Deploy stuff"
-          #             echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
-          #             echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
-          # mvn --settings .maven.xml -B deploy -P release -pl \!tests/acceptance-test
-
-
-      #       mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test
-
-      - name: Create release
-        if: ${{!github.event.client_payload.skipTests}}
-
+      - name: Release Prepare
         run: |
-          echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
-          echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
-
-          mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test
-          mvn --settings .maven.xml release:perform -DdryRun=true -pl \!tests/acceptance-test
+          mvn --settings .maven.xml release:prepare -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
+      - name: Release Perform
+        run: |
+          mvn --settings .maven.xml release:perform -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Tessera Release Build
+
+on:
+  repository_dispatch:
+    types: [release]
+
+env:
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+  GPG_EXECUTABLE: ${{ secrets.GPG_EXECUTABLE }}
+  GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+  RELEASE_VERSION: ${{github.event.client_payload.version}}
+
+jobs:
+  release:
+    runs-on: [ubuntu-latest]
+    steps:
+
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Create release skip tests
+        if: ${{github.event.client_payload.skipTests}}
+
+        run: |
+          echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
+          echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
+
+          mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
+          mvn --settings .maven.xml release:perform -DdryRun=true -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
+
+          #     mvn --settings .maven.xml -B deploy -P release -pl \!tests/acceptance-test -DskipTests
+
+
+          #          mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
+
+          #              export now=`date +%Y%m%d%H%M%S`
+          #              git config user.email "melowe.quorum@gmail.com"
+          #              git config user.name "melowe"
+          #              git checkout -b release-$now
+          #              mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion}.$now versions:commit -B
+          #              export new_version=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`
+          #              git add \*/pom.xml
+          #             git commit -m "Change pom versions to $new_version"
+          #            export tag_version=tessera-$new_version
+          #            git tag -a $tag_version -m "Create $tag_version"
+          #             git push origin $tag_version
+          #             echo "Deploy stuff"
+          #             echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
+          #             echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
+          # mvn --settings .maven.xml -B deploy -P release -pl \!tests/acceptance-test
+
+
+      #       mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test
+
+      - name: Create release
+        if: ${{!github.event.client_payload.skipTests}}
+
+        run: |
+          echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
+          echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
+
+          mvn --settings .maven.xml release:prepare -DdryRun=true -pl \!tests/acceptance-test
+          mvn --settings .maven.xml release:perform -DdryRun=true -pl \!tests/acceptance-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,6 @@ jobs:
           mvn --settings .maven.xml release:prepare -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"
       - name: Release Perform
         run: |
+          echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
+          echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
           mvn --settings .maven.xml release:perform -pl \!tests/acceptance-test -DskipTests -Darguments="-DskipTests"

--- a/pom.xml
+++ b/pom.xml
@@ -1592,6 +1592,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
maven release plugin can be activation using 

`curl -v -X POST -u "[user]:[api key]" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" --data '{"event_type":"release"}' https://api.github.com/repos/jpmorganchase/tessera/dispatches`

