### PR TITLE
Decode EncodedPayload in the resource for "push"

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManager.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManager.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.transaction;
 
+import com.quorum.tessera.enclave.EncodedPayload;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.partyinfo.ResendResponse;
 import com.quorum.tessera.partyinfo.ResendRequest;
@@ -18,7 +19,7 @@ public interface TransactionManager {
 
     ResendResponse resend(ResendRequest request);
 
-    MessageHash storePayload(byte[] toByteArray);
+    MessageHash storePayload(EncodedPayload transactionPayload);
 
     ReceiveResponse receive(ReceiveRequest request);
 

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -285,10 +285,7 @@ public class TransactionManagerImpl implements TransactionManager {
     }
 
     @Override
-    public MessageHash storePayload(byte[] input) {
-
-        final EncodedPayload payload = payloadEncoder.decode(input);
-
+    public MessageHash storePayload(final EncodedPayload payload) {
         final MessageHash transactionHash =
                 Optional.of(payload)
                         .map(EncodedPayload::getCipherText)
@@ -296,13 +293,10 @@ public class TransactionManagerImpl implements TransactionManager {
                         .get();
 
         if (enclave.getPublicKeys().contains(payload.getSenderKey())) {
-
-            this.resendManager.acceptOwnMessage(input);
-
+            this.resendManager.acceptOwnMessage(payload);
         } else {
-
             // this is a tx from someone else
-            this.encryptedTransactionDAO.save(new EncryptedTransaction(transactionHash, input));
+            this.encryptedTransactionDAO.save(new EncryptedTransaction(transactionHash, payloadEncoder.encode(payload)));
             LOGGER.info("Stored payload with hash {}", transactionHash);
         }
 

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/TransactionManagerTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/TransactionManagerTest.java
@@ -260,19 +260,14 @@ public class TransactionManagerTest {
 
     @Test
     public void storePayloadAsRecipient() {
-
-        byte[] input = "SOMEDATA".getBytes();
-
         EncodedPayload payload = mock(EncodedPayload.class);
 
         when(payload.getCipherText()).thenReturn("CIPHERTEXT".getBytes());
 
-        when(payloadEncoder.decode(input)).thenReturn(payload);
-
-        transactionManager.storePayload(input);
+        transactionManager.storePayload(payload);
 
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class));
-        verify(payloadEncoder).decode(input);
+        verify(payloadEncoder).encode(payload);
         verify(enclave).getPublicKeys();
     }
 
@@ -280,21 +275,17 @@ public class TransactionManagerTest {
     public void storePayloadWhenWeAreSender() {
         final PublicKey senderKey = PublicKey.from("SENDER".getBytes());
 
-        final byte[] input = "SOMEDATA".getBytes();
         final EncodedPayload encodedPayload = mock(EncodedPayload.class);
-
         when(encodedPayload.getSenderKey()).thenReturn(senderKey);
         when(encodedPayload.getCipherText()).thenReturn("CIPHERTEXT".getBytes());
         when(encodedPayload.getRecipientBoxes()).thenReturn(new ArrayList<>());
         when(encodedPayload.getRecipientKeys()).thenReturn(new ArrayList<>());
 
-        when(payloadEncoder.decode(input)).thenReturn(encodedPayload);
         when(enclave.getPublicKeys()).thenReturn(singleton(senderKey));
 
-        transactionManager.storePayload(input);
+        transactionManager.storePayload(encodedPayload);
 
-        verify(resendManager).acceptOwnMessage(input);
-        verify(payloadEncoder).decode(input);
+        verify(resendManager).acceptOwnMessage(encodedPayload);
         verify(enclave).getPublicKeys();
     }
 

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/TransactionResource.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/TransactionResource.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.p2p;
 
 import com.quorum.tessera.core.api.ServiceFactory;
+import com.quorum.tessera.enclave.PayloadEncoder;
 import com.quorum.tessera.partyinfo.ResendRequest;
 import com.quorum.tessera.partyinfo.ResendResponse;
 import com.quorum.tessera.data.MessageHash;
@@ -35,12 +36,15 @@ public class TransactionResource {
 
     private final TransactionManager delegate;
 
+    private final PayloadEncoder encoder;
+
     public TransactionResource() {
-        this(ServiceFactory.create().transactionManager());
+        this(ServiceFactory.create().transactionManager(), PayloadEncoder.create());
     }
 
-    public TransactionResource(TransactionManager delegate) {
+    public TransactionResource(final TransactionManager delegate, final PayloadEncoder payloadEncoder) {
         this.delegate = Objects.requireNonNull(delegate);
+        this.encoder = Objects.requireNonNull(payloadEncoder);
     }
 
     @ApiOperation("Resend transactions for given key or message hash/recipient")
@@ -76,9 +80,9 @@ public class TransactionResource {
 
         LOGGER.debug("Received push request");
 
-        final MessageHash messageHash = delegate.storePayload(payload);
-        LOGGER.debug("Push request generated hash {}", Objects.toString(messageHash));
-        // TODO: Return the query url not the string of the messageHAsh
+        final MessageHash messageHash = delegate.storePayload(encoder.decode(payload));
+        LOGGER.debug("Push request generated hash {}", messageHash);
+        // TODO: Return the query url not the string of the messageHash
         return Response.status(Response.Status.CREATED).entity(Objects.toString(messageHash)).build();
     }
 }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/ResendManager.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/ResendManager.java
@@ -1,13 +1,18 @@
 package com.quorum.tessera.partyinfo;
 
+import com.quorum.tessera.enclave.EncodedPayload;
+
 /** Handles resend requests where the response has one of our own keys as the sender */
 public interface ResendManager {
 
     /**
-     * Decodes, retrieves and/or creates an {@link com.quorum.tessera.transaction.model.EncryptedTransaction} based on
-     * currently stored contents of the node
+     * Creates or updates an {@link com.quorum.tessera.transaction.model.EncryptedTransaction} based on
+     * whether the node already contains the given transaction or not.
+     * If it contains the transaction, the recipient list is updated. If it
+     * does not contain the transaction, a new one is created with an initial
+     * recipient list of itself and the given recipient of the incoming message.
      *
-     * @param message the message to be decoded and stored
+     * @param transactionPayload the transaction to be stored
      */
-    void acceptOwnMessage(byte[] message);
+    void acceptOwnMessage(EncodedPayload transactionPayload);
 }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/ResendManagerImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/ResendManagerImpl.java
@@ -35,10 +35,7 @@ public class ResendManagerImpl implements ResendManager {
 
     // TODO: synchronize based on messagehash, so different message don't lock each other
     @Transactional
-    public synchronized void acceptOwnMessage(final byte[] message) {
-
-        final EncodedPayload payload = payloadEncoder.decode(message);
-
+    public synchronized void acceptOwnMessage(final EncodedPayload payload) {
         // check the payload can be decrpyted to ensure it isn't rubbish being sent to us
         final byte[] newDecrypted = enclave.unencryptTransaction(payload, null);
 


### PR DESCRIPTION
On a "push" request, the EncodedPayload is immediately decoded and passed to
the delegate. This keeps a good separation between the internals with the
domain object and the transport object, which is just a series of bytes.