### PR TITLE
Remove unused IPWhitelistFilter from ThirdParty server

### DIFF
--- a/tessera-jaxrs/thirdparty-jaxrs/src/main/java/com/quorum/tessera/thirdparty/ThirdPartyRestApp.java
+++ b/tessera-jaxrs/thirdparty-jaxrs/src/main/java/com/quorum/tessera/thirdparty/ThirdPartyRestApp.java
@@ -1,18 +1,16 @@
 package com.quorum.tessera.thirdparty;
 
 import com.quorum.tessera.api.common.RawTransactionResource;
-import com.quorum.tessera.api.filter.IPWhitelistFilter;
 import com.quorum.tessera.app.TesseraRestApplication;
 import com.quorum.tessera.config.AppType;
 import com.quorum.tessera.core.api.ServiceFactory;
 import com.quorum.tessera.partyinfo.PartyInfoService;
 import io.swagger.annotations.Api;
 
+import javax.ws.rs.ApplicationPath;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.ApplicationPath;
 
 /** The third party API */
 @Api
@@ -29,12 +27,11 @@ public class ThirdPartyRestApp extends TesseraRestApplication {
     @Override
     public Set<Object> getSingletons() {
 
-        final IPWhitelistFilter iPWhitelistFilter = new IPWhitelistFilter();
         final RawTransactionResource rawTransactionResource = new RawTransactionResource();
         final PartyInfoResource partyInfoResource = new PartyInfoResource(partyInfoService);
         final KeyResource keyResource = new KeyResource();
 
-        return Stream.of(iPWhitelistFilter, rawTransactionResource, partyInfoResource, keyResource)
+        return Stream.of(rawTransactionResource, partyInfoResource, keyResource)
                 .collect(Collectors.toSet());
     }
 

--- a/tessera-jaxrs/thirdparty-jaxrs/src/test/java/com/quorum/tessera/thirdparty/ThirdPartyRestAppTest.java
+++ b/tessera-jaxrs/thirdparty-jaxrs/src/test/java/com/quorum/tessera/thirdparty/ThirdPartyRestAppTest.java
@@ -6,10 +6,6 @@ import com.quorum.tessera.config.AppType;
 import com.quorum.tessera.partyinfo.PartyInfoService;
 import com.quorum.tessera.service.locator.ServiceLocator;
 import com.quorum.tessera.transaction.TransactionManager;
-import java.util.HashSet;
-import java.util.Set;
-import javax.ws.rs.core.Application;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
@@ -17,7 +13,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ThirdPartyRestAppTest {
 
@@ -63,7 +64,7 @@ public class ThirdPartyRestAppTest {
 
         Set<Object> results = thirdParty.getSingletons();
 
-        assertThat(results).hasSize(4);
+        assertThat(results).hasSize(3);
     }
 
     @Test


### PR DESCRIPTION
The `IPWhitelistFilter` has the `@GlobalFilter` name binding annotation (i.e. it is only used by  apps that also have the `@GlobalFilter` annotation, e.g. `P2PRestApp`).

The `IPWhitelistFilter` has been removed from the `ThirdPartyRestApp` to explicitly show that it is not being used.