### PR TITLE
Remove unnecessary installations of alpine packages from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,7 @@ ADD --chown=nobody:nogroup . /tessera
 RUN cd /tessera && mvn clean -Dmaven.repo.local=/tessera/.m2/repository -DskipTests -Denforcer.skip=true package
 
 # Create docker image with only distribution jar
-
 FROM adoptopenjdk/openjdk11:alpine
-
-RUN apk add bzip2=1.0.8-r1 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add musl=1.1.24-r8 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add libbz2=1.0.8-r1 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add libtasn1=4.16.0-r1 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add libpng=1.6.37-r1 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add giflib=5.2.1-r0 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add libjpeg-turbo=2.0.4-r1 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ --allow-untrusted
 
 COPY --from=builder /tessera/tessera-dist/tessera-app/target/*-app.jar /tessera/tessera-app.jar
 


### PR DESCRIPTION
These were added several releases ago to address CVE vulnerabilities with some of the packages in the alpine image available at the time.  Newer versions of the alpine image include the updated packages.

#### Additional info
For context, the available packages for a particular alpine version can be viewed at https://pkgs.alpinelinux.org/packages?name=&branch=v3.12&repo=main.
The `edge` version is unstable but is the latest alpine version available and uses the latest package versions.  The CVE vulnerabilities were resolved by installing the corresponding packages from the `edge` version's repository.

These versions are now included in the newer alpine images and so shouldn't need to manually pulled in from `edge` (checking the webpage it looks like all these packages have the same versions in `v3.12` (the version currently used by `adoptopenjdk/openjdk11:alpine`) and `edge`.

If, in the future, new CVE vulnerabilities are found then we will again have to pull in later versions from `edge` if they are available.  However, these should only be temporarily necessary whilst waiting for `adoptopenjdk/openjdk11:alpine` to update to the latest version of alpine.