### PR TITLE
Make the VersionResourceIT generic for any version

### DIFF
--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/VersionIT.java
@@ -1,5 +1,6 @@
 package com.quorum.tessera.test.rest;
 
+import com.quorum.tessera.api.Version;
 import com.quorum.tessera.test.PartyHelper;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class VersionIT {
         allUris.forEach(
                 u -> {
                     final String version = client.target(u).path("/version").request().get(String.class);
-                    assertThat(version).startsWith("0.11.1");
+                    assertThat(version).isEqualTo(Version.getVersion());
                 });
     }
 
@@ -45,7 +46,7 @@ public class VersionIT {
         allUris.forEach(
                 u -> {
                     final String version = client.target(u).path("/version/distribution").request().get(String.class);
-                    assertThat(version).startsWith("0.11.1");
+                    assertThat(version).isEqualTo(Version.getVersion());
                 });
     }
 


### PR DESCRIPTION
When a release happens, the app version gets updated automatically. The tests do not account for this, and so the test build will fail (causing either the release, or the version change merge back into master, to fail). 

Obtaining the version from the same source as the endpoint under test skirts the issue.