### PR TITLE
Add API to retrieve tx participants and if node was sender

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManager.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManager.java
@@ -1,9 +1,12 @@
 package com.quorum.tessera.transaction;
 
+import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.partyinfo.ResendResponse;
 import com.quorum.tessera.partyinfo.ResendRequest;
 import com.quorum.tessera.data.MessageHash;
 import com.quorum.tessera.api.model.*;
+
+import java.util.List;
 
 public interface TransactionManager {
 
@@ -20,4 +23,8 @@ public interface TransactionManager {
     ReceiveResponse receive(ReceiveRequest request);
 
     StoreRawResponse store(StoreRawRequest storeRequest);
+
+    boolean isSender(String ptmHash);
+
+    List<PublicKey> getParticipants(String ptmHash);
 }

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
@@ -2,6 +2,7 @@ package com.quorum.tessera.q2t;
 
 import com.quorum.tessera.api.model.*;
 import com.quorum.tessera.core.api.ServiceFactory;
+import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.transaction.TransactionManager;
 import io.swagger.annotations.*;
 import org.slf4j.Logger;
@@ -20,6 +21,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.*;
 
@@ -233,5 +235,30 @@ public class TransactionResource {
         delegate.delete(delete);
 
         return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/transaction/{key}/isSender")
+    public Response isSender(@ApiParam("Encoded hash") @PathParam("key") final String ptmHash) {
+
+        LOGGER.debug("Received isSender API request for key {}", ptmHash);
+
+        boolean isSender = delegate.isSender(ptmHash);
+
+        return Response.ok(isSender).build();
+    }
+
+    @GET
+    @Path("/transaction/{key}/participants")
+    public Response getParticipants(@ApiParam("Encoded hash") @PathParam("key") final String ptmHash) {
+
+        LOGGER.debug("Received participants list API request for key {}", ptmHash);
+
+        final String participantList =
+                delegate.getParticipants(ptmHash).stream()
+                        .map(PublicKey::encodeToBase64)
+                        .collect(Collectors.joining(","));
+
+        return Response.ok(participantList).build();
     }
 }

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResourceTest.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResourceTest.java
@@ -164,4 +164,26 @@ public class TransactionResourceTest {
 
         verify(transactionManager).delete(deleteRequest);
     }
+
+    @Test
+    public void isSenderDelegates() {
+        final String dummyPtmHash = "DUMMY_HASH";
+
+        Response response = transactionResource.isSender(dummyPtmHash);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        verify(transactionManager).isSender(dummyPtmHash);
+    }
+
+    @Test
+    public void getParticipantsDelegates() {
+        final String dummyPtmHash = "DUMMY_HASH";
+
+        Response response = transactionResource.getParticipants(dummyPtmHash);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        verify(transactionManager).getParticipants(dummyPtmHash);
+    }
 }


### PR DESCRIPTION
Add API endpoints to:
- retrieve transaction participants directly from the database (so a recipient will have no participants)
- tell if the local enclave is the sender of a particular transaction (by checking if the sender public key is part of the nodes enclave)
