### PR TITLE
Run remote enclave integration tests separately 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -85,13 +85,35 @@ jobs:
     - uses: actions/setup-java@v1
       with:
        java-version: 11
-    - run: ./gradlew :tests:acceptance-test:test
+    - run: ./gradlew :tests:acceptance-test:test -PexcludeTests="**/RestSuiteHttpH2RemoteEnclave.class"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
        name: itest-junit-report
        path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-      
+
+  remote_enclave_itest:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ env.GRADLE_CACHE_KEY }}
+          restore-keys: |
+            ${{ env.GRADLE_CACHE_KEY }}
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - run: ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: remote_enclave_itest-junit-report
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+
   atest:
     runs-on: ubuntu-latest
     needs: build

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -72,7 +72,6 @@ test {
             '**/RestSuiteHttpqlite.class',
             '**/CucumberWhitelistIT.class',
             '**/ConfigMigrationIT.class',
-           // '**/AdminRestSuite.class',
             '**/RestSuiteUnixH2.class',
             '**/P2pTestSuite.class',
             '**/CucumberFileKeyGenerationIT.class',
@@ -80,6 +79,10 @@ test {
             '**/RunAwsIT.class',
             '**/RunAzureIT.class'
     )
+
+    if (project.hasProperty('excludeTests')) {
+        exclude project.property('excludeTests')
+    }
 
 //    '**/RestSuite.class',
 //            '**/P2pTestSuite.class',


### PR DESCRIPTION
Run remote enclave integration tests separately to other integration tests to avoid intermittent flakes.