### PR TITLE
Fixed InvalidUseOfMatchersException in AtomicLongSequenceTest.java

### DIFF
--- a/eclipselink-utils/src/test/java/com/quorum/tessera/eclipselink/AtomicLongSequenceTest.java
+++ b/eclipselink-utils/src/test/java/com/quorum/tessera/eclipselink/AtomicLongSequenceTest.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class AtomicLongSequenceTest {
@@ -63,7 +61,7 @@ public class AtomicLongSequenceTest {
     @Test(expected = UnsupportedOperationException.class)
     public void getGeneratedVectorIsNotSupported() {
         AtomicLongSequence atomicLongSequence = new AtomicLongSequence();
-        atomicLongSequence.getGeneratedVector(null,null,anyString(),anyInt());
+        atomicLongSequence.getGeneratedVector(null,null,new String(),0);
     }
 
     @Test


### PR DESCRIPTION
Fixed `InvalidUseOfMatchersException` that caused by method `getGeneratedVectorIsNotSupported()` in class `com.quorum.tessera.eclipselink.AtomicLongSequenceTest`.

- **Error msg:**
    ```
    Misplaced or misused argument matcher detected here:
    -> at  com.quorum.tessera.eclipselink.AtomicLongSequenceTest.getGeneratedVectorIsNotSupported(AtomicLongSequenceTest.java:66)
    -> at com.quorum.tessera.eclipselink.AtomicLongSequenceTest.getGeneratedVectorIsNotSupported(AtomicLongSequenceTest.java:66)
    ```

- **Root cause:**
It because it's using mockito` anyString()` & `anyInt()` while calling the test method, it should be used only for verifying a mock object to ensure a certain method is called with any string parameter inside the test, but not to invoke the test itself. 

The `InvalidUseOfMatchersException` is found by running [iDFlakies](https://github.com/idflakies/iDFlakies), after fixing the issue, there's no flaky tests in `AtomicLongSequenceTest.java`