### PR TITLE
Throw an exception if configured encryptor is not on classpath

### DIFF
--- a/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/EncryptorFactory.java
+++ b/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/EncryptorFactory.java
@@ -29,7 +29,6 @@ public interface EncryptorFactory {
         return ServiceLoaderUtil.loadAll(EncryptorFactory.class)
                 .filter(f -> f.getType().equals(type))
                 .findAny()
-                .orElse(ServiceLoaderUtil.load(EncryptorFactory.class).get());
+                .orElseThrow(() -> new EncryptorFactoryNotFoundException(type));
     }
-
 }

--- a/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/EncryptorFactoryNotFoundException.java
+++ b/encryption/encryption-api/src/main/java/com/quorum/tessera/encryption/EncryptorFactoryNotFoundException.java
@@ -1,0 +1,8 @@
+package com.quorum.tessera.encryption;
+
+public class EncryptorFactoryNotFoundException extends RuntimeException {
+
+    public EncryptorFactoryNotFoundException(String encryptorType) {
+        super(encryptorType + " implementation of EncryptorFactory was not found on the classpath");
+    }
+}

--- a/encryption/encryption-api/src/test/java/com/quorum/tessera/encryption/EncryptorFactoryNotFoundExceptionTest.java
+++ b/encryption/encryption-api/src/test/java/com/quorum/tessera/encryption/EncryptorFactoryNotFoundExceptionTest.java
@@ -1,0 +1,17 @@
+package com.quorum.tessera.encryption;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EncryptorFactoryNotFoundExceptionTest {
+
+    @Test
+    public void constructor() {
+        final String type = "MYIMPL";
+        EncryptorFactoryNotFoundException exception = new EncryptorFactoryNotFoundException(type);
+
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+        assertThat(exception).hasMessage("MYIMPL implementation of EncryptorFactory was not found on the classpath");
+    }
+}

--- a/encryption/encryption-api/src/test/java/com/quorum/tessera/encryption/EncryptorFactoryTest.java
+++ b/encryption/encryption-api/src/test/java/com/quorum/tessera/encryption/EncryptorFactoryTest.java
@@ -1,9 +1,10 @@
 package com.quorum.tessera.encryption;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class EncryptorFactoryTest {
 
@@ -21,5 +22,13 @@ public class EncryptorFactoryTest {
         final Encryptor result = this.encryptorFactory.create();
 
         assertThat(result).isNotNull().isSameAs(MockEncryptor.INSTANCE);
+    }
+
+    @Test
+    public void exceptionIfServiceNotFound() {
+        Throwable ex = catchThrowable(() -> EncryptorFactory.newFactory("NOTAVAILABLE"));
+
+        assertThat(ex).isExactlyInstanceOf(EncryptorFactoryNotFoundException.class);
+        assertThat(ex).hasMessageContaining("NOTAVAILABLE");
     }
 }

--- a/key-generation/build.gradle
+++ b/key-generation/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     compile project(':config')
     compile project(':shared')
     compile project(':key-vault:key-vault-api')
+    testRuntimeOnly project(':encryption:encryption-ec')
 }


### PR DESCRIPTION
Tessera now fails fast instead of falling back to an alternate encryptor.  This prevents a different encryptor to the one configured from being used to generate keys or trying to encrypt with existing keys.  This protects the user against unexpected behaviour.