### PR TITLE
Use unique payloads for partyinfo validation

### DIFF
--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
@@ -103,11 +103,11 @@ public class PartyInfoResource {
         // Start validation stuff
         final PublicKey sender = enclave.defaultPublicKey();
         final String url = partyInfo.getUrl();
-        final String dataToEncrypt = UUID.randomUUID().toString();
 
         final Predicate<Recipient> isValidRecipientKey =
                 r -> {
                     try {
+                        final String dataToEncrypt = UUID.randomUUID().toString();
                         final PublicKey key = r.getKey();
                         final EncodedPayload encodedPayload =
                                 enclave.encryptPayload(dataToEncrypt.getBytes(), sender, Arrays.asList(key));


### PR DESCRIPTION
This maintains security if the sender has multiple keys, as it prevents the result of one validation check being reused for the validation check of another key.