### PR TITLE
Adding client response header decoration.

### DIFF
--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/http/VersionHeaderDecorator.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/http/VersionHeaderDecorator.java
@@ -10,17 +10,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-
+import static com.quorum.tessera.shared.Constants.API_VERSION_HEADER;
 
 public class VersionHeaderDecorator implements Filter {
 
-
-    public static final String API_VERSION_HEADER = "tesseraSupportedApiVersions";
-
-
     private static final Logger LOGGER = LoggerFactory.getLogger(VersionHeaderDecorator.class);
-
-
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/http/VersionHeaderDecoratorTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/http/VersionHeaderDecoratorTest.java
@@ -4,6 +4,7 @@ import com.quorum.tessera.config.CommunicationType;
 import com.quorum.tessera.config.ServerConfig;
 import com.quorum.tessera.server.JerseyServer;
 import com.quorum.tessera.server.jaxrs.SampleApplication;
+import com.quorum.tessera.shared.Constants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class VersionHeaderDecoratorTest {
         Response result = ClientBuilder.newClient().target(serverUri).path("ping").request().get();
 
         assertThat(result.getStatus()).isEqualTo(200);
-        assertThat((String) result.getHeaders().getFirst(VersionHeaderDecorator.API_VERSION_HEADER)).isNotEmpty();
+        assertThat((String) result.getHeaders().getFirst(Constants.API_VERSION_HEADER)).isNotEmpty();
 
     }
 
@@ -69,7 +70,7 @@ public class VersionHeaderDecoratorTest {
             httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
 
         assertThat(httpResponse.statusCode()).isEqualTo(200);
-        assertThat(httpResponse.headers().map().get(VersionHeaderDecorator.API_VERSION_HEADER)).isNotEmpty();
+        assertThat(httpResponse.headers().map().get(Constants.API_VERSION_HEADER)).isNotEmpty();
 
 
     }

--- a/shared/src/main/java/com/quorum/tessera/shared/Constants.java
+++ b/shared/src/main/java/com/quorum/tessera/shared/Constants.java
@@ -1,0 +1,7 @@
+package com.quorum.tessera.shared;
+
+public interface Constants {
+
+    String API_VERSION_HEADER = "tesseraSupportedApiVersions";
+
+}

--- a/tessera-jaxrs/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/ClientFactory.java
+++ b/tessera-jaxrs/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/ClientFactory.java
@@ -71,6 +71,7 @@ public class ClientFactory implements RestClientFactory {
         final long timeout = Math.round(Math.ceil(pollInterval * 0.75));
         clientBuilder.connectTimeout(timeout, TimeUnit.MILLISECONDS);
         clientBuilder.readTimeout(timeout, TimeUnit.MILLISECONDS);
+        clientBuilder.register(VersionHeaderDecorator.class);
 
         if (config.isUnixSocket()) {
             Configuration clientConfig = createUnixServerSocketConfig();

--- a/tessera-jaxrs/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecorator.java
+++ b/tessera-jaxrs/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecorator.java
@@ -1,0 +1,18 @@
+package com.quorum.tessera.jaxrs.client;
+
+import com.quorum.tessera.shared.Constants;
+import com.quorum.tessera.version.ApiVersion;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import java.io.IOException;
+
+public class VersionHeaderDecorator implements ClientResponseFilter {
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().addAll(Constants.API_VERSION_HEADER,ApiVersion.versions());
+
+    }
+}

--- a/tessera-jaxrs/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecorator.java
+++ b/tessera-jaxrs/jaxrs-client/src/main/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecorator.java
@@ -4,15 +4,14 @@ import com.quorum.tessera.shared.Constants;
 import com.quorum.tessera.version.ApiVersion;
 
 import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientResponseContext;
-import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.client.ClientRequestFilter;
 import java.io.IOException;
 
-public class VersionHeaderDecorator implements ClientResponseFilter {
+public class VersionHeaderDecorator implements ClientRequestFilter {
 
     @Override
-    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-        responseContext.getHeaders().addAll(Constants.API_VERSION_HEADER,ApiVersion.versions());
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().addAll(Constants.API_VERSION_HEADER,ApiVersion.versions());
 
     }
 }

--- a/tessera-jaxrs/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecoratorTest.java
+++ b/tessera-jaxrs/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecoratorTest.java
@@ -24,7 +24,7 @@ public class VersionHeaderDecoratorTest {
         VersionHeaderDecorator versionHeaderDecorator = new VersionHeaderDecorator();
         versionHeaderDecorator.filter(requestContext);
 
-        assertThat(headers.get(Constants.API_VERSION_HEADER)).isNotNull().isEqualTo(ApiVersion.versions());
+        assertThat(headers.getFirst(Constants.API_VERSION_HEADER)).isNotNull().isEqualTo(ApiVersion.versions());
 
         verify(requestContext).getHeaders();
         verifyNoMoreInteractions(requestContext);

--- a/tessera-jaxrs/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecoratorTest.java
+++ b/tessera-jaxrs/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecoratorTest.java
@@ -5,7 +5,6 @@ import com.quorum.tessera.version.ApiVersion;
 import org.junit.Test;
 
 import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -18,21 +17,17 @@ public class VersionHeaderDecoratorTest {
     public void filter() throws Exception {
 
         ClientRequestContext requestContext = mock(ClientRequestContext.class);
-        ClientResponseContext responseContext = mock(ClientResponseContext.class);
 
         MultivaluedMap headers = new MultivaluedHashMap();
-        when(responseContext.getHeaders()).thenReturn(headers);
+        when(requestContext.getHeaders()).thenReturn(headers);
 
         VersionHeaderDecorator versionHeaderDecorator = new VersionHeaderDecorator();
-        versionHeaderDecorator.filter(requestContext,responseContext);
+        versionHeaderDecorator.filter(requestContext);
 
         assertThat(headers.get(Constants.API_VERSION_HEADER)).isNotNull().isEqualTo(ApiVersion.versions());
 
-
-
-        verifyNoInteractions(requestContext);
-        verify(responseContext).getHeaders();
-        verifyNoMoreInteractions(responseContext);
+        verify(requestContext).getHeaders();
+        verifyNoMoreInteractions(requestContext);
 
     }
 

--- a/tessera-jaxrs/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecoratorTest.java
+++ b/tessera-jaxrs/jaxrs-client/src/test/java/com/quorum/tessera/jaxrs/client/VersionHeaderDecoratorTest.java
@@ -1,0 +1,39 @@
+package com.quorum.tessera.jaxrs.client;
+
+import com.quorum.tessera.shared.Constants;
+import com.quorum.tessera.version.ApiVersion;
+import org.junit.Test;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class VersionHeaderDecoratorTest {
+
+    @Test
+    public void filter() throws Exception {
+
+        ClientRequestContext requestContext = mock(ClientRequestContext.class);
+        ClientResponseContext responseContext = mock(ClientResponseContext.class);
+
+        MultivaluedMap headers = new MultivaluedHashMap();
+        when(responseContext.getHeaders()).thenReturn(headers);
+
+        VersionHeaderDecorator versionHeaderDecorator = new VersionHeaderDecorator();
+        versionHeaderDecorator.filter(requestContext,responseContext);
+
+        assertThat(headers.get(Constants.API_VERSION_HEADER)).isNotNull().isEqualTo(ApiVersion.versions());
+
+
+
+        verifyNoInteractions(requestContext);
+        verify(responseContext).getHeaders();
+        verifyNoMoreInteractions(responseContext);
+
+    }
+
+}

--- a/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/VersionTest.java
+++ b/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/VersionTest.java
@@ -1,0 +1,66 @@
+package com.quorum.tessera.p2p;
+
+import com.quorum.tessera.jaxrs.client.VersionHeaderDecorator;
+
+import com.quorum.tessera.shared.Constants;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionTest {
+
+    private JerseyTest jersey;
+
+    @Before
+    public void setUp() throws Exception {
+
+        jersey =
+            new JerseyTest() {
+                @Override
+                protected Application configure() {
+                    forceSet(TestProperties.CONTAINER_PORT, "0");
+                    enable(TestProperties.LOG_TRAFFIC);
+                    enable(TestProperties.DUMP_ENTITY);
+                    return new ResourceConfig().register(new MockResource());
+                }
+            };
+
+        jersey.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        jersey.tearDown();
+    }
+
+    @Test
+    public void testVersionInClientRequestNotNull() {
+        Response response = jersey.target("test").register(VersionHeaderDecorator.class).request().get();
+        assertThat(response.readEntity(boolean.class)).isTrue();
+    }
+
+
+    @Path("/")
+    public class MockResource {
+
+        @Path("test")
+        @GET
+        public boolean test(@HeaderParam(Constants.API_VERSION_HEADER) final String version) {
+            return Objects.nonNull(version);
+        }
+    }
+
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/AssertApiHeaders.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/AssertApiHeaders.java
@@ -1,7 +1,6 @@
 package com.quorum.tessera.test.rest;
 
-import com.quorum.tessera.server.http.VersionHeaderDecorator;
-
+import com.quorum.tessera.shared.Constants;
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,9 +10,9 @@ public interface AssertApiHeaders {
     static void doAsserts(Response response) {
 
         assertThat(response.getHeaders())
-            .containsKey(VersionHeaderDecorator.API_VERSION_HEADER);
+            .containsKey(Constants.API_VERSION_HEADER);
 
-        assertThat(response.getHeaders().get(VersionHeaderDecorator.API_VERSION_HEADER)).isNotEmpty();
+        assertThat(response.getHeaders().get(Constants.API_VERSION_HEADER)).isNotEmpty();
 
     }
 }


### PR DESCRIPTION
Add same response decoration made for all http responses to jaxrs client. Post constant api version header nam into shared constants class. 