### PR TITLE
Error messaging changes

### DIFF
--- a/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/DefaultExceptionMapper.java
+++ b/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/DefaultExceptionMapper.java
@@ -19,14 +19,13 @@ public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
         final Throwable rootCause = ExceptionUtils.getRootCause(ex);
         final Throwable cause = (rootCause == null) ? ex : rootCause;
 
-        LOGGER.error("Error occured: {}. Root cause: {}", ex.getMessage(), cause.getMessage());
+        LOGGER.error("Error occurred: {}. Root cause: {}", ex.getMessage(), cause.getMessage());
         LOGGER.debug(null, ex);
         LOGGER.debug(null, cause);
 
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-            .entity(cause.getMessage())
-            .type(MediaType.TEXT_PLAIN)
-            .build();
+                .entity(cause.getMessage())
+                .type(MediaType.TEXT_PLAIN)
+                .build();
     }
-
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/JerseyServer.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/JerseyServer.java
@@ -79,9 +79,7 @@ public class JerseyServer implements TesseraServer {
 
         final ResourceConfig config = ResourceConfig.forApplication(application);
 
-        config.addProperties(initParams)
-            .register(MetricsResource.class)
-            .register(LoggingFilter.class);
+        config.addProperties(initParams).register(MetricsResource.class).register(LoggingFilter.class);
 
         if (serverConfig.getCrossDomainConfig() != null && !serverConfig.isUnixSocket()) {
             config.register(new CorsDomainResponseFilter(serverConfig.getCrossDomainConfig()));
@@ -118,8 +116,10 @@ public class JerseyServer implements TesseraServer {
                     try {
                         publisher.run();
                     } catch (final Throwable ex) {
-                        LOGGER.error("Error when executing action {}", publisher.getClass().getSimpleName());
-                        LOGGER.error("Error when executing action", ex);
+                        LOGGER.error(
+                                "Error when executing action {}, exception details:",
+                                publisher.getClass().getSimpleName(),
+                                ex);
                     }
                 };
 

--- a/shared/src/main/java/com/quorum/tessera/service/ServiceContainer.java
+++ b/shared/src/main/java/com/quorum/tessera/service/ServiceContainer.java
@@ -27,10 +27,11 @@ public class ServiceContainer implements Runnable {
         this(service, Executors.newScheduledThreadPool(1), 1000L, 1000L);
     }
 
-    public ServiceContainer(final Service service,
-                            final ScheduledExecutorService executorService,
-                            final long initialDelay,
-                            final long period) {
+    public ServiceContainer(
+            final Service service,
+            final ScheduledExecutorService executorService,
+            final long initialDelay,
+            final long period) {
         this.service = service;
         this.executorService = executorService;
         this.initialDelay = initialDelay;
@@ -55,19 +56,18 @@ public class ServiceContainer implements Runnable {
         LOGGER.trace("{} Status is {}", service, status);
 
         if (status == Service.Status.STOPPED) {
-            LOGGER.warn("Service {} not stopped attempt to restart.", service);
+            LOGGER.warn("Service {} is stopped, attempting to start it.", service);
             try {
                 LOGGER.debug("Starting service {}", service);
                 service.start();
                 LOGGER.debug("Started service {}", service);
             } catch (Throwable ex) {
                 LOGGER.trace(null, ex);
-                LOGGER.warn("Exception thrown : {} While starting service {}", 
-                    Optional.ofNullable(ex.getCause())
-                        .orElse(ex)
-                        .getMessage(), service);
+                LOGGER.warn(
+                        "Exception thrown : {} While starting service {}",
+                        Optional.ofNullable(ex.getCause()).orElse(ex).getMessage(),
+                        service);
             }
         }
     }
-
 }

--- a/tessera-core/src/main/java/com/quorum/tessera/threading/TesseraScheduledExecutor.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/threading/TesseraScheduledExecutor.java
@@ -49,8 +49,10 @@ public class TesseraScheduledExecutor {
 
                         this.action.run();
                     } catch (final Throwable ex) {
-                        LOGGER.error("Error when executing action {}", action.getClass().getSimpleName());
-                        LOGGER.error("Error when executing action", ex);
+                        LOGGER.error(
+                                "Error when executing action {}, exception details:",
+                                action.getClass().getSimpleName(),
+                                ex);
                     } finally {
                         LOGGER.debug("{} has finished running", getClass().getSimpleName());
                     }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -115,8 +115,7 @@ public class TransactionManagerImpl implements TransactionManager {
 
         recipientList.addAll(enclave.getForwardingKeys());
 
-        final List<PublicKey> recipientListNoDuplicate =
-            recipientList.stream().distinct().collect(Collectors.toList());
+        final List<PublicKey> recipientListNoDuplicate = recipientList.stream().distinct().collect(Collectors.toList());
 
         final byte[] raw = sendRequest.getPayload();
 
@@ -173,8 +172,7 @@ public class TransactionManagerImpl implements TransactionManager {
 
         recipientList.add(PublicKey.from(encryptedRawTransaction.getSender()));
 
-        final List<PublicKey> recipientListNoDuplicate =
-            recipientList.stream().distinct().collect(Collectors.toList());
+        final List<PublicKey> recipientListNoDuplicate = recipientList.stream().distinct().collect(Collectors.toList());
 
         final EncodedPayload payload =
                 enclave.encryptPayload(encryptedRawTransaction.toRawTransaction(), recipientListNoDuplicate);
@@ -247,8 +245,9 @@ public class TransactionManagerImpl implements TransactionManager {
                                         partyInfoService.publishPayload(prunedPayload, recipientPublicKey);
                                     } catch (PublishPayloadException ex) {
                                         LOGGER.warn(
-                                                "Unable to publish payload to recipient {} during resend",
-                                                recipientPublicKey.encodeToBase64());
+                                                "Unable to resend payload to recipient with public key {}, due to {}",
+                                                recipientPublicKey.encodeToBase64(),
+                                                ex.getMessage());
                                     }
                                 });
 

--- a/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
+++ b/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
@@ -91,11 +91,11 @@ public class Main {
             if (JsonException.class.isInstance(cause)) {
                 System.err.println("ERROR: Invalid json, cause is " + cause.getMessage());
             } else {
-                System.err.println("ERROR: " + Objects.toString(cause));
+                System.err.println("ERROR: Configuration exception, cause is " + Objects.toString(cause));
             }
             System.exit(3);
         } catch (final CliException ex) {
-            System.err.println("ERROR: " + ex.getMessage());
+            System.err.println("ERROR: CLI exception, cause is " + ex.getMessage());
             System.exit(4);
         } catch (final ServiceConfigurationError ex) {
             Optional<Throwable> e = Optional.of(ex);
@@ -115,9 +115,9 @@ public class Main {
                 ex.printStackTrace();
             } else {
                 if (Optional.ofNullable(ex.getMessage()).isPresent()) {
-                    System.err.println("ERROR: " + ex.getMessage());
+                    System.err.println("ERROR: Cause is " + ex.getMessage());
                 } else {
-                    System.err.println("ERROR: " + ex.getClass().getSimpleName());
+                    System.err.println("ERROR: In class " + ex.getClass().getSimpleName());
                 }
             }
 

--- a/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
+++ b/tessera-dist/tessera-launcher/src/main/java/com/quorum/tessera/launcher/Main.java
@@ -38,9 +38,9 @@ public class Main {
         try {
 
             PicoCliDelegate picoCliDelegate = new PicoCliDelegate();
-            LOGGER.debug("Execute PicoCliDelegate with args [{}]",String.join(",",args));
+            LOGGER.debug("Execute PicoCliDelegate with args [{}]", String.join(",", args));
             final CliResult cliResult = picoCliDelegate.execute(args);
-            LOGGER.debug("Executed PicoCliDelegate with args [{}].",String.join(",",args));
+            LOGGER.debug("Executed PicoCliDelegate with args [{}].", String.join(",", args));
             CliDelegate.instance().setConfig(cliResult.getConfig().orElse(null));
 
             if (cliResult.isSuppressStartup()) {
@@ -60,39 +60,42 @@ public class Main {
 
             LOGGER.debug("Creating service locator");
             ServiceLocator serviceLocator = ServiceLocator.create();
-            LOGGER.debug("Created service locator {}",serviceLocator);
+            LOGGER.debug("Created service locator {}", serviceLocator);
 
             Set<Object> services = serviceLocator.getServices();
 
-            LOGGER.debug("Created {} services",services.size());
+            LOGGER.debug("Created {} services", services.size());
 
-            services.forEach(o -> LOGGER.debug("Service : {}",o));
+            services.forEach(o -> LOGGER.debug("Service : {}", o));
 
             services.stream()
-                .filter(PartyInfoService.class::isInstance)
-                .map(PartyInfoService.class::cast)
-                .findAny()
-                .ifPresent(p -> p.populateStore());
+                    .filter(PartyInfoService.class::isInstance)
+                    .map(PartyInfoService.class::cast)
+                    .findAny()
+                    .ifPresent(p -> p.populateStore());
 
             runWebServer(config);
 
         } catch (final ConstraintViolationException ex) {
             for (final ConstraintViolation<?> violation : ex.getConstraintViolations()) {
-                System.out.println(
-                        "Config validation issue: " + violation.getPropertyPath() + " " + violation.getMessage());
+                System.err.println(
+                        "ERROR: Config validation issue: "
+                                + violation.getPropertyPath()
+                                + " "
+                                + violation.getMessage());
             }
             System.exit(1);
         } catch (final ConfigException ex) {
             final Throwable cause = ExceptionUtils.getRootCause(ex);
 
             if (JsonException.class.isInstance(cause)) {
-                System.err.println("Invalid json, error is " + cause.getMessage());
+                System.err.println("ERROR: Invalid json, cause is " + cause.getMessage());
             } else {
-                System.err.println(Objects.toString(cause));
+                System.err.println("ERROR: " + Objects.toString(cause));
             }
             System.exit(3);
         } catch (final CliException ex) {
-            System.err.println(ex.getMessage());
+            System.err.println("ERROR: " + ex.getMessage());
             System.exit(4);
         } catch (final ServiceConfigurationError ex) {
             Optional<Throwable> e = Optional.of(ex);
@@ -112,9 +115,9 @@ public class Main {
                 ex.printStackTrace();
             } else {
                 if (Optional.ofNullable(ex.getMessage()).isPresent()) {
-                    System.err.println(ex.getMessage());
+                    System.err.println("ERROR: " + ex.getMessage());
                 } else {
-                    System.err.println(ex.getClass().getSimpleName());
+                    System.err.println("ERROR: " + ex.getClass().getSimpleName());
                 }
             }
 

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoPoller.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoPoller.java
@@ -83,7 +83,7 @@ public class PartyInfoPoller implements Runnable {
         CompletableFuture.runAsync(() -> p2pClient.sendPartyInfo(url, encodedPartyInfo), executor)
                 .exceptionally(
                         ex -> {
-                            LOGGER.warn("Error {} when connecting to {}", ex.getMessage(), url);
+                            LOGGER.warn("Failed to connect to node {}, due to {}", url, ex.getMessage());
                             LOGGER.debug(null, ex);
                             return null;
                         });

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/SyncPoller.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/SyncPoller.java
@@ -116,7 +116,7 @@ public class SyncPoller implements Runnable {
             // we deliberately discard the response as we do not want to fully duplicate the PartyInfoPoller
             return p2pClient.sendPartyInfo(url, encodedPartyInfo);
         } catch (final Exception ex) {
-            LOGGER.warn("Server error {} when connecting to {}", ex.getMessage(), url);
+            LOGGER.warn("Failed to connect to node {} for partyinfo, due to {}", url, ex.getMessage());
             LOGGER.debug(null, ex);
             return false;
         }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/TransactionRequesterImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/sync/TransactionRequesterImpl.java
@@ -41,7 +41,11 @@ public class TransactionRequesterImpl implements TransactionRequester {
         try {
             return client.makeResendRequest(uri, request);
         } catch (final Exception ex) {
-            LOGGER.warn("Failed to make resend request to node {} for key {}", uri, request.getPublicKey());
+            LOGGER.warn(
+                    "Failed to make resend request to node {} for key {}, due to {}",
+                    uri,
+                    request.getPublicKey(),
+                    ex.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
- Fix typos
- Reduce duplication from logged message and exception message.
- Only have the text 'Error' in error messages, remove from warnings.
- Ensure all pertinent information is in messages (e.g. IP, hostname, public key etc)