### PR TITLE
Remove inactive nodes from party info. 

### DIFF
--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/exception/PartyOfflineExceptionMapper.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/exception/PartyOfflineExceptionMapper.java
@@ -1,0 +1,15 @@
+package com.quorum.tessera.api.exception;
+
+import com.quorum.tessera.partyinfo.PartyOfflineException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class PartyOfflineExceptionMapper implements ExceptionMapper<PartyOfflineException> {
+    @Override
+    public Response toResponse(PartyOfflineException exception) {
+        return Response.status(503,exception.getMessage()).build();
+    }
+}

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/app/TesseraRestApplication.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/app/TesseraRestApplication.java
@@ -31,7 +31,8 @@ public abstract class TesseraRestApplication extends Application implements Tess
                 UpCheckResource.class,
                 VersionResource.class,
                 ApiResource.class,
-                BaseResource.class);
+                BaseResource.class,
+                PartyOfflineExceptionMapper.class);
     }
 
     @Override

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/exception/PartyOfflineExceptionMapperTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/exception/PartyOfflineExceptionMapperTest.java
@@ -1,0 +1,30 @@
+package com.quorum.tessera.api.exception;
+
+import com.quorum.tessera.partyinfo.PartyOfflineException;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PartyOfflineExceptionMapperTest {
+
+    private PartyOfflineExceptionMapper partyOfflineExceptionMapper;
+
+    @Before
+    public void onSetUp() {
+        partyOfflineExceptionMapper = new PartyOfflineExceptionMapper();
+    }
+
+    @Test
+    public void toResponse() {
+        PartyOfflineException exception = new PartyOfflineException("Node not avialable",new Exception("OUCH"));
+
+        Response response = partyOfflineExceptionMapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(response.getStatusInfo().getReasonPhrase()).isEqualTo("Node not avialable");
+    }
+
+}

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/RestPayloadPublisher.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/RestPayloadPublisher.java
@@ -4,12 +4,13 @@ import com.quorum.tessera.enclave.EncodedPayload;
 import com.quorum.tessera.enclave.PayloadEncoder;
 import com.quorum.tessera.partyinfo.PayloadPublisher;
 import com.quorum.tessera.partyinfo.PublishPayloadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RestPayloadPublisher implements PayloadPublisher {
 

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/ExclusionCache.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/ExclusionCache.java
@@ -1,0 +1,19 @@
+package com.quorum.tessera.partyinfo;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+public interface ExclusionCache<T> {
+
+    boolean isExcluded(T recipient);
+
+    ExclusionCache<T> exclude(T recipient);
+
+    Optional<T> include(String recipientUrl);
+
+    static <T> ExclusionCache<T> create() {
+        return ServiceLoader.load(ExclusionCache.class)
+            .findFirst().get();
+    }
+
+}

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceImpl.java
@@ -157,9 +157,15 @@ public class PartyInfoServiceImpl implements PartyInfoService {
 
         LOGGER.info("Publishing message to {}", targetUrl);
 
-        payloadPublisher.publishPayload(payload, targetUrl);
+        try {
+            payloadPublisher.publishPayload(payload, targetUrl);
+            LOGGER.info("Published to {}", targetUrl);
+        } catch (ProcessingException ex) {
+            this.removeRecipient(targetUrl);
+            LOGGER.warn("Publish to {} failed.", targetUrl);
+            throw new PartyOfflineException(String.format("Publish to %s failed.",targetUrl),ex);
+        }
 
-        LOGGER.info("Published to {}", targetUrl);
     }
 
     /**

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceImpl.java
@@ -10,6 +10,8 @@ import com.quorum.tessera.partyinfo.model.PartyInfo;
 import com.quorum.tessera.partyinfo.model.Recipient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.ProcessingException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -92,6 +94,7 @@ public class PartyInfoServiceImpl implements PartyInfoService {
 
         if (!runtimeContext.isDisablePeerDiscovery()) {
             // auto-discovery is on, we can accept all input to us
+
             this.partyInfoStore.store(partyInfo);
             return this.getPartyInfo();
         }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoStore.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoStore.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.partyinfo;
 
-
 import com.quorum.tessera.ServiceLoaderUtil;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.partyinfo.model.PartyInfo;
@@ -25,6 +24,7 @@ public interface PartyInfoStore {
     String getAdvertisedUrl();
 
     PartyInfo removeRecipient(String s);
+
 }
 
 

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoStore.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoStore.java
@@ -11,8 +11,10 @@ public interface PartyInfoStore {
 
 
     static PartyInfoStore create(URI uri) {
+
+        ExclusionCache<Recipient> recipientExclusionCache = ExclusionCache.create();
         return ServiceLoaderUtil.load(PartyInfoStore.class)
-            .orElse(new PartyInfoStoreImpl(uri));
+            .orElse(new PartyInfoStoreImpl(uri,recipientExclusionCache));
     }
 
     PartyInfo getPartyInfo();

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoStoreImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoStoreImpl.java
@@ -82,6 +82,10 @@ public class PartyInfoStoreImpl implements PartyInfoStore {
 
 
     public synchronized PartyInfo removeRecipient(final String uri) {
+        RuntimeContext runtimeContext = RuntimeContext.getInstance();
+        if(runtimeContext.isDisablePeerDiscovery()) {
+            return this.getPartyInfo();
+        }
         recipients.entrySet().stream()
             .filter(e -> uri.startsWith(e.getValue().getUrl()))
             .map(Map.Entry::getKey)

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyOfflineException.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyOfflineException.java
@@ -1,0 +1,8 @@
+package com.quorum.tessera.partyinfo;
+
+public class PartyOfflineException extends RuntimeException {
+
+    public PartyOfflineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/RecipientExclusionCache.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/RecipientExclusionCache.java
@@ -1,0 +1,41 @@
+package com.quorum.tessera.partyinfo;
+
+import com.quorum.tessera.partyinfo.model.Recipient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+public class RecipientExclusionCache implements ExclusionCache<Recipient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecipientExclusionCache.class);
+
+    private final ConcurrentSkipListSet<Recipient> excluded
+        = new ConcurrentSkipListSet<>(Comparator.comparing(Recipient::getUrl));
+
+    @Override
+    public boolean isExcluded(Recipient recipient) {
+        return excluded.contains(recipient);
+    }
+
+    @Override
+    public ExclusionCache<Recipient> exclude(Recipient recipient) {
+        excluded.add(recipient);
+        return this;
+    }
+
+    @Override
+    public Optional<Recipient> include(String recipientUrl) {
+
+        Optional<Recipient> recipient = excluded.stream()
+            .filter(r -> r.getUrl().equalsIgnoreCase(recipientUrl))
+            .findFirst();
+
+        recipient.ifPresent(excluded::remove);
+        return recipient;
+    }
+
+
+}

--- a/tessera-partyinfo/src/main/resources/META-INF/services/com.quorum.tessera.partyinfo.ExclusionCache
+++ b/tessera-partyinfo/src/main/resources/META-INF/services/com.quorum.tessera.partyinfo.ExclusionCache
@@ -1,0 +1,1 @@
+com.quorum.tessera.partyinfo.RecipientExclusionCache

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/ExclusionCacheTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/ExclusionCacheTest.java
@@ -1,0 +1,14 @@
+package com.quorum.tessera.partyinfo;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExclusionCacheTest {
+
+    @Test
+    public void create() {
+        ExclusionCache result = ExclusionCache.create();
+        assertThat(result).isNotNull().isExactlyInstanceOf(RecipientExclusionCache.class);
+    }
+}

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoServiceTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import javax.ws.rs.ProcessingException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -409,4 +410,6 @@ public class PartyInfoServiceTest {
 
         verify(enclave).getPublicKeys();
     }
+
+
 }

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoStoreTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoStoreTest.java
@@ -197,6 +197,8 @@ public class PartyInfoStoreTest {
     @Test
     public void removeRecipient() {
         // Given
+        when(runtimeContext.isDisablePeerDiscovery()).thenReturn(false);
+
         final PublicKey someKey = PublicKey.from("someKey".getBytes());
         final PublicKey someOtherKey = PublicKey.from("someOtherKey".getBytes());
 
@@ -222,7 +224,7 @@ public class PartyInfoStoreTest {
         assertThat(result.getRecipients()).hasSize(1).containsOnly(Recipient.of(someKey, uri));
         verify(exclusionCache).exclude(any(Recipient.class));
         verify(exclusionCache,times(2)).include(uri);
-        verify(runtimeContext,times(2)).isDisablePeerDiscovery();
+        verify(runtimeContext,times(3)).isDisablePeerDiscovery();
 
     }
 
@@ -305,7 +307,7 @@ public class PartyInfoStoreTest {
 
         verify(exclusionCache,times(2)).isExcluded(recipient);
         verify(exclusionCache,times(2)).include(anyString());
-        verify(runtimeContext,times(2)).isDisablePeerDiscovery();
+        verify(runtimeContext,times(3)).isDisablePeerDiscovery();
 
     }
 
@@ -341,5 +343,23 @@ public class PartyInfoStoreTest {
         verify(exclusionCache).include(url);
 
     }
+
+    @Test
+    public void removeRecipientWithDiscoveryDisabled() {
+
+        when(runtimeContext.isDisablePeerDiscovery()).thenReturn(true);
+
+        PartyInfo existingPartyInfo = mock(PartyInfo.class);
+        PartyInfoStore store = spy(this.partyInfoStore);
+        when(store.getPartyInfo()).thenReturn(existingPartyInfo);
+
+        PartyInfo result = store.removeRecipient("http://junit.xom");
+
+        assertThat(result).isSameAs(existingPartyInfo);
+        verify(runtimeContext).isDisablePeerDiscovery();
+        verify(store).getPartyInfo();
+
+    }
+
 
 }

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoStoreTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/PartyInfoStoreTest.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.partyinfo;
 
+import com.quorum.tessera.context.RuntimeContext;
 import com.quorum.tessera.context.RuntimeContextFactory;
 import com.quorum.tessera.encryption.KeyNotFoundException;
 import com.quorum.tessera.partyinfo.model.Party;
@@ -14,6 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.emptySet;
@@ -64,6 +66,10 @@ public class PartyInfoStoreTest {
         final PartyInfo output = this.partyInfoStore.getPartyInfo();
 
         assertThat(output.getParties()).containsExactlyInAnyOrder(new Party("http://localhost:8080/"));
+
+        verify(exclusionCache).include("http://localhost:8080/");
+
+        verify(runtimeContext).isDisablePeerDiscovery();
     }
 
     @Test
@@ -83,6 +89,10 @@ public class PartyInfoStoreTest {
         assertThat(retrievedRecipients)
                 .hasSize(2)
                 .containsExactlyInAnyOrder(Recipient.of(localKey, uri), Recipient.of(remoteKey, "example.com"));
+
+        verify(exclusionCache,times(2)).include(uri);
+
+        verify(runtimeContext,times(2)).isDisablePeerDiscovery();
     }
 
     @Test
@@ -100,6 +110,9 @@ public class PartyInfoStoreTest {
         final Set<Recipient> retrievedRecipients = partyInfoStore.getPartyInfo().getRecipients();
 
         assertThat(retrievedRecipients).hasSize(1).containsExactly(Recipient.of(testKey, uri));
+        verify(exclusionCache,times(2)).include(uri);
+
+        verify(runtimeContext,times(2)).isDisablePeerDiscovery();
     }
 
     @Test
@@ -127,6 +140,9 @@ public class PartyInfoStoreTest {
         // so check they are not the same object, meaning the time was overwritten (just with the same time)
         assertThat(firstContact).isNotSameAs(secondContact);
         assertThat(firstContact).isBeforeOrEqualTo(secondContact);
+
+        verify(exclusionCache,times(2)).include(anyString());
+        verify(runtimeContext,times(2)).isDisablePeerDiscovery();
     }
 
     @Test

--- a/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/RecipientExclusionCacheTest.java
+++ b/tessera-partyinfo/src/test/java/com/quorum/tessera/partyinfo/RecipientExclusionCacheTest.java
@@ -1,0 +1,67 @@
+package com.quorum.tessera.partyinfo;
+
+import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.partyinfo.model.Recipient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecipientExclusionCacheTest {
+
+    private RecipientExclusionCache exclusionCache;
+
+    @Before
+    public void onSetup() {
+        exclusionCache = new RecipientExclusionCache();
+    }
+
+    @After
+    public void onTearDown() {
+
+    }
+
+    @Test
+    public void excludeRecipient() throws Exception {
+
+        PublicKey publicKey = PublicKey.from("SOMEDATA".getBytes());
+        String url = "http://someurl.com";
+        Recipient recipient = Recipient.of(publicKey,url);
+
+        exclusionCache.exclude(recipient);
+        assertThat(exclusionCache.isExcluded(recipient)).isTrue();
+
+    }
+
+    @Test
+    public void includeNonExcludedRecipient() throws Exception {
+
+        PublicKey publicKey = PublicKey.from("SOMEDATA".getBytes());
+        String url = "http://someurl.com";
+        Recipient recipient = Recipient.of(publicKey,url);
+
+        Optional<Recipient> result = exclusionCache.include(url);
+        assertThat(result).isNotPresent();
+
+    }
+
+    @Test
+    public void excludeAndThenIncludeRecipient() throws Exception {
+
+        PublicKey publicKey = PublicKey.from("SOMEDATA".getBytes());
+        String url = "http://someurl.com";
+        Recipient recipient = Recipient.of(publicKey,url);
+
+        assertThat(exclusionCache.include(url)).isNotPresent();
+
+        exclusionCache.exclude(recipient);
+
+        Optional<Recipient> result = exclusionCache.include(url);
+        assertThat(result).isPresent().containsSame(recipient);
+
+    }
+
+}

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -76,7 +76,8 @@ test {
             '**/CucumberFileKeyGenerationIT.class',
             '**/P2pTestSuite.class',
             '**/RunAwsIT.class',
-            '**/RunAzureIT.class'
+            '**/RunAzureIT.class',
+            '**/NodeRemoval.class'
     )
 
     if (project.hasProperty('excludeTests')) {

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -207,6 +207,7 @@
                         <include>ConfigMigrationIT</include>
                         <include>P2pTestSuite</include>
                         <include>SendWithRemoteEnclaveReconnectIT</include>
+                        <include>NodeRemoval</include>
                     </includes>
                 </configuration>
                 <executions>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/NodeRemoval.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/NodeRemoval.java
@@ -8,6 +8,7 @@ import com.quorum.tessera.config.keys.KeyEncryptorFactory;
 import com.quorum.tessera.test.DBType;
 import com.quorum.tessera.test.Party;
 import com.quorum.tessera.test.PartyHelper;
+import config.ConfigDescriptor;
 import db.DatabaseServer;
 import db.SetupDatabase;
 import exec.ExecManager;
@@ -83,6 +84,9 @@ public class NodeRemoval {
                     exec.start();
                     executors.add(exec);
                 });
+
+        executionContext.getConfigs().stream().map(ConfigDescriptor::getConfig)
+            .forEach(c -> c.setDisablePeerDiscovery(false));
 
         checkAllNodesAreRunning();
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/NodeRemoval.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/NodeRemoval.java
@@ -1,0 +1,174 @@
+package com.quorum.tessera.test.rest;
+
+import com.quorum.tessera.api.SendRequest;
+import com.quorum.tessera.config.CommunicationType;
+import com.quorum.tessera.config.EncryptorConfig;
+import com.quorum.tessera.config.EncryptorType;
+import com.quorum.tessera.config.keys.KeyEncryptorFactory;
+import com.quorum.tessera.test.DBType;
+import com.quorum.tessera.test.Party;
+import com.quorum.tessera.test.PartyHelper;
+import db.DatabaseServer;
+import db.SetupDatabase;
+import exec.ExecManager;
+import exec.NodeExecManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import suite.*;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class NodeRemoval {
+
+    private List<ExecManager> executors;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeRemoval.class);
+
+    private PartyHelper partyHelper;
+
+    private ExecutionContext executionContext;
+
+    @Before
+    public void onSetup() throws Exception {
+
+        executors = new ArrayList<>();
+
+        EncryptorConfig encryptorConfig = new EncryptorConfig() {{
+            setType(EncryptorType.NACL);
+        }};
+
+        executionContext =
+            ExecutionContext.Builder.create()
+                .with(CommunicationType.REST)
+                .with(DBType.H2)
+                .with(SocketType.HTTP)
+                .with(EnclaveType.LOCAL)
+                .withAdmin(false)
+                .with(encryptorConfig.getType())
+                .prefix(getClass().getSimpleName().toLowerCase())
+                .createAndSetupContext();
+
+
+        partyHelper = PartyHelper.create();
+
+        KeyEncryptorFactory.newFactory().create(encryptorConfig);
+
+        String nodeId = NodeId.generate(executionContext);
+        DatabaseServer databaseServer = executionContext.getDbType().createDatabaseServer(nodeId);
+        databaseServer.start();
+
+        SetupDatabase setupDatabase = new SetupDatabase(executionContext);
+        setupDatabase.setUp();
+
+        executionContext.getConfigs().stream()
+            .map(NodeExecManager::new)
+            .forEach(
+                exec -> {
+                    exec.start();
+                    executors.add(exec);
+                });
+
+        checkAllNodesAreRunning();
+
+    }
+
+    @After
+    public void onTearDown() throws Exception {
+        executors.forEach(ExecManager::stop);
+    }
+
+    private void checkAllNodesAreRunning() throws Exception {
+        PartyInfoChecker partyInfoChecker = PartyInfoChecker.create(executionContext.getCommunicationType());
+
+        CountDownLatch partyInfoSyncLatch = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(
+            () -> {
+                while (!partyInfoChecker.hasSynced()) {
+                    try {
+                        Thread.sleep(1000L);
+                    } catch (InterruptedException ex) {
+                    }
+                }
+                partyInfoSyncLatch.countDown();
+            });
+
+        if (!partyInfoSyncLatch.await(2, TimeUnit.MINUTES)) {
+            fail("Unable to sync party info nodes");
+        }
+        executorService.shutdown();
+    }
+
+    @Test
+    public void transactionPushedToNetworkWithAbsentNodeAndThenComeBackOnline() throws Exception {
+
+        final Client client = ClientBuilder.newClient();
+
+        //Given a 4 node network
+        final Party sendingParty = partyHelper.findByAlias("A");
+        final Party secondParty = partyHelper.findByAlias("B");
+        final Party thirdParty = partyHelper.findByAlias("D");
+        final Party forthParty = partyHelper.findByAlias("C");
+
+        final byte[] transactionData = new RestUtils().createTransactionData();
+
+        final SendRequest sendRequest = new SendRequest();
+        sendRequest.setFrom(sendingParty.getPublicKey());
+        sendRequest.setTo(secondParty.getPublicKey(), thirdParty.getPublicKey(),forthParty.getPublicKey());
+        sendRequest.setPayload(transactionData);
+
+        //And second party goes offline
+        ExecManager execManager = executors.get(1);
+        executors.remove(execManager);
+        execManager.stop();
+
+        //When transaction is send a node
+        final Response response =
+            client.target(sendingParty.getQ2TUri())
+                .path("send")
+                .request()
+                .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
+
+        // Then Server returns error
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(response.getStatusInfo().getReasonPhrase()).contains(secondParty.getP2PUri().toString());
+
+
+        //When node comes back online
+        NodeExecManager nodeExecManager = new NodeExecManager(executionContext.getConfigs().get(1));
+        nodeExecManager.start();
+        executors.add(nodeExecManager);
+
+        checkAllNodesAreRunning();
+
+        //And transaction is resent
+        final Response response2 =
+            client.target(sendingParty.getQ2TUri())
+                .path("send")
+                .request()
+                .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
+
+        //Then transaction is published to network
+        assertThat(response2.getStatus()).isEqualTo(201);
+
+    }
+
+
+
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/NodeRemoval.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/NodeRemoval.java
@@ -91,6 +91,7 @@ public class NodeRemoval {
     @After
     public void onTearDown() throws Exception {
         executors.forEach(ExecManager::stop);
+        ExecutionContext.destroyContext();
     }
 
     private void checkAllNodesAreRunning() throws Exception {


### PR DESCRIPTION
Add cache to store nodes that are offline to supress party info updates from other parties including the offline node's info. Assume that jaxrs processing exception is connectivity related and return 502 status when nodes are unable to push transactions to its peers.

When asynchronously publishing party info remove nodes if there are any exceptions. Errors are logged as warning (existing behaviour) , node is removed from party info but no error status is returned to caller. 

