### PR TITLE
Upgrade build files for java 14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,10 @@ allprojects {
 
                 testCompile "junit:junit:4.12"
                 testCompile "org.assertj:assertj-core:3.9.1"
-                testCompile "org.mockito:mockito-core:2.23.0"
+                testCompile "org.mockito:mockito-core:3.4.4"
                 testCompile "com.openpojo:openpojo:0.8.10"
                 testCompile "com.github.stefanbirkner:system-rules:1.18.0"
-                testCompile "nl.jqno.equalsverifier:equalsverifier:3.1.5"
+                testCompile "nl.jqno.equalsverifier:equalsverifier:3.4.1"
                 compile "com.github.jnr:jnr-unixsocket:0.28"
                 compile "de.mkammerer:argon2-jvm:2.5"
                 compile "javax.validation:validation-api:2.0.1.Final"

--- a/ddls/pom.xml
+++ b/ddls/pom.xml
@@ -30,7 +30,7 @@
                 <plugin>
                     <groupId>org.codehaus.gmaven</groupId>
                     <artifactId>groovy-maven-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>2.1.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -52,7 +52,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy</artifactId>
-                        <version>2.5.6</version>
+                        <version>3.0.5</version>
                     </dependency>
                     
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.3</version>
+                    <version>0.8.5</version>
                     <dependencies>
                         <dependency>
                             <groupId>commons-collections</groupId>
@@ -745,7 +745,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.3.3</version>
+                <version>3.4.4</version>
                 <scope>test</scope>
             </dependency>
 
@@ -1024,7 +1024,7 @@
             <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
-                <version>3.1.5</version>
+                <version>3.4.1</version>
             </dependency>
 
             <dependency>
@@ -1417,7 +1417,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.5</version>
 
                 <reportSets>
                     <reportSet>


### PR DESCRIPTION
upgrade maven groovy plugin and groovy, upgrade mockito and equals verifier to build using java 14

fixes #1109