### PR TITLE
allow 'to' in ReceiveRequest to be null so /receive can be used by besu when using multi-tenancy

### DIFF
--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveRequest.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveRequest.java
@@ -21,7 +21,6 @@ public class ReceiveRequest {
     private String key;
 
     @Size(min = 1)
-    @NotNull
     @ApiModelProperty("Encoded recipient public key")
     private String to;
 


### PR DESCRIPTION
When multi-tenancy is enabled in besu and a block is imported, besu needs to call /receive without specifying the "to" when encountering a marker transaction, because private transactions for all tenants need to be retrieved.
The code in the receive method in q2t/TransactionResource does allow for the case that "to" is null. In that case all private keys available to the tessera instance will be used to try to decrypt the encrypted payload. 

Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>