### PR TITLE
Remove duplicate swagger operationIds 

### DIFF
--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.api;
 
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.xml.bind.annotation.XmlMimeType;

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
@@ -22,12 +22,8 @@ public class ReceiveResponse {
             allowableValues = {"0", "1", "3"})
     private int privacyFlag;
 
-    @ArraySchema(
-            arraySchema =
-                    @Schema(
-                            description =
-                                    "encoded payload hashes identifying all affected private contracts after tx simulation"),
-            schema = @Schema(format = "base64"))
+    @Schema(description =
+                "encoded payload hashes identifying all affected private contracts after tx simulation", format = "base64")
     private String[] affectedContractTransactions;
 
     @Schema(
@@ -35,12 +31,9 @@ public class ReceiveResponse {
             format = "base64")
     private String execHash;
 
-    @ArraySchema(
-            arraySchema =
-                    @Schema(
-                            description =
-                                    "participant public keys of key pairs managed by the enclave of this Tessera instance"),
-            schema = @Schema(format = "base64"))
+
+    @Schema(description = "participant public keys of key pairs managed by the enclave of this Tessera instance",
+            format = "base64")
     private String[] managedParties;
 
     public ReceiveResponse() {}

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/EncodedPayloadResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/EncodedPayloadResource.java
@@ -59,14 +59,8 @@ public class EncodedPayloadResource {
         this.transactionManager = Objects.requireNonNull(transactionManager);
     }
 
-    @Operation(
-            summary = "/encodedpayload/create",
-            operationId = "encrypt",
-            description = "encrypt a payload and return the result; does not store to the database or push to peers")
-    @ApiResponse(
-            responseCode = "200",
-            description = "encrypted payload",
-            content = @Content(schema = @Schema(implementation = PayloadEncryptResponse.class)))
+    // hide this operation from swagger generation; the /encodedpayload/create operation is overloaded and must be documented in a single place
+    @Hidden
     @POST
     @Path("create")
     @Consumes(APPLICATION_JSON)
@@ -133,7 +127,7 @@ public class EncodedPayloadResource {
         return Response.ok(response).type(APPLICATION_JSON).build();
     }
 
-    // hide this operation from swagger generation; the /decrypt operation is overloaded and must be documented in a single place
+    // hide this operation from swagger generation; the /encodedpayload/decrypt operation is overloaded and must be documented in a single place
     @Hidden
     @POST
     @Path("decrypt")
@@ -181,16 +175,25 @@ public class EncodedPayloadResource {
         return Response.ok(receiveResponse).type(APPLICATION_JSON).build();
     }
 
+    // path /encodedpayload/create is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
     @POST
     @Path("create")
     @Operation(
             summary = "/encodedpayload/create",
             operationId = "encrypt",
-            description = "encrypt a payload and return the result; does not store to the database or push to peers")
+            description = "encrypt a payload and return the result; does not store to the database or push to peers",
+            requestBody = @RequestBody(
+                content = {
+                    @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendRequest.class)),
+                    @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendRequest.class))
+                }
+            ))
     @ApiResponse(
             responseCode = "200",
             description = "encrypted payload",
-            content = @Content(schema = @Schema(implementation = PayloadEncryptResponse.class)))
+            content = {
+                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = PayloadEncryptResponse.class)),
+                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = PayloadEncryptResponse.class))})
     @Consumes(MIME_TYPE_JSON_2_1)
     @Produces(MIME_TYPE_JSON_2_1)
     public Response createEncodedPayload21(@NotNull @Valid final SendRequest sendRequest) {
@@ -255,7 +258,7 @@ public class EncodedPayloadResource {
         return Response.ok(response).type(MIME_TYPE_JSON_2_1).build();
     }
 
-    // path /decrypt is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
+    // path /encodedpayload/decrypt is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
     @POST
     @Path("decrypt")
     @Operation(

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/EncodedPayloadResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/EncodedPayloadResource.java
@@ -12,9 +12,11 @@ import com.quorum.tessera.enclave.TxHash;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.transaction.EncodedPayloadManager;
 import com.quorum.tessera.transaction.TransactionManager;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -131,15 +133,8 @@ public class EncodedPayloadResource {
         return Response.ok(response).type(APPLICATION_JSON).build();
     }
 
-    @Operation(
-            summary = "encodedpayload/decrypt",
-            operationId = "decrypt",
-            description =
-                    "decrypt an encrypted payload and return the result; does not store to the database or push to peers")
-    @ApiResponse(
-            responseCode = "200",
-            description = "decrypted payload",
-            content = @Content(schema = @Schema(implementation = ReceiveResponse.class)))
+    // hide this operation from swagger generation; the /decrypt operation is overloaded and must be documented in a single place
+    @Hidden
     @POST
     @Path("decrypt")
     @Consumes(APPLICATION_JSON)
@@ -260,17 +255,26 @@ public class EncodedPayloadResource {
         return Response.ok(response).type(MIME_TYPE_JSON_2_1).build();
     }
 
+    // path /decrypt is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
     @POST
     @Path("decrypt")
     @Operation(
-            summary = "encodedpayload/decrypt",
+            summary = "/encodedpayload/decrypt",
             operationId = "decrypt",
             description =
-                    "decrypt an encrypted payload and return the result; does not store to the database or push to peers")
+                    "decrypt an encrypted payload and return the result; does not store to the database or push to peers",
+            requestBody = @RequestBody(
+                content = {
+                    @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = PayloadDecryptRequest.class)),
+                    @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = PayloadDecryptRequest.class))
+                }
+            ))
     @ApiResponse(
             responseCode = "200",
             description = "decrypted payload",
-            content = @Content(schema = @Schema(implementation = ReceiveResponse.class)))
+            content = {
+                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ReceiveResponse.class)),
+                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = ReceiveResponse.class))})
     @Consumes(MIME_TYPE_JSON_2_1)
     @Produces(MIME_TYPE_JSON_2_1)
     public Response receive21(@Valid @NotNull final PayloadDecryptRequest request) {

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -56,14 +55,9 @@ public class TransactionResource {
         this.transactionManager = Objects.requireNonNull(transactionManager);
     }
 
-    @Operation(
-            summary = "/send",
-            operationId = "encryptStoreAndSendJson",
-            description = "encrypts a payload, stores result in database, and publishes result to recipients")
-    @ApiResponse(
-            responseCode = "201",
-            description = "encrypted payload hash",
-            content = @Content(schema = @Schema(implementation = SendResponse.class)))
+    // hide this operation from swagger generation; the /send operation is overloaded and must be documented in a single
+    // place
+    @Hidden
     @POST
     @Path("send")
     @Consumes(APPLICATION_JSON)
@@ -131,47 +125,9 @@ public class TransactionResource {
         return Response.status(Status.CREATED).type(APPLICATION_JSON).location(location).entity(sendResponse).build();
     }
 
-    @Operation(
-            operationId = "sendStored",
-            summary = "/sendsignedtx",
-            description =
-                    "re-wraps a pre-stored & pre-encrypted payload, stores result in database, and publishes result to recipients",
-            requestBody =
-                    @RequestBody(
-                            content = {
-                                @Content(
-                                        mediaType = APPLICATION_JSON,
-                                        schema = @Schema(implementation = SendSignedRequest.class)),
-                                @Content(
-                                        mediaType = APPLICATION_OCTET_STREAM,
-                                        array =
-                                                @ArraySchema(
-                                                        schema =
-                                                                @Schema(
-                                                                        description = "hash of pre-stored payload",
-                                                                        type = "string",
-                                                                        format = "base64")))
-                            }))
-    @ApiResponse(
-            responseCode = "200",
-            description = "hash of rewrapped payload (for application/octet-stream requests)",
-            content =
-                    @Content(
-                            schema =
-                                    @Schema(
-                                            description = "hash of rewrapped payload",
-                                            type = "string",
-                                            format = "base64")))
-    @ApiResponse(
-            responseCode = "201",
-            description = "hash of rewrapped payload (for application/json requests)",
-            content =
-                    @Content(
-                            mediaType = APPLICATION_JSON,
-                            schema =
-                                    @Schema(
-                                            implementation = SendResponse.class,
-                                            description = "hash of rewrapped payload")))
+    // hide this operation from swagger generation; the /sendsignedtx operation is overloaded and must be documented in
+    // a single place
+    @Hidden
     @POST
     @Path("sendsignedtx")
     @Consumes(APPLICATION_OCTET_STREAM)
@@ -219,8 +175,8 @@ public class TransactionResource {
         return Response.status(Status.OK).entity(encodedTransactionHash).location(location).build();
     }
 
-    // path /sendsignedtx is overloaded (application/octet-stream and application/json) annotations cannot handle
-    // situations like this so hide this operation and document both in the other methods
+    // hide this operation from swagger generation; the /sendsignedtx operation is overloaded and must be documented in
+    // a single place
     @Hidden
     @POST
     @Path("sendsignedtx")
@@ -361,14 +317,9 @@ public class TransactionResource {
         return Response.status(Status.OK).entity(encodedTransactionHash).location(location).build();
     }
 
-    @Operation(
-            summary = "/transaction/{hash}",
-            operationId = "getDecryptedPayloadJsonUrl",
-            description = "get payload from database, decrypt, and return")
-    @ApiResponse(
-            responseCode = "200",
-            description = "decrypted payload",
-            content = @Content(schema = @Schema(implementation = ReceiveResponse.class)))
+    // hide this operation from swagger generation; the /transaction/{hash} operation is overloaded and must be
+    // documented in a single place
+    @Hidden
     @GET
     @Path("/transaction/{hash}")
     @Produces(APPLICATION_JSON)

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
@@ -61,14 +61,22 @@ public class TransactionResource3 {
         this.transactionManager = Objects.requireNonNull(transactionManager);
     }
 
+    // path /send is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
     @Operation(
             summary = "/send",
             operationId = "encryptStoreAndSendJson",
-            description = "encrypts a payload, stores result in database, and publishes result to recipients")
+            description = "encrypts a payload, stores result in database, and publishes result to recipients",
+            requestBody = @RequestBody(content = {
+                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendRequest.class)),
+                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendRequest.class))
+            }))
     @ApiResponse(
             responseCode = "201",
             description = "encrypted payload hash",
-            content = @Content(schema = @Schema(implementation = SendResponse.class)))
+            content = {
+                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendResponse.class)),
+                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendResponse.class)),
+            })
     @POST
     @Path("send")
     @Consumes(MIME_TYPE_JSON_2_1)
@@ -140,37 +148,35 @@ public class TransactionResource3 {
         return Response.created(location).entity(sendResponse).build();
     }
 
+    // path /sendsignedtx is overloaded (application/octet-stream, application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
     @Operation(
-            operationId = "sendStored",
-            summary = "/sendsignedtx",
-            description =
-                    "re-wraps a pre-stored & pre-encrypted payload, stores result in database, and publishes result to recipients",
-            requestBody =
-                    @RequestBody(
-                            content = {
-                                @Content(
-                                        mediaType = APPLICATION_JSON,
-                                        schema = @Schema(implementation = SendSignedRequest.class)),
-                                @Content(
-                                        mediaType = APPLICATION_OCTET_STREAM,
-                                        array =
-                                                @ArraySchema(
-                                                        schema =
-                                                                @Schema(
-                                                                        description = "hash of pre-stored payload",
-                                                                        type = "string",
-                                                                        format = "base64")))
-                            }))
+        operationId = "sendStored",
+        summary = "/sendsignedtx",
+        description =
+            "re-wraps a pre-stored & pre-encrypted payload, stores result in database, and publishes result to recipients",
+        requestBody =
+        @RequestBody(
+            content = {
+                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendSignedRequest.class)),
+                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendSignedRequest.class)),
+                @Content(
+                    mediaType = APPLICATION_OCTET_STREAM,
+                    array =
+                    @ArraySchema(
+                        schema = @Schema(description = "hash of pre-stored payload", type = "string", format = "base64")))
+            }))
     @ApiResponse(
-            responseCode = "201",
-            description = "hash of rewrapped payload (for application/json requests)",
-            content =
-                    @Content(
-                            mediaType = APPLICATION_JSON,
-                            schema =
-                                    @Schema(
-                                            implementation = SendResponse.class,
-                                            description = "hash of rewrapped payload")))
+        responseCode = "200",
+        description = "hash of rewrapped payload (for application/octet-stream requests)",
+        content =
+        @Content(mediaType = APPLICATION_OCTET_STREAM, schema = @Schema(description = "hash of rewrapped payload", type = "string", format = "base64")))
+    @ApiResponse(
+        responseCode = "201",
+        description = "hash of rewrapped payload",
+        content = {
+            @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendResponse.class, description = "hash of rewrapped payload")),
+            @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendResponse.class, description = "hash of rewrapped payload"))
+        })
     @POST
     @Path("sendsignedtx")
     @Consumes(MIME_TYPE_JSON_2_1)
@@ -236,14 +242,19 @@ public class TransactionResource3 {
         return Response.created(location).entity(responseEntity).build();
     }
 
+    // path /transaction/{hash} is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
     @Operation(
-            summary = "/transaction/{hash}",
-            operationId = "getDecryptedPayloadJsonUrl",
-            description = "get payload from database, decrypt, and return")
+        summary = "/transaction/{hash}",
+        operationId = "getDecryptedPayloadJsonUrl",
+        description = "get payload from database, decrypt, and return"
+    )
     @ApiResponse(
-            responseCode = "200",
-            description = "decrypted payload",
-            content = @Content(schema = @Schema(implementation = ReceiveResponse.class)))
+        responseCode = "200",
+        description = "decrypted payload",
+        content = {
+            @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ReceiveResponse.class)),
+            @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = ReceiveResponse.class))
+        })
     @GET
     @Path("/transaction/{hash}")
     @Produces(MIME_TYPE_JSON_2_1)


### PR DESCRIPTION
Ensure each declared operationId is unique, and that overloaded endpoints' docs are declared in only one location so that they are formatted in the swagger doc as variations of the same endpoint