### PR TITLE
Add Actions workflow to push Docker images on new tag & changes to master

### DIFF
--- a/.github/workflows/docker-dry-run.yml
+++ b/.github/workflows/docker-dry-run.yml
@@ -1,19 +1,17 @@
-name: Tessera Docker Build
+name: Tessera Docker Dry Run
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
 
 jobs:
   docker-build:
+    name: Build Docker image without pushing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
         with:
-          repository: quorumengineering/tessera
+          repository: ${{ secrets.DOCKER_REPO }}
           push: false

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,44 @@
+name: Tessera Docker Push
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - tessera-*
+
+jobs:
+  push-latest:
+    name: Push latest
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: ${{ secrets.DOCKER_REPO }}
+          tags: latest
+          add_git_labels: true
+  push-tag:
+    name: Push tag
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/tessera-')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine tag name
+        id: tag
+        shell: bash
+        run: |
+          REF=${{ github.ref }}
+          PREFIX=refs/tags/tessera-
+          TAG=${REF#PREFIX}
+          echo "::set-output name=name::$TAG"
+      - uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: ${{ secrets.DOCKER_REPO }}
+          tags: ${{ steps.tag.name }}
+          add_git_labels: true


### PR DESCRIPTION
Closes #1156 

* Push changes to master as image `tessera:latest`
* Push new tags as image `tessera:x.x.x`
* Disable dry run on pushes to master
* Continue to do dry run on PRs to master