### PR TITLE
Remove header from server response

### DIFF
--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/JerseyServer.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/JerseyServer.java
@@ -9,7 +9,6 @@ import com.quorum.tessera.server.jaxrs.LoggingFilter;
 import com.quorum.tessera.server.monitoring.InfluxDbClient;
 import com.quorum.tessera.server.monitoring.InfluxDbPublisher;
 import com.quorum.tessera.server.monitoring.MetricsResource;
-import com.quorum.tessera.server.http.VersionHeaderDecorator;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -17,11 +16,8 @@ import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
-
-import javax.servlet.DispatcherType;
 import javax.ws.rs.core.Application;
 import java.net.URI;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -97,8 +93,6 @@ public class JerseyServer implements TesseraServer {
         ServletHolder jerseyServlet = new ServletHolder(servletContainer);
 
         context.addServlet(jerseyServlet, "/*");
-
-        context.addFilter(VersionHeaderDecorator.class,"/*", EnumSet.allOf(DispatcherType.class));
 
         LOGGER.info("Starting {}", uri);
 

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/http/VersionHeaderDecoratorTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/http/VersionHeaderDecoratorTest.java
@@ -1,14 +1,20 @@
 package com.quorum.tessera.server.http;
 
+import com.jpmorgan.quorum.server.utils.ServerUtils;
 import com.quorum.tessera.config.CommunicationType;
 import com.quorum.tessera.config.ServerConfig;
-import com.quorum.tessera.server.JerseyServer;
 import com.quorum.tessera.server.jaxrs.SampleApplication;
 import com.quorum.tessera.shared.Constants;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.servlet.DispatcherType;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
@@ -16,6 +22,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,7 +30,7 @@ public class VersionHeaderDecoratorTest {
 
     private URI serverUri = URI.create("http://localhost:8080");
 
-    private JerseyServer server;
+    private Server server;
 
     @Before
     public void onSetUp() throws Exception {
@@ -34,7 +41,18 @@ public class VersionHeaderDecoratorTest {
         serverConfig.setServerAddress("http://localhost:8080");
 
         Application sample = new SampleApplication();
-        server = new JerseyServer(serverConfig, sample);
+
+        final ResourceConfig config = ResourceConfig.forApplication(sample);
+        this.server = ServerUtils.buildWebServer(serverConfig);
+
+        ServletContextHandler context = new ServletContextHandler(server, "/");
+        ServletContainer servletContainer = new ServletContainer(config);
+        ServletHolder jerseyServlet = new ServletHolder(servletContainer);
+
+        context.addServlet(jerseyServlet, "/*");
+
+        // Sample Usage
+        context.addFilter(VersionHeaderDecorator.class, "/*", EnumSet.allOf(DispatcherType.class));
 
         server.start();
     }
@@ -47,33 +65,23 @@ public class VersionHeaderDecoratorTest {
     @Test
     public void headersPopulatedForJaxrsRequest() {
 
-
         Response result = ClientBuilder.newClient().target(serverUri).path("ping").request().get();
 
         assertThat(result.getStatus()).isEqualTo(200);
         assertThat((String) result.getHeaders().getFirst(Constants.API_VERSION_HEADER)).isNotEmpty();
-
     }
-
 
     @Test
     public void headerPopulatedForPlainHttpRequest() throws Exception {
 
         HttpClient httpClient = HttpClient.newBuilder().build();
 
-        HttpRequest httpRequest = HttpRequest.newBuilder()
-            .uri(URI.create(serverUri.toString().concat("/ping")))
-            .GET()
-            .build();
+        HttpRequest httpRequest =
+                HttpRequest.newBuilder().uri(URI.create(serverUri.toString().concat("/ping"))).GET().build();
 
-        HttpResponse<String> httpResponse =
-            httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> httpResponse = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
 
         assertThat(httpResponse.statusCode()).isEqualTo(200);
         assertThat(httpResponse.headers().map().get(Constants.API_VERSION_HEADER)).isNotEmpty();
-
-
     }
-
-
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendIT.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.test.rest;
 
-
 import com.quorum.tessera.api.ReceiveResponse;
 import com.quorum.tessera.api.SendRequest;
 import com.quorum.tessera.api.SendResponse;
@@ -66,15 +65,14 @@ public class SendIT {
         URI location = response.getLocation();
 
         final Response checkPersistedTxnResponse = client.target(location).request().get();
-        AssertApiHeaders.doAsserts(checkPersistedTxnResponse);
 
         assertThat(checkPersistedTxnResponse.getStatus()).isEqualTo(200);
 
         ReceiveResponse receiveResponse = checkPersistedTxnResponse.readEntity(ReceiveResponse.class);
 
         assertThat(receiveResponse.getPayload())
-            .describedAs("The response payload should be equal to the sent txn data")
-            .isEqualTo(transactionData);
+                .describedAs("The response payload should be equal to the sent txn data")
+                .isEqualTo(transactionData);
 
         utils.findTransaction(result.getKey(), partyHelper.findByAlias("A"), partyHelper.findByAlias("B"))
                 .forEach(
@@ -112,8 +110,6 @@ public class SendIT {
                         .path(SEND_PATH)
                         .request()
                         .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
-
-        AssertApiHeaders.doAsserts(response);
 
         //
         final SendResponse result = response.readEntity(SendResponse.class);
@@ -162,8 +158,6 @@ public class SendIT {
                         .request()
                         .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
 
-        AssertApiHeaders.doAsserts(response);
-
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
 
@@ -196,8 +190,6 @@ public class SendIT {
                         .path(SEND_PATH)
                         .request()
                         .post(Entity.entity(sendRequest, MediaType.APPLICATION_JSON));
-
-        AssertApiHeaders.doAsserts(response);
 
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();


### PR DESCRIPTION
We are yet require to populate version in the header of the response on the server side. At this point it's only needed on client request and to be more specific p2p client