### PR TITLE
Exclude CVE-2020-15250 junit vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,8 @@
 
                                 <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies">
                                     <excludeVulnerabilityIds>
-                                        33fe5e62-2998-4820-aebc-68e348539b22
+                                        <exclude>33fe5e62-2998-4820-aebc-68e348539b22</exclude>
+                                        <exclude>7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1</exclude>
                                     </excludeVulnerabilityIds>
                                 </banVulnerable>
 


### PR DESCRIPTION
In junit 4.13.1 (currently used) & java 1.7+ (currently java 11+) this vulnerability is fixed.

https://ossindex.sonatype.org/vuln/7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1?component-type=maven&component-name=junit.junit&utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1