### PR TITLE
Get Vault ITs working with tech debt branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -120,7 +120,13 @@ jobs:
     - uses: actions/setup-java@v1
       with:
        java-version: 11
-    - run: ./gradlew :tests:acceptance-test:test -x generateSwaggerDocumentation -PexcludeTests="**/RestSuiteHttpH2RemoteEnclave.class,**/SendWithRemoteEnclaveReconnectIT.class"
+    - name: Install Hashicorp Vault CLI & run tests
+      run: |
+        wget https://releases.hashicorp.com/vault/1.5.0/vault_1.5.0_linux_amd64.zip -O /tmp/vault_1.5.0_linux_amd64.zip
+        mkdir -p vault/bin && pushd $_
+        unzip /tmp/vault_1.5.0_linux_amd64.zip
+        export PATH=$PATH:$PWD && popd
+        ./gradlew :tests:acceptance-test:test -x generateSwaggerDocumentation -PexcludeTests="**/RestSuiteHttpH2RemoteEnclave.class,**/SendWithRemoteEnclaveReconnectIT.class"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -85,7 +85,7 @@ test {
             "**/P2pTestSuite.class",
             "**/CucumberFileKeyGenerationIT.class",
             "**/P2pTestSuite.class",
-          //  "**/VaultTestSuite.class"
+            "**/VaultTestSuite.class"
     )
 
     if (project.hasProperty("excludeTests")) {

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation project(":key-vault:aws-key-vault")
     testImplementation project(":key-vault:azure-key-vault")
+    testImplementation project(":key-vault:hashicorp-key-vault")
 
 
     testImplementation project(":ddls")
@@ -71,6 +72,7 @@ test {
 
     systemProperty "keyvault.aws.dist","${buildDir}/unpacked/dist/aws-key-vault-"+ project.version +"/lib/"
     systemProperty "keyvault.azure.dist","${buildDir}/unpacked/dist/azure-key-vault-"+ project.version +"/lib/"
+    systemProperty "keyvault.hashicorp.dist","${buildDir}/unpacked/dist/hashicorp-key-vault-"+ project.version +"/lib/"
 
     include(
            "**/RestSuiteHttpH2RemoteEnclave.class",
@@ -104,6 +106,14 @@ task unzipAzureKeyVault(type: Copy) {
 
 task unzipAwsKeyVault(type: Copy) {
     def zipFile = file(project(":key-vault:aws-key-vault").distZip.outputs.files.getFiles()[0])
+    def outputDir = file("${buildDir}/unpacked/dist")
+    from zipTree(zipFile)
+    into outputDir
+
+}
+
+task unzipHashicorpKeyVault(type: Copy) {
+    def zipFile = file(project(":key-vault:hashicorp-key-vault").distZip.outputs.files.getFiles()[0])
     def outputDir = file("${buildDir}/unpacked/dist")
     from zipTree(zipFile)
     into outputDir
@@ -154,5 +164,5 @@ task list(dependsOn: configurations.compileClasspath) {
 }
 
 
-test.dependsOn clean,copyJdbcJars,unzipDdl,unzipTessera,unzipEnclave,unzipAwsKeyVault,unzipAzureKeyVault
+test.dependsOn clean,copyJdbcJars,unzipDdl,unzipTessera,unzipEnclave,unzipAwsKeyVault,unzipAzureKeyVault,unzipHashicorpKeyVault
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/VaultTestSuite.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/VaultTestSuite.java
@@ -7,7 +7,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     RunAwsIT.class,
- //   RunAzureIT.class,
+ //   RunAzureIT.class, // disabled as Azure tests do not currently work due to challenge mocking the authentication protocol used by new Azure SDK libs
 })
 public class VaultTestSuite {
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/VaultTestSuite.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/VaultTestSuite.java
@@ -1,13 +1,15 @@
 package com.quorum.tessera.test.vault;
 
 import com.quorum.tessera.test.vault.aws.RunAwsIT;
+import com.quorum.tessera.test.vault.hashicorp.RunHashicorpIT;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     RunAwsIT.class,
- //   RunAzureIT.class, // disabled as Azure tests do not currently work due to challenge mocking the authentication protocol used by new Azure SDK libs
+    RunHashicorpIT.class
+ //   RunAzureIT.class, // disabled as Azure tests do not currently work due to challenge mocking the authentication protocol used by new Azure SDK libs,
 })
 public class VaultTestSuite {
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/aws/AwsStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/aws/AwsStepDefs.java
@@ -150,7 +150,8 @@ public class AwsStepDefs implements En {
                         .withArg("-configfile",tempTesseraConfig.toString())
                         .withArg("-pidfile", pid.toAbsolutePath().toString())
                         .withArg("-jdbc.autoCreateTables", "true")
-                        .withClassPathItem(distDirectory.resolve("*"));
+                        .withClassPathItem(distDirectory.resolve("*"))
+                        .withArg("--debug");
 
                     List<String> args = execArgsBuilder.build();
 
@@ -222,7 +223,8 @@ public class AwsStepDefs implements En {
                         .withJvmArg("-Daws.accessKeyId=an-id")
                         .withJvmArg("-Daws.secretAccessKey=a-key")
                         .withStartScriptOrJarFile(Paths.get(jarfile))
-                        .withClassPathItem(distDirectory).build();
+                        .withClassPathItem(distDirectory)
+                        .withArg("--debug").build();
 
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
 
@@ -237,7 +239,7 @@ public class AwsStepDefs implements En {
     }
 
     private void startTessera(List<String> args, Path verifyConfig) throws Exception {
-        System.out.println(String.join(" ", args));
+        LOGGER.info("Starting: {}", String.join(" ", args));
 
         ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/aws/AwsStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/aws/AwsStepDefs.java
@@ -135,6 +135,7 @@ public class AwsStepDefs implements En {
 
 
                     Path distDirectory = Optional.of("keyvault.aws.dist")
+                        .map(System::getProperty)
                         .map(Paths::get).get();
 
                     ExecArgsBuilder execArgsBuilder = new ExecArgsBuilder()
@@ -153,9 +154,19 @@ public class AwsStepDefs implements En {
                         .withClassPathItem(distDirectory.resolve("*"))
                         .withArg("--debug");
 
-                    List<String> args = execArgsBuilder.build();
+                    final List<String> args = execArgsBuilder.build();
 
-                    startTessera(args, tempTesseraConfig);
+                    final List<String> jvmArgs = new ArrayList<>();
+                    jvmArgs.add("-Djavax.net.ssl.trustStore=" + truststore.getFile());
+                    jvmArgs.add("-Djavax.net.ssl.trustStorePassword=testtest");
+                    jvmArgs.add("-Dspring.profiles.active=disable-unixsocket");
+                    jvmArgs.add("-Dlogback.configurationFile=" + logbackConfigFile.getFile());
+                    jvmArgs.add("-Ddebug=true");
+                    jvmArgs.add("-Daws.region=a-region");
+                    jvmArgs.add("-Daws.accessKeyId=an-id");
+                    jvmArgs.add("-Daws.secretAccessKey=a-key");
+
+                    startTessera(args, jvmArgs, tempTesseraConfig);
                 });
 
         Then(
@@ -228,7 +239,17 @@ public class AwsStepDefs implements En {
 
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
 
-                    startTessera(args, null); // node is not started during keygen so do not want to verify
+                    List<String> jvmArgs = new ArrayList<>();
+                    jvmArgs.add("-Djavax.net.ssl.trustStore=" + truststore.getFile());
+                    jvmArgs.add("-Djavax.net.ssl.trustStorePassword=testtest");
+                    jvmArgs.add("-Dspring.profiles.active=disable-unixsocket");
+                    jvmArgs.add("-Dlogback.configurationFile=" + logbackConfigFile.getFile());
+                    jvmArgs.add("-Ddebug=true");
+                    jvmArgs.add("-Daws.region=a-region");
+                    jvmArgs.add("-Daws.accessKeyId=an-id");
+                    jvmArgs.add("-Daws.secretAccessKey=a-key");
+                    
+                    startTessera(args, jvmArgs, null); // node is not started during keygen so do not want to verify
                 });
 
         Then(
@@ -238,13 +259,16 @@ public class AwsStepDefs implements En {
                 });
     }
 
-    private void startTessera(List<String> args, Path verifyConfig) throws Exception {
+    private void startTessera(List<String> args, List<String> jvmArgs, Path verifyConfig) throws Exception {
         LOGGER.info("Starting: {}", String.join(" ", args));
+        String jvmArgsStr = String.join(" ", jvmArgs);
+        LOGGER.info("JVM Args: {}", jvmArgsStr);
 
         ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
 
         Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
         tesseraEnvironment.put(AWS_REGION, "us-east-1");
+        tesseraEnvironment.put("JAVA_OPTS", jvmArgsStr); // JAVA_OPTS is read by start script and is used to provide jvm args
 
         try {
             tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/azure/AzureStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/azure/AzureStepDefs.java
@@ -217,7 +217,8 @@ public class AzureStepDefs implements En {
                                             "-pidfile",
                                             pid.toAbsolutePath().toString(),
                                             "-jdbc.autoCreateTables",
-                                            "true"));
+                                            "true",
+                                            "--debug"));
 
                     startTessera(args, tempTesseraConfig);
                 });
@@ -326,6 +327,7 @@ public class AzureStepDefs implements En {
                                     "-jar",
                                     jarfile));
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
+                    args.add("--debug");
 
                     startTessera(args, null); // node is not started during keygen so do not want to verify
                 });

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/hashicorp/HashicorpStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/hashicorp/HashicorpStepDefs.java
@@ -5,7 +5,10 @@ import com.quorum.tessera.config.HashicorpKeyVaultConfig;
 import com.quorum.tessera.config.util.JaxbUtil;
 import com.quorum.tessera.test.util.ElUtil;
 import cucumber.api.java8.En;
+import exec.ExecArgsBuilder;
 import exec.NodeExecManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -32,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class HashicorpStepDefs implements En {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HashicorpStepDefs.class);
+
     private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     private String vaultToken;
@@ -46,9 +51,10 @@ public class HashicorpStepDefs implements En {
 
     private Path tempTesseraConfig;
 
+    private final AtomicReference<Process> tesseraProcess = new AtomicReference<>();
+
     public HashicorpStepDefs() {
         final AtomicReference<Process> vaultServerProcess = new AtomicReference<>();
-        final AtomicReference<Process> tesseraProcess = new AtomicReference<>();
 
         Before(
                 () -> {
@@ -425,112 +431,24 @@ public class HashicorpStepDefs implements En {
                     String formattedArgs =
                             String.format(cliArgs, tempTesseraConfig.toString(), pid.toAbsolutePath().toString());
 
-                    List<String> args = new ArrayList<>();
-                    args.addAll(
-                            Arrays.asList(
-                                    "java",
-                                    "-Dspring.profiles.active=disable-unixsocket",
-                                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
-                                    "-Ddebug=true",
-                                    "-jar",
-                                    jarfile));
+                    final Path distDirectory = Optional.of("keyvault.hashicorp.dist")
+                        .map(System::getProperty)
+                        .map(Paths::get).get().resolve("*");
+
+                    final List<String> args = new ExecArgsBuilder()
+                        .withStartScriptOrExecutableJarFile(Paths.get(jarfile))
+                        .withClassPathItem(distDirectory)
+                        .withArg("--debug")
+                        .build();
+
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
-                    args.add("--debug");
-                    System.out.println(String.join(" ", args));
 
-                    ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
+                    List<String> jvmArgs = new ArrayList<>();
+                    jvmArgs.add("-Dspring.profiles.active=disable-unixsocket");
+                    jvmArgs.add("-Dlogback.configurationFile=" + logbackConfigFile.getFile());
+                    jvmArgs.add("-Ddebug=true");
 
-                    Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
-                    tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
-                    tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
-
-                    if ("token".equals(authMethod)) {
-
-                        Objects.requireNonNull(vaultToken);
-                        tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
-
-                    } else {
-
-                        Objects.requireNonNull(approleRoleId);
-                        Objects.requireNonNull(approleSecretId);
-                        tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
-                        tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
-                    }
-
-                    try {
-                        tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());
-                    } catch (NullPointerException ex) {
-                        throw new NullPointerException("Check that application.jar property has been set");
-                    }
-
-                    executorService.submit(
-                            () -> {
-                                try (BufferedReader reader =
-                                        Stream.of(tesseraProcess.get().getInputStream())
-                                                .map(InputStreamReader::new)
-                                                .map(BufferedReader::new)
-                                                .findAny()
-                                                .get()) {
-
-                                    String line;
-                                    while ((line = reader.readLine()) != null) {
-                                        System.out.println(line);
-                                    }
-
-                                } catch (IOException ex) {
-                                    throw new UncheckedIOException(ex);
-                                }
-                            });
-
-                    final Config config = JaxbUtil.unmarshal(Files.newInputStream(tempTesseraConfig), Config.class);
-
-                    final URL bindingUrl =
-                            UriBuilder.fromUri(config.getP2PServerConfig().getBindingUri())
-                                    .path("upcheck")
-                                    .build()
-                                    .toURL();
-
-                    CountDownLatch startUpLatch = new CountDownLatch(1);
-
-                    executorService.submit(
-                            () -> {
-                                while (true) {
-                                    try {
-                                        HttpURLConnection conn = (HttpURLConnection) bindingUrl.openConnection();
-                                        conn.connect();
-
-                                        System.out.println(bindingUrl + " started." + conn.getResponseCode());
-
-                                        startUpLatch.countDown();
-                                        return;
-                                    } catch (IOException ex) {
-                                        try {
-                                            TimeUnit.MILLISECONDS.sleep(200L);
-                                        } catch (InterruptedException ex1) {
-                                        }
-                                    }
-                                }
-                            });
-
-                    boolean started = startUpLatch.await(30, TimeUnit.SECONDS);
-
-                    if (!started) {
-                        System.err.println(bindingUrl + " Not started. ");
-                    }
-
-                    executorService.submit(
-                            () -> {
-                                try {
-                                    int exitCode = tesseraProcess.get().waitFor();
-                                    if (0 != exitCode) {
-                                        System.err.println("Tessera node exited with code " + exitCode);
-                                    }
-                                } catch (InterruptedException ex) {
-                                    ex.printStackTrace();
-                                }
-                            });
-
-                    startUpLatch.await(30, TimeUnit.SECONDS);
+                    startTessera(args, jvmArgs, tempTesseraConfig, authMethod);
                 });
 
         When(
@@ -541,65 +459,24 @@ public class HashicorpStepDefs implements En {
 
                     String formattedArgs = String.format(cliArgs, getClientTlsKeystore(), getClientTlsTruststore());
 
-                    List<String> args = new ArrayList<>();
-                    args.addAll(
-                            Arrays.asList(
-                                    "java",
-                                    "-Dspring.profiles.active=disable-unixsocket",
-                                    "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
-                                    "-Ddebug=true",
-                                    "-jar",
-                                    jarfile));
+                    final Path distDirectory = Optional.of("keyvault.hashicorp.dist")
+                        .map(System::getProperty)
+                        .map(Paths::get).get().resolve("*");
+
+                    final List<String> args = new ExecArgsBuilder()
+                        .withStartScriptOrExecutableJarFile(Paths.get(jarfile))
+                        .withClassPathItem(distDirectory)
+                        .withArg("--debug")
+                        .build();
+
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
-                    args.add("--debug");
-                    System.out.println(String.join(" ", args));
 
-                    ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
+                    List<String> jvmArgs = new ArrayList<>();
+                    jvmArgs.add("-Dspring.profiles.active=disable-unixsocket");
+                    jvmArgs.add("-Dlogback.configurationFile=" + logbackConfigFile.getFile());
+                    jvmArgs.add("-Ddebug=true");
 
-                    Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
-                    tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
-                    tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
-
-                    if ("token".equals(authMethod)) {
-
-                        Objects.requireNonNull(vaultToken);
-                        tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
-
-                    } else {
-
-                        Objects.requireNonNull(approleRoleId);
-                        Objects.requireNonNull(approleSecretId);
-                        tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
-                        tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
-                    }
-
-                    try {
-                        tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());
-                    } catch (NullPointerException ex) {
-                        throw new NullPointerException("Check that application.jar property has been set");
-                    }
-
-                    executorService.submit(
-                            () -> {
-                                try (BufferedReader reader =
-                                        Stream.of(tesseraProcess.get().getInputStream())
-                                                .map(InputStreamReader::new)
-                                                .map(BufferedReader::new)
-                                                .findAny()
-                                                .get()) {
-
-                                    String line;
-                                    while ((line = reader.readLine()) != null) {
-                                        System.out.println(line);
-                                    }
-
-                                } catch (IOException ex) {
-                                    throw new UncheckedIOException(ex);
-                                }
-                            });
-
-                    CountDownLatch startUpLatch = new CountDownLatch(1);
-                    startUpLatch.await(10, TimeUnit.SECONDS);
+                    startTessera(args, jvmArgs, null, authMethod);
                 });
 
         Then(
@@ -718,4 +595,107 @@ public class HashicorpStepDefs implements En {
     private String getClientTlsTruststore() {
         return getClass().getResource("/certificates/truststore.jks").getFile();
     }
+
+    private void startTessera(List<String> args, List<String> jvmArgs, Path verifyConfig, String authMethod) throws Exception {
+        String jvmArgsStr = String.join(" ", jvmArgs);
+
+        LOGGER.info("Starting: {}", String.join(" ", args));
+        LOGGER.info("JVM Args: {}", jvmArgsStr);
+
+        ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
+
+        Map<String, String> tesseraEnvironment = tesseraProcessBuilder.environment();
+        tesseraEnvironment.put(HASHICORP_CLIENT_KEYSTORE_PWD, "testtest");
+        tesseraEnvironment.put(HASHICORP_CLIENT_TRUSTSTORE_PWD, "testtest");
+        tesseraEnvironment.put("JAVA_OPTS", jvmArgsStr); // JAVA_OPTS is read by start script and is used to provide jvm args
+
+        if ("token".equals(authMethod)) {
+            Objects.requireNonNull(vaultToken);
+            tesseraEnvironment.put(HASHICORP_TOKEN, vaultToken);
+        } else {
+            Objects.requireNonNull(approleRoleId);
+            Objects.requireNonNull(approleSecretId);
+            tesseraEnvironment.put(HASHICORP_ROLE_ID, approleRoleId);
+            tesseraEnvironment.put(HASHICORP_SECRET_ID, approleSecretId);
+        }
+
+        try {
+            tesseraProcess.set(tesseraProcessBuilder.redirectErrorStream(true).start());
+        } catch (NullPointerException ex) {
+            throw new NullPointerException("Check that application.jar property has been set");
+        }
+
+        executorService.submit(
+            () -> {
+                try (BufferedReader reader =
+                         Stream.of(tesseraProcess.get().getInputStream())
+                             .map(InputStreamReader::new)
+                             .map(BufferedReader::new)
+                             .findAny()
+                             .get()) {
+
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        System.out.println(line);
+                    }
+
+                } catch (IOException ex) {
+                    throw new UncheckedIOException(ex);
+                }
+            });
+
+        CountDownLatch startUpLatch = new CountDownLatch(1);
+
+        if (Objects.nonNull(verifyConfig)) {
+            final Config config = JaxbUtil.unmarshal(Files.newInputStream(verifyConfig), Config.class);
+
+            final URL bindingUrl =
+                UriBuilder.fromUri(config.getP2PServerConfig().getBindingUri())
+                    .path("upcheck")
+                    .build()
+                    .toURL();
+
+            executorService.submit(
+                () -> {
+                    while (true) {
+                        try {
+                            HttpURLConnection conn = (HttpURLConnection) bindingUrl.openConnection();
+                            conn.connect();
+
+                            System.out.println(bindingUrl + " started." + conn.getResponseCode());
+
+                            startUpLatch.countDown();
+                            return;
+                        } catch (IOException ex) {
+                            try {
+                                TimeUnit.MILLISECONDS.sleep(200L);
+                            } catch (InterruptedException ex1) {
+                            }
+                        }
+                    }
+                });
+
+            boolean started = startUpLatch.await(30, TimeUnit.SECONDS);
+
+            if (!started) {
+                System.err.println(bindingUrl + " Not started. ");
+            }
+        }
+
+        executorService.submit(
+            () -> {
+                try {
+                    int exitCode = tesseraProcess.get().waitFor();
+                    startUpLatch.countDown();
+                    if (0 != exitCode) {
+                        System.err.println("Tessera node exited with code " + exitCode);
+                    }
+                } catch (InterruptedException ex) {
+                    ex.printStackTrace();
+                }
+            });
+
+        startUpLatch.await(30, TimeUnit.SECONDS);
+    }
+
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/hashicorp/HashicorpStepDefs.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/vault/hashicorp/HashicorpStepDefs.java
@@ -435,6 +435,7 @@ public class HashicorpStepDefs implements En {
                                     "-jar",
                                     jarfile));
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
+                    args.add("--debug");
                     System.out.println(String.join(" ", args));
 
                     ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);
@@ -550,6 +551,7 @@ public class HashicorpStepDefs implements En {
                                     "-jar",
                                     jarfile));
                     args.addAll(Arrays.asList(formattedArgs.split(" ")));
+                    args.add("--debug");
                     System.out.println(String.join(" ", args));
 
                     ProcessBuilder tesseraProcessBuilder = new ProcessBuilder(args);

--- a/tests/acceptance-test/src/test/java/exec/ExecArgsBuilder.java
+++ b/tests/acceptance-test/src/test/java/exec/ExecArgsBuilder.java
@@ -71,6 +71,7 @@ public class ExecArgsBuilder {
         }
     }
 
+    // TODO(cjh) delete if not distributing as an executable jar file
     private ExecArgsBuilder withExecutableJarFile(Path executableJarFile) {
         this.executableJarFile = executableJarFile;
         return this;


### PR DESCRIPTION
Necessary changes for Vault ITs to work.

Azure ITs have been disabled for the time being.  As part of authentication, the new Azure SDK makes a request to `https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=<endpoint>`.

The value of `endpoint` can be customised with the initial `401` wiremock response but the request URL is hardcoded.

One workaround to mock this call could be to update the `/etc/hosts` file so that `login.microsoftonline.com` resolves to some other IP (e.g. `10.0.0.1`), and the `iptables` can be updated to route requests for `10.0.0.1:80` to `127.0.0.1:<wiremock-port>`.  An intial attempt was made here https://github.com/jpmorganchase/tessera/pull/1114/files#diff-90829e76e906f1c73140c7ded7e1b268R108-R119 but it needs some more work.