### PR TITLE
Remove unused transaction pushing method

### DIFF
--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/RestP2pClient.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/RestP2pClient.java
@@ -22,28 +22,6 @@ public class RestP2pClient implements P2pClient {
     }
 
     @Override
-    public byte[] push(final String targetUrl, final byte[] data) {
-        LOGGER.debug("Sending Transaction via /push to peer {}", targetUrl);
-
-        try (Response response =
-                 client.target(targetUrl)
-                     .path("/push")
-                     .request()
-                     .post(Entity.entity(data, MediaType.APPLICATION_OCTET_STREAM_TYPE))) {
-
-            final int returnStatusCode = response.getStatus();
-            if (Response.Status.OK.getStatusCode() != returnStatusCode
-                && Response.Status.CREATED.getStatusCode() != returnStatusCode) {
-                LOGGER.warn("Push returned status code for peer {} was {}", targetUrl, returnStatusCode);
-                return null;
-            }
-
-            LOGGER.debug("Successful Push call to {}", targetUrl);
-            return response.readEntity(byte[].class);
-        }
-    }
-
-    @Override
     public boolean sendPartyInfo(final String targetUrl, final byte[] data) {
         LOGGER.debug("Sending PartyInfo to peer {}", targetUrl);
 

--- a/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/RestP2pClientTest.java
+++ b/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/RestP2pClientTest.java
@@ -1,14 +1,16 @@
 package com.quorum.tessera.p2p;
 
 import com.quorum.tessera.jaxrs.mock.MockClient;
-import java.util.ArrayList;
-import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Before;
-import org.junit.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -36,12 +38,12 @@ public class RestP2pClientTest {
 
         List<Entity> postedEntities = new ArrayList<>();
         doAnswer(
-                        (invocation) -> {
-                            postedEntities.add(invocation.getArgument(0));
-                            return response;
-                        })
-                .when(m)
-                .post(any(Entity.class));
+            (invocation) -> {
+                postedEntities.add(invocation.getArgument(0));
+                return response;
+            })
+            .when(m)
+            .post(any(Entity.class));
 
         String targetUrl = "http://somedomain.com";
         byte[] data = "Some Data".getBytes();
@@ -49,77 +51,6 @@ public class RestP2pClientTest {
         boolean outcome = client.sendPartyInfo(targetUrl, data);
 
         assertThat(outcome).isTrue();
-        assertThat(postedEntities).hasSize(1);
-
-        Entity entity = postedEntities.get(0);
-        assertThat(entity.getMediaType()).isEqualTo(javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE);
-        assertThat(entity.getEntity()).isSameAs(data);
-
-        verify(response).readEntity(byte[].class);
-    }
-
-    @Test
-    public void push() {
-
-        Invocation.Builder m = restClient.getWebTarget().getMockInvocationBuilder();
-
-        byte[] responseData = "Result".getBytes();
-        Response response = mock(Response.class);
-        when(response.readEntity(byte[].class)).thenReturn(responseData);
-        when(response.getStatus()).thenReturn(200);
-
-        List<Entity> postedEntities = new ArrayList<>();
-        doAnswer(
-                        (invocation) -> {
-                            postedEntities.add(invocation.getArgument(0));
-                            return response;
-                        })
-                .when(m)
-                .post(any(Entity.class));
-
-        String targetUrl = "http://somedomain.com";
-        byte[] data = "Some Data".getBytes();
-
-        byte[] outcome = client.push(targetUrl, data);
-
-        assertThat(outcome).isSameAs(responseData);
-
-        assertThat(postedEntities).hasSize(1);
-
-        Entity entity = postedEntities.get(0);
-        assertThat(entity.getMediaType()).isEqualTo(javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE);
-        assertThat(entity.getEntity()).isSameAs(data);
-
-        verify(response).readEntity(byte[].class);
-    }
-
-    @Test
-    public void pushReturns201() {
-
-        Invocation.Builder m = restClient.getWebTarget().getMockInvocationBuilder();
-
-        byte[] responseData = "Result".getBytes();
-
-        Response response = mock(Response.class);
-        when(response.readEntity(byte[].class)).thenReturn(responseData);
-        when(response.getStatus()).thenReturn(201);
-
-        List<Entity> postedEntities = new ArrayList<>();
-        doAnswer(
-                        (invocation) -> {
-                            postedEntities.add(invocation.getArgument(0));
-                            return response;
-                        })
-                .when(m)
-                .post(any(Entity.class));
-
-        String targetUrl = "http://somedomain.com";
-        byte[] data = "Some Data".getBytes();
-
-        byte[] outcome = client.push(targetUrl, data);
-
-        assertThat(outcome).isSameAs(responseData);
-
         assertThat(postedEntities).hasSize(1);
 
         Entity entity = postedEntities.get(0);
@@ -142,12 +73,12 @@ public class RestP2pClientTest {
 
         List<Entity> postedEntities = new ArrayList<>();
         doAnswer(
-                        (invocation) -> {
-                            postedEntities.add(invocation.getArgument(0));
-                            return response;
-                        })
-                .when(m)
-                .post(any(Entity.class));
+            (invocation) -> {
+                postedEntities.add(invocation.getArgument(0));
+                return response;
+            })
+            .when(m)
+            .post(any(Entity.class));
 
         String targetUrl = "http://somedomain.com";
         byte[] data = "Some Data".getBytes();
@@ -165,26 +96,6 @@ public class RestP2pClientTest {
     }
 
     @Test
-    public void pushReturns400() {
-
-        Invocation.Builder m = restClient.getWebTarget().getMockInvocationBuilder();
-
-        doAnswer(
-                        (invocation) -> {
-                            return Response.status(400).build();
-                        })
-                .when(m)
-                .post(any(Entity.class));
-
-        String targetUrl = "http://somedomain.com";
-        byte[] data = "Some Data".getBytes();
-
-        byte[] outcome = client.push(targetUrl, data);
-
-        assertThat(outcome).isNull();
-    }
-
-    @Test
     public void sendPartyInfoReturns400() {
 
         Invocation.Builder m = restClient.getWebTarget().getMockInvocationBuilder();
@@ -195,12 +106,9 @@ public class RestP2pClientTest {
         when(response.readEntity(byte[].class)).thenReturn(responseData);
         when(response.getStatus()).thenReturn(400);
 
-        doAnswer(
-                        (invocation) -> {
-                            return Response.status(400).build();
-                        })
-                .when(m)
-                .post(any(Entity.class));
+        doAnswer((invocation) -> Response.status(400).build())
+            .when(m)
+            .post(any(Entity.class));
 
         String targetUrl = "http://somedomain.com";
         byte[] data = "Some Data".getBytes();

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/P2pClient.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/P2pClient.java
@@ -2,7 +2,5 @@ package com.quorum.tessera.partyinfo;
 
 public interface P2pClient {
 
-    byte[] push(String targetUrl, byte[] data);
-
     boolean sendPartyInfo(String targetUrl, byte[] data);
 }

--- a/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceImpl.java
+++ b/tessera-partyinfo/src/main/java/com/quorum/tessera/partyinfo/PartyInfoServiceImpl.java
@@ -138,35 +138,6 @@ public class PartyInfoServiceImpl implements PartyInfoService {
         return partyInfoStore.removeRecipient(uri);
     }
 
-    //    @Override
-    //    public void publishPayload(final EncodedPayload payload, final PublicKey recipientKey) {
-    //
-    //        if (enclave.getPublicKeys().contains(recipientKey)) {
-    //            // we are trying to send something to ourselves - don't do it
-    //            LOGGER.debug(
-    //                    "Trying to send message to ourselves with key {}, not publishing",
-    // recipientKey.encodeToBase64());
-    //            return;
-    //        }
-    //
-    //        final Recipient retrievedRecipientFromStore =
-    //                partyInfoStore.getPartyInfo().getRecipients().stream()
-    //                        .filter(recipient -> recipientKey.equals(recipient.getKey()))
-    //                        .findAny()
-    //                        .orElseThrow(
-    //                                () ->
-    //                                        new KeyNotFoundException(
-    //                                                "Recipient not found for key: " + recipientKey.encodeToBase64()));
-    //
-    //        final String targetUrl = retrievedRecipientFromStore.getUrl();
-    //
-    //        LOGGER.info("Publishing message to {}", targetUrl);
-    //
-    //        payloadPublisher.publishPayload(payload, targetUrl);
-    //
-    //        LOGGER.info("Published to {}", targetUrl);
-    //    }
-
     /**
      * Fetches local public keys from the Enclave and adds them to the local store. This is useful when the Enclave is
      * remote and can restart with new keys independently of the Transaction Manager


### PR DESCRIPTION
This method hasn't been used for a long time and should be removed.

Instead, the `PayloadPublisher` is responsible for pushing transactions.