### PR TITLE
Replace acceptance test setup with docker image

### DIFF
--- a/.github/workflows/DockerfileTest
+++ b/.github/workflows/DockerfileTest
@@ -1,0 +1,8 @@
+# Create docker image with only distribution jar
+
+FROM adoptopenjdk/openjdk11:alpine
+
+ARG JAR_FILE
+COPY ${JAR_FILE} /tessera/tessera-app.jar
+
+ENTRYPOINT ["java", "-jar", "/tessera/tessera-app.jar"]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -130,40 +130,12 @@ jobs:
             ${{ env.GRADLE_CACHE_KEY }}
       - run: |
           ./gradlew build -x test -x dependencyCheckAnalyze -x javadoc
-          export TESSERA_JAR=`ls $(pwd)/tessera-dist/tessera-app/build/libs/tessera-app-*-app.jar`
-          cd
-          git clone https://github.com/jpmorganchase/quorum-examples.git
-          git clone https://github.com/jpmorganchase/quorum-acceptance-tests.git
-          echo "Install geth"
-          curl -L https://dl.bintray.com/quorumengineering/quorum/v2.6.0/geth_v2.6.0_linux_amd64.tar.gz -o geth.tar.gz
-          tar xvzf geth.tar.gz
-          sudo mv geth /usr/local/bin/
-          geth version
-          echo "Installed geth"
-          echo "Install solc"
-          curl -L https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux -o solc
-          sudo mv solc /usr/local/bin/
-          sudo chmod 755 /usr/local/bin/solc
-          solc --version
-          echo "Installed solc"
-          echo "Install gauge"
-          curl -L https://github.com/getgauge/gauge/releases/download/v1.0.7/gauge-1.0.7-linux.x86_64.zip -o gauge.zip
-          sudo unzip -o gauge.zip -d /usr/local/bin
-          cd quorum-acceptance-tests
-          gauge install java --version 0.7.4
-          cd
-          echo "Installed gauge"
-          echo "Start $TESSERA_JAR for 7 nodes"
-          cd quorum-examples/examples/7nodes
-          ./tessera-init.sh
-          ./init.sh istanbul
-          ./start.sh istanbul tessera
-          cd ../../../
-          echo "Started $TESSERA_JAR for 7 nodes"
-          echo "Run quorum-acceptance-tests"
-          cd quorum-acceptance-tests
-          cp config/application-local.7nodes.yml config/application-local.yml
-          SPRING_PROFILES_ACTIVE=local.7nodes mvn clean test -Dtags="basic || basic-istanbul || networks/typical::istanbul"
-          echo "Complete quorum-acceptance-tests"
-        env:
-          MAVEN_OPTS: -Xms1024m -Xmx2048m
+      - uses: docker/build-push-action@v1
+        with:
+          repository: quorumengineering/tessera
+          tags: latest
+          push: false
+          dockerfile: .github/workflows/DockerfileTest
+          build_args: JAR_FILE=tessera-dist/tessera-app/build/libs/tessera-app-*-app.jar
+      - run:
+          docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests quorumengineering/acctests:latest test -Pauto -Dtags="basic || basic-istanbul || networks/typical::istanbul" -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,45 +129,16 @@ jobs:
           restore-keys: |
             ${{env.MAVEN_REPO_CACHE_KEY}}
       - run: |
-          mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B
-          export TESSERA_VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`
-          export TESSERA_JAR=~/.m2/repository/com/jpmorgan/quorum/tessera-app/$TESSERA_VERSION/tessera-app-$TESSERA_VERSION-app.jar
-          cd
-          git clone https://github.com/jpmorganchase/quorum-examples.git
-          git clone https://github.com/jpmorganchase/quorum-acceptance-tests.git
-          echo "Install geth"
-          curl -L https://dl.bintray.com/quorumengineering/quorum/v2.6.0/geth_v2.6.0_linux_amd64.tar.gz -o geth.tar.gz
-          tar xvzf geth.tar.gz
-          sudo mv geth /usr/local/bin/
-          geth version
-          echo "Installed geth"
-          echo "Install solc"
-          curl -L https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux -o solc
-          sudo mv solc /usr/local/bin/
-          sudo chmod 755 /usr/local/bin/solc
-          solc --version
-          echo "Installed solc"
-          echo "Install gauge"
-          curl -L https://github.com/getgauge/gauge/releases/download/v1.0.7/gauge-1.0.7-linux.x86_64.zip -o gauge.zip
-          sudo unzip -o gauge.zip -d /usr/local/bin
-          cd quorum-acceptance-tests
-          gauge install java --version 0.7.4
-          cd
-          echo "Installed gauge"
-          echo "Start $TESSERA_JAR for 7 nodes"
-          cd quorum-examples/examples/7nodes
-          ./tessera-init.sh
-          ./init.sh istanbul
-          ./start.sh istanbul tessera
-          cd ../../../
-          echo "Started $TESSERA_JAR for 7 nodes"
-          echo "Run quorum-acceptance-tests"
-          cd quorum-acceptance-tests
-          cp config/application-local.7nodes.yml config/application-local.yml
-          SPRING_PROFILES_ACTIVE=local.7nodes mvn clean test -Dtags="basic || basic-istanbul || networks/typical::istanbul"
-          echo "Complete quorum-acceptance-tests"
-        env:
-          MAVEN_OPTS: -Xms1024m -Xmx2048m
+          mvn install -Dsilent=true -DskipTests=true -Dmaven.javadoc.skip=true -Dchecksyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -B -ntp
+      - uses: docker/build-push-action@v1
+        with:
+          repository: quorumengineering/tessera
+          tags: latest
+          push: false
+          dockerfile: .github/workflows/DockerfileTest
+          build_args: JAR_FILE=tessera-dist/tessera-app/target/*-app.jar
+      - run:
+          docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests quorumengineering/acctests:latest test -Pauto -Dtags="basic || basic-istanbul || networks/typical::istanbul" -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true
       - uses: homoluctus/slatify@v2.1.2
         if: failure()
         with:


### PR DESCRIPTION
The acceptance tests now has a docker image that handles the installation of all the deps. By using this, we can avoid needing to set them up ourselves, and will be auto-updated as the acceptance tests update.

It expects the tessera to use to be under the `latest` tag, so first we build a docker image locally under that tag using the newly built tessera.

Fixes #1070