### PR TITLE
Fixes to whitelist filter

### DIFF
--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
@@ -162,21 +162,4 @@ public class IPWhitelistFilterTest {
         verify(request).getRemoteAddr();
         verifyNoMoreInteractions(ctx);
     }
-
-    @Test
-    public void localHostIPv6IsAlsoWhiteListed() {
-        URI peer = URI.create("http://localhost:8080");
-        when(configService.getPeers()).thenReturn(singletonList(peer));
-
-        final HttpServletRequest request = mock(HttpServletRequest.class);
-        doReturn("0:0:0:0:0:0:0:1").when(request).getRemoteAddr();
-
-        filter.setHttpServletRequest(request);
-
-        filter.filter(ctx);
-
-        verify(request).getRemoteHost();
-        verify(request).getRemoteAddr();
-        verifyNoMoreInteractions(ctx);
-    }
 }

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
@@ -162,4 +162,21 @@ public class IPWhitelistFilterTest {
         verify(request).getRemoteAddr();
         verifyNoMoreInteractions(ctx);
     }
+
+    @Test
+    public void localHostIPv6IsAlsoWhiteListed() {
+        URI peer = URI.create("http://localhost:8080");
+        when(configService.getPeers()).thenReturn(singletonList(peer));
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn("0:0:0:0:0:0:0:1").when(request).getRemoteAddr();
+
+        filter.setHttpServletRequest(request);
+
+        filter.filter(ctx);
+
+        verify(request).getRemoteHost();
+        verify(request).getRemoteAddr();
+        verifyNoMoreInteractions(ctx);
+    }
 }

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
@@ -42,8 +42,6 @@ public class IPWhitelistFilterTest {
         when(uriInfo.getBaseUri()).thenReturn(new URI("otherhost"));
         when(ctx.getUriInfo()).thenReturn(uriInfo);
 
-
-
         this.filter = new IPWhitelistFilter();
     }
 
@@ -107,7 +105,6 @@ public class IPWhitelistFilterTest {
     @Test
     public void errorFilteringStopsFutureFilters() {
 
-
         when(configService.isUseWhiteList()).thenReturn(true);
         // show that one request goes through okay
         final HttpServletRequest request = mock(HttpServletRequest.class);
@@ -166,6 +163,23 @@ public class IPWhitelistFilterTest {
     @Test
     public void localhostIPv6IsAlsoWhiteListed() {
         URI peer = URI.create("http://localhost:8080");
+        when(configService.getPeers()).thenReturn(singletonList(peer));
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn("0:0:0:0:0:0:0:1").when(request).getRemoteAddr();
+
+        filter.setHttpServletRequest(request);
+
+        filter.filter(ctx);
+
+        verify(request).getRemoteHost();
+        verify(request).getRemoteAddr();
+        verifyNoMoreInteractions(ctx);
+    }
+
+    @Test
+    public void localAddrIPv6IsAlsoWhiteListed() {
+        URI peer = URI.create("http://127.0.0.1:8080");
         when(configService.getPeers()).thenReturn(singletonList(peer));
 
         final HttpServletRequest request = mock(HttpServletRequest.class);

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/filter/IPWhitelistFilterTest.java
@@ -103,37 +103,6 @@ public class IPWhitelistFilterTest {
     }
 
     @Test
-    public void errorFilteringStopsFutureFilters() {
-
-        when(configService.isUseWhiteList()).thenReturn(true);
-        // show that one request goes through okay
-        final HttpServletRequest request = mock(HttpServletRequest.class);
-        doReturn("whitelistedHost").when(request).getRemoteAddr();
-        filter.setHttpServletRequest(request);
-        filter.filter(ctx);
-        verify(request).getRemoteHost();
-        verify(request).getRemoteAddr();
-
-        verifyNoMoreInteractions(ctx);
-
-        // show the second one errors
-        final HttpServletRequest requestError = mock(HttpServletRequest.class);
-        doThrow(RuntimeException.class).when(requestError).getRemoteHost();
-        filter.setHttpServletRequest(requestError);
-        filter.filter(ctx);
-
-        verifyNoMoreInteractions(ctx);
-        verify(request).getRemoteAddr();
-
-        // show the third doesn't get filtered
-        final HttpServletRequest requestIgnored = mock(HttpServletRequest.class);
-        filter.setHttpServletRequest(requestIgnored);
-        filter.filter(ctx);
-        verifyZeroInteractions(requestIgnored);
-        verifyZeroInteractions(ctx);
-    }
-
-    @Test
     public void defaultConstructor() {
         when(configService.isUseWhiteList()).thenReturn(Boolean.TRUE);
         MockServiceLocator mockServiceLocator = (MockServiceLocator) ServiceLocator.create();


### PR DESCRIPTION
- Fixing whitelist validation for curl requests (where local host IP is IPv6 format).
- Adding extra log info when peer rejected due to whitelist.
- Remove catch for generic exception, where whitelist was being disabled.