### PR TITLE
Normalise urls when repopulate PartyStore

### DIFF
--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyStore.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyStore.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.p2p;
 
 import com.quorum.tessera.context.RuntimeContext;
+import com.quorum.tessera.discovery.NodeUri;
 
 import java.net.URI;
 import java.util.ServiceLoader;
@@ -17,7 +18,11 @@ public interface PartyStore {
 
         final Set<URI> parties = getParties();
 
-        if (parties.isEmpty() || !parties.stream().anyMatch(runtimeContext.getPeers()::contains)) {
+        if (parties.isEmpty()
+                || !runtimeContext.getPeers().stream()
+                        .map(NodeUri::create)
+                        .map(NodeUri::asURI)
+                        .anyMatch(parties::contains)) {
             runtimeContext.getPeers().forEach(this::store);
         }
     }

--- a/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/PartyStoreFactoryTest.java
+++ b/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/PartyStoreFactoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,6 +77,20 @@ public class PartyStoreFactoryTest {
         partyStoreFactory.loadFromConfigIfEmpty();
 
         verify(partyStore).getParties();
+    }
+
+    @Test
+    public void loadFromConfigNormaliseURLsBeforeCompare() {
+
+        when(partyStore.getParties()).thenReturn(Set.of(URI.create("http://peer.com/")));
+
+        when(RuntimeContext.getInstance().getPeers()).thenReturn(List.of(URI.create("http://peer.com")));
+
+        partyStoreFactory.loadFromConfigIfEmpty();
+
+        verify(partyStore).getParties();
+        verify(partyStore, times(0)).store(any());
+
     }
 
     @Test


### PR DESCRIPTION
When check if PartyStore should be repopulated from peer list, normalise url before comparing 2 sets of URIs