### PR TITLE
Fix process kill on integration tests

### DIFF
--- a/tests/acceptance-test/src/test/java/exec/ExecUtils.java
+++ b/tests/acceptance-test/src/test/java/exec/ExecUtils.java
@@ -60,23 +60,24 @@ public class ExecUtils {
         Optional<ProcessHandle> optionalProcessHandle = ProcessHandle.of(Long.valueOf(pid));
         try {
             ProcessHandle processHandle = optionalProcessHandle.get();
-            LOGGER.debug("Killing process: {}", processHandle.pid());
+            LOGGER.debug("Killing process, pid: {}", processHandle.pid());
             processHandle.destroy();
 
             for (int i = 0; i < 10; i++) {
                 if (processHandle.isAlive()) {
-                    LOGGER.debug("Waiting for process to exit: {}", processHandle.pid());
+                    LOGGER.debug("Waiting for process to exit, pid: {}", processHandle.pid());
                     try {
                         Thread.sleep(100L);
                     } catch (InterruptedException ex) {
                     }
                 } else {
-                    LOGGER.debug("Process successfully killed: {}", processHandle.pid());
-                    break;
+                    LOGGER.debug("Process successfully killed, pid: {}", processHandle.pid());
+                    return;
                 }
             }
         } catch (NoSuchElementException e) {
-            LOGGER.debug("No such process: {}", pid);
+            LOGGER.debug("No such process, pid: {}", pid);
         }
+        LOGGER.warn("Process did not exit yet, pid: {}", pid);
     }
 }

--- a/tests/acceptance-test/src/test/java/transaction/whitelist/WhitelistSteps.java
+++ b/tests/acceptance-test/src/test/java/transaction/whitelist/WhitelistSteps.java
@@ -38,7 +38,7 @@ public class WhitelistSteps implements En {
     private static final Logger LOGGER = LoggerFactory.getLogger(WhitelistSteps.class);
 
     private static String jarPath =
-        System.getProperty("application.jar", "../../tessera-app/target/tessera-app-0.9-SNAPSHOT-app.jar");
+            System.getProperty("application.jar", "../../tessera-app/target/tessera-app-0.9-SNAPSHOT-app.jar");
 
     private final URL logbackConfigFile = WhitelistSteps.class.getResource("/logback-node.xml");
 
@@ -54,133 +54,130 @@ public class WhitelistSteps implements En {
             ExecutorService executorService = Executors.newCachedThreadPool();
 
             Given(
-                "Node at port {int}",
-                (Integer port) -> {
-                    ExecutionContext executionContext =
-                        ExecutionContext.Builder.create()
-                            .with(CommunicationType.REST)
-                            .with(DBType.H2)
-                            .with(EnclaveType.LOCAL)
-                            .with(SocketType.HTTP)
-                            .with(EncryptorType.NACL)
-                            .build();
+                    "Node at port {int}",
+                    (Integer port) -> {
+                        ExecutionContext executionContext =
+                                ExecutionContext.Builder.create()
+                                        .with(CommunicationType.REST)
+                                        .with(DBType.H2)
+                                        .with(EnclaveType.LOCAL)
+                                        .with(SocketType.HTTP)
+                                        .with(EncryptorType.NACL)
+                                        .build();
 
-                    ConfigBuilder whiteListConfigBuilder =
-                        new ConfigBuilder()
-                            .withNodeId("whitelist")
-                            .withNodeNumber(5)
-                            .withQ2TSocketType(SocketType.HTTP)
-                            .withQt2Port(Q2T_PORT)
-                            .withExecutionContext(executionContext)
-                            .withP2pPort(port)
-                            .withEncryptorConfig(
-                                new EncryptorConfig() {
-                                    {
-                                        setType(EncryptorType.NACL);
+                        ConfigBuilder whiteListConfigBuilder =
+                                new ConfigBuilder()
+                                        .withNodeId("whitelist")
+                                        .withNodeNumber(5)
+                                        .withQ2TSocketType(SocketType.HTTP)
+                                        .withQt2Port(Q2T_PORT)
+                                        .withExecutionContext(executionContext)
+                                        .withP2pPort(port)
+                                        .withEncryptorConfig(
+                                                new EncryptorConfig() {
+                                                    {
+                                                        setType(EncryptorType.NACL);
+                                                    }
+                                                })
+                                        .withKeys(
+                                                "WxsJ4souK0mptNx1UGw6hb1WNNIbPhLPvW9GoaXau3Q=",
+                                                "YbOOFA4mwSSdGH6aFfGl2M7N1aiPOj5nHpD7GzJKSiA=");
+
+                        Config whiteListConfig = whiteListConfigBuilder.build();
+                        whiteListConfig.setUseWhiteList(true);
+
+                        Path configFile =
+                                Paths.get(System.getProperty("java.io.tmpdir")).resolve("white-list-config.json");
+
+                        try (OutputStream out = Files.newOutputStream(configFile)) {
+                            JaxbUtil.marshalWithNoValidation(whiteListConfig, out);
+                        } catch (IOException ex) {
+                            throw new UncheckedIOException(ex);
+                        }
+
+                        List<String> cmd =
+                                new ExecArgsBuilder()
+                                        .withMainClass(Main.class)
+                                        .withClassPathItem(Paths.get(jarPath))
+                                        .withConfigFile(configFile)
+                                        .withJvmArg("-Dlogback.configurationFile=" + logbackConfigFile)
+                                        .withJvmArg("-Dnode.number=whitelist")
+                                        .withPidFile(pid)
+                                        .build();
+
+                        ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+                        processBuilder.redirectErrorStream(true);
+
+                        Process process = processBuilder.start();
+
+                        executorService.submit(
+                                () -> {
+                                    try (BufferedReader reader =
+                                            Stream.of(process.getInputStream())
+                                                    .map(InputStreamReader::new)
+                                                    .map(BufferedReader::new)
+                                                    .findAny()
+                                                    .get()) {
+
+                                        String line;
+                                        while ((line = reader.readLine()) != null) {
+                                            LOGGER.info("Exec line Whitelist : {}", line);
+                                        }
+
+                                    } catch (IOException ex) {
+                                        throw new UncheckedIOException(ex);
                                     }
-                                })
-                            .withKeys(
-                                "WxsJ4souK0mptNx1UGw6hb1WNNIbPhLPvW9GoaXau3Q=",
-                                "YbOOFA4mwSSdGH6aFfGl2M7N1aiPOj5nHpD7GzJKSiA=");
+                                });
 
-                    Config whiteListConfig = whiteListConfigBuilder.build();
-                    whiteListConfig.setUseWhiteList(true);
+                        executorService.submit(
+                                () -> {
+                                    try {
+                                        process.waitFor();
+                                    } catch (InterruptedException ex) {
 
-                    Path configFile =
-                        Paths.get(System.getProperty("java.io.tmpdir")).resolve("white-list-config.json");
+                                    }
+                                });
 
-                    try (OutputStream out = Files.newOutputStream(configFile)) {
-                        JaxbUtil.marshalWithNoValidation(whiteListConfig, out);
-                    } catch (IOException ex) {
-                        throw new UncheckedIOException(ex);
-                    }
+                        ServerStatusCheck serverStatusCheck =
+                                ServerStatusCheck.create(
+                                        whiteListConfig.getServerConfigs().stream()
+                                                .filter(s -> s.getApp() == AppType.P2P)
+                                                .findAny()
+                                                .get());
 
-                    List<String> cmd =
-                        new ExecArgsBuilder()
-                            .withMainClass(Main.class)
-                            .withClassPathItem(Paths.get(jarPath))
-                            .withConfigFile(configFile)
-                            .withJvmArg("-Dlogback.configurationFile=" + logbackConfigFile)
-                            .withJvmArg("-Dnode.number=whitelist")
-                            .withPidFile(pid)
-                            .build();
+                        Boolean started =
+                                executorService
+                                        .submit(new ServerStatusCheckExecutor(serverStatusCheck))
+                                        .get(20, TimeUnit.SECONDS);
 
-                    ProcessBuilder processBuilder = new ProcessBuilder(cmd);
-                    processBuilder.redirectErrorStream(true);
-
-                    Process process = processBuilder.start();
-
-                    executorService.submit(
-                        () -> {
-                            try (BufferedReader reader =
-                                     Stream.of(process.getInputStream())
-                                         .map(InputStreamReader::new)
-                                         .map(BufferedReader::new)
-                                         .findAny()
-                                         .get()) {
-
-                                String line;
-                                while ((line = reader.readLine()) != null) {
-                                    LOGGER.info("Exec line Whitelist : {}", line);
-                                }
-
-                            } catch (IOException ex) {
-                                throw new UncheckedIOException(ex);
-                            }
-                        });
-
-                    executorService.submit(
-                        () -> {
-                            try {
-                                process.waitFor();
-                            } catch (InterruptedException ex) {
-
-                            }
-                        });
-
-                    ServerStatusCheck serverStatusCheck =
-                        ServerStatusCheck.create(
-                            whiteListConfig.getServerConfigs().stream()
-                                .filter(s -> s.getApp() == AppType.P2P)
-                                .findAny()
-                                .get());
-
-                    Boolean started =
-                        executorService
-                            .submit(new ServerStatusCheckExecutor(serverStatusCheck))
-                            .get(20, TimeUnit.SECONDS);
-
-                    assertThat(started).isTrue();
-                });
+                        assertThat(started).isTrue();
+                    });
 
             List<Response> responseHolder = new ArrayList<>();
             When(
-                "a request is made against the node",
-                () -> {
-                    Client client = ClientBuilder.newClient();
-                    Response response =
-                        client.target("http://localhost:" + P2P_PORT).path("upcheck").request().get();
+                    "a request is made against the node",
+                    () -> {
+                        Client client = ClientBuilder.newClient();
+                        Response response =
+                                client.target("http://localhost:" + P2P_PORT).path("upcheck").request().get();
 
-                    responseHolder.add(response);
-                });
-
-            Then(
-                "the response code is UNAUTHORIZED",
-                () -> assertThat(responseHolder.get(0).getStatus()).isEqualTo(401));
+                        responseHolder.add(response);
+                    });
 
             Then(
-                "the node is stopped",
-                () -> {
-                    Files.lines(pid)
-                        .findAny()
-                        .ifPresent(
-                            p -> {
-                                try {
-                                    ExecUtils.kill(p);
-                                } catch (IOException | InterruptedException ex) {
-                                }
-                            });
-                });
+                    "the response code is UNAUTHORIZED",
+                    () -> assertThat(responseHolder.get(0).getStatus()).isEqualTo(401));
+
+            Then(
+                    "the node is stopped",
+                    () -> {
+                        Files.lines(pid)
+                                .findAny()
+                                .ifPresent(
+                                        p -> {
+                                            ExecUtils.kill(p);
+                                        });
+                    });
 
         } catch (Exception ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
Whilst working on code changes for https://github.com/ConsenSys/tessera/issues/552, I found issues in the tests, where they attempt to drop database tables whilst they are in use by processed that are being killed.
This PR modifies ExecUtils.kill() so that it waits sufficient time for the process to die (otherwise it logs a message to assist with trouble shooting).