### PR TITLE
Fix NPE on logged error

### DIFF
--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/jaxrs/LoggingFilter.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/jaxrs/LoggingFilter.java
@@ -12,13 +12,13 @@ public class LoggingFilter implements ContainerRequestFilter, ContainerResponseF
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingFilter.class);
 
-    @Context
-    private ResourceInfo resourceInfo;
+    @Context private ResourceInfo resourceInfo;
 
     private Logger getLogger() {
         return Optional.ofNullable(resourceInfo)
-            .map(r -> LoggerFactory.getLogger(r.getResourceClass()))
-            .orElse(LOGGER);
+                .filter(r -> r.getResourceClass() != null)
+                .map(r -> LoggerFactory.getLogger(r.getResourceClass()))
+                .orElse(LOGGER);
     }
 
     @Override
@@ -30,15 +30,16 @@ public class LoggingFilter implements ContainerRequestFilter, ContainerResponseF
     public void filter(final ContainerRequestContext request, final ContainerResponseContext response) {
         log("Exit", request);
         String path = Optional.ofNullable(request.getUriInfo()).map(UriInfo::getPath).orElse(null);
-        Optional.ofNullable(response.getStatusInfo()).ifPresent(statusType -> getLogger().info("Response for {} : {} {}", path, statusType.getStatusCode(), statusType.getReasonPhrase()));
+        Optional.ofNullable(response.getStatusInfo())
+            .ifPresent(statusType -> getLogger()
+                .info("Response for {} : {} {}",
+                    path,
+                    statusType.getStatusCode(),
+                    statusType.getReasonPhrase()));
     }
 
     private void log(String prefix, ContainerRequestContext request) {
         String path = Optional.ofNullable(request.getUriInfo()).map(UriInfo::getPath).orElse(null);
         getLogger().info("{} Request : {} : {}", prefix, request.getMethod(), "/" + path);
-
     }
-    
-
- 
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/jaxrs/LoggingFilter.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/jaxrs/LoggingFilter.java
@@ -33,13 +33,23 @@ public class LoggingFilter implements ContainerRequestFilter, ContainerResponseF
         Optional.ofNullable(response.getStatusInfo())
             .ifPresent(statusType -> getLogger()
                 .info("Response for {} : {} {}",
-                    path,
-                    statusType.getStatusCode(),
-                    statusType.getReasonPhrase()));
+                                                path,
+                                                statusType.getStatusCode(),
+                                                statusType.getReasonPhrase()));
     }
 
     private void log(String prefix, ContainerRequestContext request) {
         String path = Optional.ofNullable(request.getUriInfo()).map(UriInfo::getPath).orElse(null);
         getLogger().info("{} Request : {} : {}", prefix, request.getMethod(), "/" + path);
+    }
+
+    /**
+     * Set the request resource info. Only needed for unit tests.
+     *
+     * @param resourceInfo the resource info
+     */
+    @Context
+    public void setResourceInfo(final ResourceInfo resourceInfo) {
+        this.resourceInfo = resourceInfo;
     }
 }

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/jaxrs/LoggingFilterTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/jaxrs/LoggingFilterTest.java
@@ -6,18 +6,17 @@ import org.junit.Test;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class LoggingFilterTest {
 
     private LoggingFilter loggingFilter;
 
-    public LoggingFilterTest() {
-    }
+    public LoggingFilterTest() {}
 
     @Before
     public void setUp() {
@@ -33,9 +32,8 @@ public class LoggingFilterTest {
     public void filterRequest() {
         ContainerRequestContext request = mock(ContainerRequestContext.class);
         loggingFilter.filter(request);
-        //Very silly test 
+        // Very silly test
         assertThat(loggingFilter).isNotNull();
-
     }
 
     @Test
@@ -44,10 +42,26 @@ public class LoggingFilterTest {
         ContainerResponseContext response = mock(ContainerResponseContext.class);
         Response.StatusType statusInfo = mock(Response.StatusType.class);
         when(response.getStatusInfo()).thenReturn(statusInfo);
-        loggingFilter.filter(request,response);
-        
-        //Very silly test 
-        assertThat(loggingFilter).isNotNull();
+        loggingFilter.filter(request, response);
 
+        // Very silly test
+        assertThat(loggingFilter).isNotNull();
+    }
+
+    @Test
+    public void filterNullResourceInfo() {
+        ContainerRequestContext request = mock(ContainerRequestContext.class);
+        loggingFilter.setResourceInfo(null);
+        loggingFilter.filter(request); // if this doesn't throw exception then test passed
+    }
+
+    @Test
+    public void filterNullResourceInfoClass() {
+        ResourceInfo resourceInfo = mock(ResourceInfo.class);
+        loggingFilter.setResourceInfo(resourceInfo);
+        when(resourceInfo.getResourceClass()).thenReturn(null);
+
+        ContainerRequestContext request = mock(ContainerRequestContext.class);
+        loggingFilter.filter(request); // if this doesn't throw exception then test passed
     }
 }

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/exception/EntityNotFoundExceptionMapper.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/exception/EntityNotFoundExceptionMapper.java
@@ -12,7 +12,7 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EnclaveNotAvailableExceptionMapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntityNotFoundExceptionMapper.class);
 
     @Override
     public Response toResponse(final EntityNotFoundException ex) {

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/exception/WebApplicationExceptionMapper.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/exception/WebApplicationExceptionMapper.java
@@ -11,7 +11,7 @@ import javax.xml.bind.UnmarshalException;
 
 public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionMapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebApplicationExceptionMapper.class);
 
     @Override
     public Response toResponse(final WebApplicationException exception) {


### PR DESCRIPTION
Fix issue where Null Pointer Exception thrown after error logged for invalid resource request, e.g.
curl -s http://localhost:9001/badendpoint.
Also correction to a couple of LOGGER class names.