### PR TITLE
Fix version resource. 

### DIFF
--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/Version.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/Version.java
@@ -1,8 +1,17 @@
 package com.quorum.tessera.api;
 
-public class Version {
+import java.util.ServiceLoader;
 
-    public static String getVersion() {
+public interface Version {
+
+    static String getVersion() {
+        return ServiceLoader.load(Version.class)
+            .findFirst()
+            .orElse(new Version() {})
+            .version();
+    }
+
+    default String version() {
         return Version.class.getPackage().getSpecificationVersion();
     }
 }

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
@@ -21,19 +21,29 @@ import java.util.stream.Collectors;
 @Api
 public class VersionResource {
 
+    private static final String VERSION = Version.getVersion();
 
-    @Deprecated //Callers shouldn't need the build version
+    @Deprecated //getDistributionVersion
     @GET
     @Path("version")
     @Produces(MediaType.TEXT_PLAIN)
     @ApiOperation(value = "Request distribution version of Tessera")
     @ApiResponses({@ApiResponse(code = 200, message = "Current application version ", response = String.class)})
     public String getVersion() {
-        return Version.getVersion();
+        return VERSION;
     }
 
     @GET
-    @Path("versions")
+    @Path("version/distribution")
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = "Request distribution version of Tessera")
+    @ApiResponses({@ApiResponse(code = 200, message = "Current application version ", response = String.class)})
+    public String getDistributionVersion() {
+        return VERSION;
+    }
+
+    @GET
+    @Path("version/api")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Request all API versions available")
     @ApiResponses({@ApiResponse(code = 200, message = "All supported api versions", response = JsonArray.class)})

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
@@ -22,14 +22,14 @@ import java.util.stream.Collectors;
 public class VersionResource {
 
 
+    @Deprecated //Callers shouldn't need the build version
     @GET
     @Path("version")
     @Produces(MediaType.TEXT_PLAIN)
     @ApiOperation(value = "Request distribution version of Tessera")
-    @ApiResponses({@ApiResponse(code = 200, message = "Current api version ", response = String.class)})
+    @ApiResponses({@ApiResponse(code = 200, message = "Current application version ", response = String.class)})
     public String getVersion() {
-        List<String> versions = versions();
-        return versions.get(versions.size() - 1);
+        return Version.getVersion();
     }
 
     @GET
@@ -38,30 +38,16 @@ public class VersionResource {
     @ApiOperation(value = "Request all API versions available")
     @ApiResponses({@ApiResponse(code = 200, message = "All supported api versions", response = JsonArray.class)})
     public JsonArray getVersions() {
-        return Json.createArrayBuilder(versions()).build();
-    }
-
-    @GET
-    @Path("version/info")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "All version info")
-    @ApiResponses({@ApiResponse(code = 200, message = "All version info", response = JsonObject.class)})
-    public JsonObject getInfo() {
-        return Json.createObjectBuilder()
-            .add("versions",Json.createArrayBuilder(versions()))
-            .add("dist",Version.getVersion()).build();
-
-
-    }
-
-    private static List<String> versions() {
-       return ApiVersion.versions()
+        List<String> versions = ApiVersion.versions()
             .stream()
             .map(version -> version.substring(1)) //remove the "v" prefix
             .map(Double::parseDouble)
             .sorted()
             .map(Objects::toString)
             .collect(Collectors.toList());
+
+
+        return Json.createArrayBuilder(versions).build();
     }
 
 }

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/VersionResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** Provides endpoints to determine versioning information */
@@ -20,49 +21,47 @@ import java.util.stream.Collectors;
 @Api
 public class VersionResource {
 
-    private static final String VERSION = Version.getVersion();
 
-    /**
-     * An endpoint describing the current version of the application
-     *
-     * @return the version of the application
-     */
     @GET
     @Path("version")
     @Produces(MediaType.TEXT_PLAIN)
     @ApiOperation(value = "Request distribution version of Tessera")
-    @ApiResponses({@ApiResponse(code = 200, message = "Current application version ", response = String.class)})
+    @ApiResponses({@ApiResponse(code = 200, message = "Current api version ", response = String.class)})
     public String getVersion() {
-        return VERSION;
+        List<String> versions = versions();
+        return versions.get(versions.size() - 1);
     }
 
     @GET
-    @Path("version/distribution")
-    @Produces(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Request distribution version of Tessera")
-    @ApiResponses({@ApiResponse(code = 200, message = "Current application version ", response = String.class)})
-    public String getDistributionVersion() {
-        return VERSION;
-    }
-
-    @GET
-    @Path("version/api")
+    @Path("versions")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Request all API versions available")
     @ApiResponses({@ApiResponse(code = 200, message = "All supported api versions", response = JsonArray.class)})
-    public JsonObject getVersions() {
-        final List<JsonObjectBuilder> sortedAllVersions = ApiVersion.versions()
+    public JsonArray getVersions() {
+        return Json.createArrayBuilder(versions()).build();
+    }
+
+    @GET
+    @Path("version/info")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "All version info")
+    @ApiResponses({@ApiResponse(code = 200, message = "All version info", response = JsonObject.class)})
+    public JsonObject getInfo() {
+        return Json.createObjectBuilder()
+            .add("versions",Json.createArrayBuilder(versions()))
+            .add("dist",Version.getVersion()).build();
+
+
+    }
+
+    private static List<String> versions() {
+       return ApiVersion.versions()
             .stream()
             .map(version -> version.substring(1)) //remove the "v" prefix
             .map(Double::parseDouble)
             .sorted()
-            .map(Object::toString)
-            .map(version -> Json.createObjectBuilder().add("version", version))
+            .map(Objects::toString)
             .collect(Collectors.toList());
-
-        JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-        sortedAllVersions.forEach(arrayBuilder::add);
-
-        return Json.createObjectBuilder().add("versions", arrayBuilder).build();
     }
+
 }

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/ApiObjectTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/ApiObjectTest.java
@@ -12,9 +12,10 @@ public class ApiObjectTest {
 
     @Test
     public void testAccessorsForApiObjects() {
-        Validator validator = ValidatorBuilder.create().with(new GetterTester()).with(new SetterTester()).build();
+        Validator validator = ValidatorBuilder.create()
+            .with(new GetterTester()).with(new SetterTester()).build();
 
-        validator.validate("com.quorum.tessera.api");
+        validator.validate("com.quorum.tessera.api", pojoClass -> !pojoClass.getClazz().getName().contains(VersionTest.class.getName()));
     }
 
     @Test

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/MockVersion.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/MockVersion.java
@@ -1,0 +1,11 @@
+package com.quorum.tessera.api;
+
+public class MockVersion implements Version {
+
+    public static final String VERSION = "MOCK";
+
+    @Override
+    public String version() {
+        return VERSION;
+    }
+}

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/VersionTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/VersionTest.java
@@ -1,0 +1,21 @@
+package com.quorum.tessera.api;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionTest {
+
+    @Test
+    public void getVersion() {
+        String version = Version.getVersion();
+        assertThat(version).isEqualTo(MockVersion.VERSION);
+    }
+
+    @Test
+    public void getDefaultVersion() {
+        String version = new Version(){}.version();
+        assertThat(version).isNull();
+    }
+
+}

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/VersionResourceTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/VersionResourceTest.java
@@ -26,6 +26,11 @@ public class VersionResourceTest {
         assertThat(instance.getVersion()).isEqualTo(MockVersion.VERSION);
     }
 
+    @Test
+    public void getDistributionVersion() {
+        assertThat(instance.getDistributionVersion()).isEqualTo(MockVersion.VERSION);
+    }
+
 
     @Test
     public void getVersions() {

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/VersionResourceTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/VersionResourceTest.java
@@ -1,16 +1,21 @@
 package com.quorum.tessera.api.common;
 
-import com.quorum.tessera.api.Version;
+import com.quorum.tessera.api.MockVersion;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.json.Json;
 import javax.json.JsonObject;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class VersionResourceTest {
 
     private VersionResource instance;
+
+    public VersionResourceTest() {}
 
     @Before
     public void onSetUp() {
@@ -19,23 +24,25 @@ public class VersionResourceTest {
 
     @Test
     public void getVersion() {
-        assertThat(instance.getVersion()).isEqualTo(Version.getVersion());
+        assertThat(instance.getVersion()).isEqualTo("2.0");
     }
 
     @Test
-    public void getDistributionVersion() {
-        assertThat(instance.getDistributionVersion()).isEqualTo(Version.getVersion());
+    public void getInfo() {
+        JsonObject info = instance.getInfo();
+
+        assertThat(info).isNotNull();
+        assertThat(info.getString("dist")).isEqualTo(MockVersion.VERSION);
+        assertThat(info.getJsonArray("versions"))
+            .containsExactlyElementsOf(Stream.of("1.0", "2.0")
+                .map(Json::createValue).collect(Collectors.toSet()));
     }
 
     @Test
     public void getVersions() {
-        final JsonObject versions = instance.getVersions();
-
-        final String expected = "{\"versions\":[{\"version\":\"1.0\"},{\"version\":\"2.0\"}]}";
-
-        // since the versions should be sorted, we know that the JSON string is in a particular order
-        final String versionJson = versions.toString();
-
-        assertThat(versionJson).isEqualTo(expected);
+        assertThat(instance.getVersions())
+            .containsExactlyElementsOf(Stream.of("1.0", "2.0")
+                .map(Json::createValue)
+                .collect(Collectors.toSet()));
     }
 }

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/VersionResourceTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/VersionResourceTest.java
@@ -5,7 +5,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.json.Json;
-import javax.json.JsonObject;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -24,19 +23,9 @@ public class VersionResourceTest {
 
     @Test
     public void getVersion() {
-        assertThat(instance.getVersion()).isEqualTo("2.0");
+        assertThat(instance.getVersion()).isEqualTo(MockVersion.VERSION);
     }
 
-    @Test
-    public void getInfo() {
-        JsonObject info = instance.getInfo();
-
-        assertThat(info).isNotNull();
-        assertThat(info.getString("dist")).isEqualTo(MockVersion.VERSION);
-        assertThat(info.getJsonArray("versions"))
-            .containsExactlyElementsOf(Stream.of("1.0", "2.0")
-                .map(Json::createValue).collect(Collectors.toSet()));
-    }
 
     @Test
     public void getVersions() {

--- a/tessera-jaxrs/common-jaxrs/src/test/resources/META-INF/services/com.quorum.tessera.api.Version
+++ b/tessera-jaxrs/common-jaxrs/src/test/resources/META-INF/services/com.quorum.tessera.api.Version
@@ -1,0 +1,1 @@
+com.quorum.tessera.api.MockVersion

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/P2PRestAppIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/P2PRestAppIT.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.test.rest;
 
-import com.quorum.tessera.api.Version;
 import com.quorum.tessera.test.Party;
 import com.quorum.tessera.test.PartyHelper;
 import org.junit.*;
@@ -72,20 +71,7 @@ public class P2PRestAppIT {
         assertThat(response.getStatus()).isEqualTo(200);
     }
 
-    @Test
-    public void requestVersion() {
 
-        javax.ws.rs.core.Response response = client.target(actor.getP2PUri())
-                .path("/version")
-                .request()
-                .get();
-
-        assertThat(response).isNotNull();
-        assertThat(response.readEntity(String.class))
-                .isEqualTo(Version.getVersion());
-        assertThat(response.getStatus()).isEqualTo(200);
-
-    }
 
     @Test
     public void requestOpenApiSchema() throws IOException {

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.test.rest;
 
+import com.quorum.tessera.api.Version;
 import com.quorum.tessera.test.PartyHelper;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class VersionIT {
         allUris.forEach(u -> {
 
             String version = client.target(u).path("/version").request().get(String.class);
-            assertThat(version).isEqualTo("0.11.1");
+            assertThat(version).isEqualTo(Version.getVersion());
 
         });
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
@@ -30,13 +30,30 @@ public class VersionIT {
 
         allUris.forEach(u -> {
 
-            String version = client.target(u).path("/version").request().get(String.class);
+            String version = client.target(u).path("version").request().get(String.class);
             assertThat(version).isEqualTo(Version.getVersion());
 
         });
 
     }
+    @Test
+    public void getDistVersion() {
 
+        List<URI> allUris = partyHelper.getParties().flatMap(p ->
+            Stream.of(p.getQ2TUri(),p.getP2PUri())
+        ).collect(Collectors.toList());
+
+        allUris.forEach(u -> {
+
+            String version = client.target(u)
+                .path("version")
+                .path("distribution")
+                .request().get(String.class);
+            assertThat(version).isEqualTo(Version.getVersion());
+
+        });
+
+    }
     @Test
     public void getSupportedVersions() {
 
@@ -46,7 +63,10 @@ public class VersionIT {
 
         allUris.forEach(u -> {
 
-            JsonArray versions = client.target(u).path("/versions").request().get(JsonArray.class);
+            JsonArray versions = client.target(u)
+                .path("version")
+                .path("api")
+                .request().get(JsonArray.class);
             assertThat(versions.stream()
                 .map(JsonString.class::cast)
                 .map(JsonString::getString)

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
@@ -30,7 +30,7 @@ public class VersionIT {
         allUris.forEach(u -> {
 
             String version = client.target(u).path("/version").request().get(String.class);
-            assertThat(version).isEqualTo("2.0");
+            assertThat(version).isEqualTo("0.11.1");
 
         });
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
@@ -4,7 +4,6 @@ import com.quorum.tessera.test.PartyHelper;
 import org.junit.Test;
 
 import javax.json.JsonArray;
-import javax.json.JsonObject;
 import javax.json.JsonString;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -55,28 +54,7 @@ public class VersionIT {
         });
 
     }
-    @Test
-    public void getAllVersionInfo() {
 
-        List<URI> allUris = partyHelper.getParties().flatMap(p ->
-            Stream.of(p.getQ2TUri(),p.getP2PUri())
-        ).collect(Collectors.toList());
-
-        allUris.forEach(u -> {
-
-            JsonObject info = client.target(u).path("/version").path("info").request().get(JsonObject.class);
-            JsonArray versions = info.getJsonArray("versions");
-            assertThat(versions.stream()
-                .map(JsonString.class::cast)
-                .map(JsonString::getString)
-                .toArray(String[]::new)).containsExactly("1.0", "2.0");
-
-            String distVersion = info.getString("dist");
-            assertThat(distVersion).isNotNull();
-
-        });
-
-    }
 }
 
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
@@ -3,7 +3,9 @@ package com.quorum.tessera.test.rest;
 import com.quorum.tessera.test.PartyHelper;
 import org.junit.Test;
 
+import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonString;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import java.net.URI;
@@ -17,51 +19,65 @@ public class VersionIT {
 
     private final Client client = ClientBuilder.newClient();
 
-    private final PartyHelper partyHelper = PartyHelper.create();
+    private PartyHelper partyHelper = PartyHelper.create();
 
     @Test
     public void getVersion() {
-        final List<URI> allUris =
-                partyHelper
-                        .getParties()
-                        .flatMap(p -> Stream.of(p.getQ2TUri(), p.getP2PUri()))
-                        .collect(Collectors.toList());
 
-        allUris.forEach(
-                u -> {
-                    final String version = client.target(u).path("/version").request().get(String.class);
-                    assertThat(version).startsWith("0.11.1");
-                });
-    }
+        List<URI> allUris = partyHelper.getParties().flatMap(p ->
+            Stream.of(p.getQ2TUri(),p.getP2PUri())
+        ).collect(Collectors.toList());
 
-    @Test
-    public void getDistributionVersion() {
-        final List<URI> allUris =
-                partyHelper
-                        .getParties()
-                        .flatMap(p -> Stream.of(p.getQ2TUri(), p.getP2PUri()))
-                        .collect(Collectors.toList());
+        allUris.forEach(u -> {
 
-        allUris.forEach(
-                u -> {
-                    final String version = client.target(u).path("/version/distribution").request().get(String.class);
-                    assertThat(version).startsWith("0.11.1");
-                });
+            String version = client.target(u).path("/version").request().get(String.class);
+            assertThat(version).isEqualTo("2.0");
+
+        });
+
     }
 
     @Test
     public void getSupportedVersions() {
-        final List<URI> allUris =
-                partyHelper
-                        .getParties()
-                        .flatMap(p -> Stream.of(p.getQ2TUri(), p.getP2PUri()))
-                        .collect(Collectors.toList());
 
-        final String expectedVersionResponse = "{\"versions\":[{\"version\":\"1.0\"},{\"version\":\"2.0\"}]}";
-        allUris.forEach(
-                u -> {
-                    final JsonObject versions = client.target(u).path("/version/api").request().get(JsonObject.class);
-                    assertThat(versions.toString()).isEqualTo(expectedVersionResponse);
-                });
+        List<URI> allUris = partyHelper.getParties().flatMap(p ->
+            Stream.of(p.getQ2TUri(),p.getP2PUri())
+        ).collect(Collectors.toList());
+
+        allUris.forEach(u -> {
+
+            JsonArray versions = client.target(u).path("/versions").request().get(JsonArray.class);
+            assertThat(versions.stream()
+                .map(JsonString.class::cast)
+                .map(JsonString::getString)
+                .toArray(String[]::new)).containsExactly("1.0", "2.0");
+
+        });
+
+    }
+    @Test
+    public void getAllVersionInfo() {
+
+        List<URI> allUris = partyHelper.getParties().flatMap(p ->
+            Stream.of(p.getQ2TUri(),p.getP2PUri())
+        ).collect(Collectors.toList());
+
+        allUris.forEach(u -> {
+
+            JsonObject info = client.target(u).path("/version").path("info").request().get(JsonObject.class);
+            JsonArray versions = info.getJsonArray("versions");
+            assertThat(versions.stream()
+                .map(JsonString.class::cast)
+                .map(JsonString::getString)
+                .toArray(String[]::new)).containsExactly("1.0", "2.0");
+
+            String distVersion = info.getString("dist");
+            assertThat(distVersion).isNotNull();
+
+        });
+
     }
 }
+
+
+


### PR DESCRIPTION
`/version` continues to return distribution version for backward compatibility. To be removed or changed with api version in the future.
`version/api` returns all supported versions as a JsonArray


