### PR TITLE
Add transaction sender to send/receive API responses

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/EncodedPayloadManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/EncodedPayloadManagerImpl.java
@@ -22,9 +22,8 @@ public class EncodedPayloadManagerImpl implements EncodedPayloadManager {
 
     private final MessageHashFactory messageHashFactory;
 
-    public EncodedPayloadManagerImpl(final Enclave enclave,
-                                     final PrivacyHelper privacyHelper,
-                                     final MessageHashFactory mhFactory) {
+    public EncodedPayloadManagerImpl(
+            final Enclave enclave, final PrivacyHelper privacyHelper, final MessageHashFactory mhFactory) {
         this.enclave = Objects.requireNonNull(enclave);
         this.privacyHelper = Objects.requireNonNull(privacyHelper);
         this.messageHashFactory = Objects.requireNonNull(mhFactory);
@@ -48,16 +47,20 @@ public class EncodedPayloadManagerImpl implements EncodedPayloadManager {
         LOGGER.debug("ExecHash for payload: {}", new String(request.getExecHash()));
 
         final List<AffectedTransaction> affectedContractTransactions =
-            privacyHelper.findAffectedContractTransactionsFromSendRequest(request.getAffectedContractTransactions());
+                privacyHelper.findAffectedContractTransactionsFromSendRequest(
+                        request.getAffectedContractTransactions());
 
         LOGGER.debug("Validating request against affected contracts");
         privacyHelper.validateSendRequest(privacyMode, recipientListNoDuplicate, affectedContractTransactions);
         LOGGER.debug("Successful validation against affected contracts");
 
         return enclave.encryptPayload(
-            request.getPayload(), senderPublicKey, recipientListNoDuplicate,
-            privacyMode, affectedContractTransactions, request.getExecHash()
-        );
+                request.getPayload(),
+                senderPublicKey,
+                recipientListNoDuplicate,
+                privacyMode,
+                affectedContractTransactions,
+                request.getExecHash());
     }
 
     @Override
@@ -66,26 +69,32 @@ public class EncodedPayloadManagerImpl implements EncodedPayloadManager {
         LOGGER.debug("Decrypt request for custom message with hash {}", customPayloadHash);
 
         final PublicKey recipientKey =
-            Optional.ofNullable(maybeDefaultRecipient)
-                .orElseGet(() -> searchForRecipientKey(payload).orElseThrow(() -> new RecipientKeyNotFoundException("No suitable recipient keys found to decrypt payload for " + customPayloadHash)));
+                Optional.ofNullable(maybeDefaultRecipient)
+                        .orElseGet(
+                                () ->
+                                        searchForRecipientKey(payload)
+                                                .orElseThrow(
+                                                        () ->
+                                                                new RecipientKeyNotFoundException(
+                                                                        "No suitable recipient keys found to decrypt payload for "
+                                                                                + customPayloadHash)));
         LOGGER.debug("Decryption key found: {}", recipientKey.encodeToBase64());
 
         final byte[] decryptedTransactionData = enclave.unencryptTransaction(payload, recipientKey);
 
-        final Set<MessageHash> txns = payload
-            .getAffectedContractTransactions()
-            .keySet()
-            .stream()
-            .map(TxHash::getBytes)
-            .map(MessageHash::new)
-            .collect(Collectors.toSet());
+        final Set<MessageHash> txns =
+                payload.getAffectedContractTransactions().keySet().stream()
+                        .map(TxHash::getBytes)
+                        .map(MessageHash::new)
+                        .collect(Collectors.toSet());
 
         return ReceiveResponse.Builder.create()
-            .withUnencryptedTransactionData(decryptedTransactionData)
-            .withPrivacyMode(payload.getPrivacyMode())
-            .withAffectedTransactions(txns)
-            .withExecHash(payload.getExecHash())
-            .build();
+                .withUnencryptedTransactionData(decryptedTransactionData)
+                .withPrivacyMode(payload.getPrivacyMode())
+                .withAffectedTransactions(txns)
+                .withExecHash(payload.getExecHash())
+                .withSender(payload.getSenderKey())
+                .build();
     }
 
     private Optional<PublicKey> searchForRecipientKey(final EncodedPayload payload) {
@@ -93,9 +102,15 @@ public class EncodedPayloadManagerImpl implements EncodedPayloadManager {
 
         for (final PublicKey potentialMatchingKey : enclave.getPublicKeys()) {
             try {
-                LOGGER.debug("Attempting to decrypt {} using key {}", customPayloadHash, potentialMatchingKey.encodeToBase64());
+                LOGGER.debug(
+                        "Attempting to decrypt {} using key {}",
+                        customPayloadHash,
+                        potentialMatchingKey.encodeToBase64());
                 enclave.unencryptTransaction(payload, potentialMatchingKey);
-                LOGGER.debug("Succeeded decrypting {} using key {}", customPayloadHash, potentialMatchingKey.encodeToBase64());
+                LOGGER.debug(
+                        "Succeeded decrypting {} using key {}",
+                        customPayloadHash,
+                        potentialMatchingKey.encodeToBase64());
                 return Optional.of(potentialMatchingKey);
             } catch (EnclaveException | IndexOutOfBoundsException | EncryptorException ex) {
                 LOGGER.debug("Attempted payload decryption using wrong key, discarding.");

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/ReceiveResponse.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/ReceiveResponse.java
@@ -21,6 +21,8 @@ public interface ReceiveResponse {
 
     Set<PublicKey> getManagedParties();
 
+    PublicKey sender();
+
     class Builder {
 
         private byte[] unencryptedTransactionData;
@@ -32,6 +34,8 @@ public interface ReceiveResponse {
         private Set<MessageHash> affectedTransactions = Collections.emptySet();
 
         private Set<PublicKey> managedParties = Collections.emptySet();
+
+        private PublicKey sender;
 
         private Builder() {}
 
@@ -64,10 +68,16 @@ public interface ReceiveResponse {
             return this;
         }
 
+        public Builder withSender(PublicKey sender) {
+            this.sender = sender;
+            return this;
+        }
+
         public ReceiveResponse build() {
 
             Objects.requireNonNull(unencryptedTransactionData, "unencrypted payload is required");
             Objects.requireNonNull(privacyMode, "Privacy mode is required");
+            Objects.requireNonNull(sender, "transaction sender is required");
 
             if (privacyMode == PrivacyMode.PRIVATE_STATE_VALIDATION) {
                 if (execHash.length == 0) {
@@ -100,6 +110,11 @@ public interface ReceiveResponse {
                 @Override
                 public Set<PublicKey> getManagedParties() {
                     return managedParties;
+                }
+
+                @Override
+                public PublicKey sender() {
+                    return sender;
                 }
             };
         }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/SendResponse.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/SendResponse.java
@@ -12,11 +12,15 @@ public interface SendResponse {
 
     Set<PublicKey> getManagedParties();
 
+    PublicKey getSender();
+
     class Builder {
 
         private MessageHash messageHash;
 
         private Set<PublicKey> managedParties;
+
+        private PublicKey sender;
 
         private Builder() {}
 
@@ -34,6 +38,11 @@ public interface SendResponse {
             return this;
         }
 
+        public Builder withSender(final PublicKey sender) {
+            this.sender = sender;
+            return this;
+        }
+
         public SendResponse build() {
             Objects.requireNonNull(messageHash, "Transaction hash is required");
 
@@ -47,6 +56,11 @@ public interface SendResponse {
                 @Override
                 public Set<PublicKey> getManagedParties() {
                     return managedParties;
+                }
+
+                @Override
+                public PublicKey getSender() {
+                    return sender;
                 }
             };
         }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -148,6 +148,7 @@ public class TransactionManagerImpl implements TransactionManager {
         return SendResponse.Builder.create()
                 .withMessageHash(transactionHash)
                 .withManagedParties(managedParties)
+                .withSender(payload.getSenderKey())
                 .build();
     }
 
@@ -209,7 +210,11 @@ public class TransactionManagerImpl implements TransactionManager {
         final Set<PublicKey> managedParties =
                 recipientListNoDuplicate.stream().filter(managedPublicKeys::contains).collect(Collectors.toSet());
 
-        return SendResponse.Builder.create().withMessageHash(messageHash).withManagedParties(managedParties).build();
+        return SendResponse.Builder.create()
+                .withMessageHash(messageHash)
+                .withManagedParties(managedParties)
+                .withSender(PublicKey.from(encryptedRawTransaction.getSender()))
+                .build();
     }
 
     @Override

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManagerImpl.java
@@ -372,6 +372,7 @@ public class TransactionManagerImpl implements TransactionManager {
                     .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
                     .withUnencryptedTransactionData(response)
                     .withManagedParties(Set.of(senderKey))
+                    .withSender(senderKey)
                     .build();
         }
 
@@ -427,6 +428,7 @@ public class TransactionManagerImpl implements TransactionManager {
                 .withAffectedTransactions(txns)
                 .withExecHash(payload.getExecHash())
                 .withManagedParties(managedParties)
+                .withSender(payload.getSenderKey())
                 .build();
     }
 

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/ReceiveResponseTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/ReceiveResponseTest.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.enclave.PrivacyMode;
+import com.quorum.tessera.encryption.PublicKey;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,6 +15,7 @@ public class ReceiveResponseTest {
                 ReceiveResponse.Builder.create()
                         .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
                         .withUnencryptedTransactionData(someData)
+                        .withSender(PublicKey.from("sender".getBytes()))
                         .build();
 
         assertThat(result.getUnencryptedTransactionData()).containsExactly(someData);
@@ -26,17 +28,33 @@ public class ReceiveResponseTest {
         ReceiveResponse.Builder.create()
                 .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                 .withUnencryptedTransactionData(someData)
+                .withSender(PublicKey.from("sender".getBytes()))
                 .build();
     }
 
     @Test(expected = NullPointerException.class)
     public void privacyModeIsRequired() {
         byte[] someData = "SomeData".getBytes();
-        ReceiveResponse.Builder.create().withUnencryptedTransactionData(someData).build();
+        ReceiveResponse.Builder.create()
+                .withUnencryptedTransactionData(someData)
+                .withSender(PublicKey.from("sender".getBytes()))
+                .build();
     }
 
     @Test(expected = NullPointerException.class)
     public void unencryptedTransactionDataIsRequired() {
-        ReceiveResponse.Builder.create().withPrivacyMode(PrivacyMode.STANDARD_PRIVATE).build();
+        ReceiveResponse.Builder.create()
+                .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                .withSender(PublicKey.from("sender".getBytes()))
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void senderIsRequired() {
+        byte[] someData = "SomeData".getBytes();
+        ReceiveResponse.Builder.create()
+                .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                .withUnencryptedTransactionData(someData)
+                .build();
     }
 }

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/SendResponseTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/SendResponseTest.java
@@ -19,11 +19,13 @@ public class SendResponseTest {
                 SendResponse.Builder.create()
                         .withMessageHash(transactionHash)
                         .withManagedParties(arbitraryManagedKeys)
+                        .withSender(PublicKey.from("sender".getBytes()))
                         .build();
 
         assertThat(response).isNotNull();
         assertThat(response.getTransactionHash()).isSameAs(transactionHash);
         assertThat(response.getManagedParties()).isSameAs(arbitraryManagedKeys);
+        assertThat(response.getSender()).isEqualTo(PublicKey.from("sender".getBytes()));
     }
 
     @Test(expected = NullPointerException.class)

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/TransactionManagerTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/TransactionManagerTest.java
@@ -838,6 +838,7 @@ public class TransactionManagerTest {
 
     @Test
     public void receive() {
+        PublicKey sender = PublicKey.from("sender".getBytes());
         byte[] randomData = Base64.getEncoder().encode("odd-data".getBytes());
         MessageHash messageHash = new MessageHash(randomData);
 
@@ -852,6 +853,7 @@ public class TransactionManagerTest {
         EncodedPayload payload = mock(EncodedPayload.class);
         when(payload.getExecHash()).thenReturn("execHash".getBytes());
         when(payload.getPrivacyMode()).thenReturn(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        when(payload.getSenderKey()).thenReturn(sender);
         when(payloadEncoder.decode(any(byte[].class))).thenReturn(payload);
 
         when(encryptedTransactionDAO.retrieveByHash(any(MessageHash.class)))
@@ -867,7 +869,7 @@ public class TransactionManagerTest {
         ReceiveResponse receiveResponse = transactionManager.receive(receiveRequest);
 
         assertThat(receiveResponse).isNotNull();
-
+        assertThat(receiveResponse.sender()).isEqualTo(sender);
         assertThat(receiveResponse.getUnencryptedTransactionData()).isEqualTo(expectedOutcome);
 
         verify(payloadEncoder).decode(any(byte[].class));
@@ -878,6 +880,7 @@ public class TransactionManagerTest {
 
     @Test
     public void receiveWithRecipientsPresent() {
+        final PublicKey sender = PublicKey.from("sender".getBytes());
         final PublicKey recipient1 = PublicKey.from("recipient1".getBytes());
         final PublicKey recipient2 = PublicKey.from("recipient2".getBytes());
 
@@ -896,6 +899,7 @@ public class TransactionManagerTest {
         when(payload.getExecHash()).thenReturn("execHash".getBytes());
         when(payload.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
         when(payload.getRecipientKeys()).thenReturn(List.of(recipient1, recipient2));
+        when(payload.getSenderKey()).thenReturn(sender);
         when(payloadEncoder.decode(any(byte[].class))).thenReturn(payload);
 
         when(encryptedTransactionDAO.retrieveByHash(any(MessageHash.class)))
@@ -911,6 +915,7 @@ public class TransactionManagerTest {
         assertThat(receiveResponse).isNotNull();
         assertThat(receiveResponse.getUnencryptedTransactionData()).isEqualTo(expectedOutcome);
         assertThat(receiveResponse.getManagedParties()).containsExactlyInAnyOrder(recipient1, recipient2);
+        assertThat(receiveResponse.sender()).isEqualTo(sender);
 
         verify(payloadEncoder).decode(any(byte[].class));
         verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));
@@ -920,6 +925,7 @@ public class TransactionManagerTest {
 
     @Test
     public void receiveWithNoRecipientsPresent() {
+        final PublicKey sender = PublicKey.from("sender".getBytes());
         final PublicKey recipient1 = PublicKey.from("recipient1".getBytes());
 
         byte[] randomData = Base64.getEncoder().encode("odd-data".getBytes());
@@ -934,6 +940,7 @@ public class TransactionManagerTest {
         EncryptedTransaction encryptedTransaction = new EncryptedTransaction(messageHash, randomData);
 
         EncodedPayload payload = mock(EncodedPayload.class);
+        when(payload.getSenderKey()).thenReturn(sender);
         when(payload.getExecHash()).thenReturn("execHash".getBytes());
         when(payload.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
         when(payload.getRecipientBoxes()).thenReturn(List.of(RecipientBox.from("box1".getBytes())));
@@ -952,6 +959,7 @@ public class TransactionManagerTest {
         assertThat(receiveResponse).isNotNull();
         assertThat(receiveResponse.getUnencryptedTransactionData()).isEqualTo(expectedOutcome);
         assertThat(receiveResponse.getManagedParties()).containsExactly(recipient1);
+        assertThat(receiveResponse.sender()).isEqualTo(sender);
 
         verify(payloadEncoder).decode(any(byte[].class));
         verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));
@@ -1007,7 +1015,7 @@ public class TransactionManagerTest {
 
     @Test
     public void receiveWithAffectedContractTransactions() {
-
+        PublicKey sender = PublicKey.from("sender".getBytes());
         byte[] keyData = Base64.getEncoder().encode("KEY".getBytes());
         PublicKey recipient = PublicKey.from("recipient".getBytes());
         MessageHash messageHash = new MessageHash(keyData);
@@ -1026,6 +1034,7 @@ public class TransactionManagerTest {
         when(payload.getExecHash()).thenReturn("execHash".getBytes());
         when(payload.getPrivacyMode()).thenReturn(PrivacyMode.PRIVATE_STATE_VALIDATION);
         when(payload.getAffectedContractTransactions()).thenReturn(affectedTxs);
+        when(payload.getSenderKey()).thenReturn(sender);
 
         when(payloadEncoder.decode(any(byte[].class))).thenReturn(payload);
 
@@ -1046,6 +1055,7 @@ public class TransactionManagerTest {
         assertThat(receiveResponse.getUnencryptedTransactionData()).isEqualTo(expectedOutcome);
         assertThat(receiveResponse.getExecHash()).isEqualTo("execHash".getBytes());
         assertThat(receiveResponse.getAffectedTransactions()).hasSize(1);
+        assertThat(receiveResponse.sender()).isEqualTo(sender);
 
         verify(payloadEncoder).decode(any(byte[].class));
         verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
@@ -21,8 +21,9 @@ public class ReceiveResponse {
             allowableValues = {"0", "1", "3"})
     private int privacyFlag;
 
-    @Schema(description =
-                "encoded payload hashes identifying all affected private contracts after tx simulation", format = "base64")
+    @Schema(
+            description = "encoded payload hashes identifying all affected private contracts after tx simulation",
+            format = "base64")
     private String[] affectedContractTransactions;
 
     @Schema(
@@ -30,10 +31,13 @@ public class ReceiveResponse {
             format = "base64")
     private String execHash;
 
-
-    @Schema(description = "participant public keys of key pairs managed by the enclave of this Tessera instance",
+    @Schema(
+            description = "participant public keys of key pairs managed by the enclave of this Tessera instance",
             format = "base64")
     private String[] managedParties;
+
+    @Schema(description = "public key of the transaction sender", format = "base64")
+    private String sender;
 
     public ReceiveResponse() {}
 
@@ -75,5 +79,13 @@ public class ReceiveResponse {
 
     public void setManagedParties(final String[] managedParties) {
         this.managedParties = managedParties;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(final String sender) {
+        this.sender = sender;
     }
 }

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/SendResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/SendResponse.java
@@ -15,7 +15,7 @@ public class SendResponse {
     @Schema(description = "participant public keys managed by the enclave of this Tessera node", format = "base64")
     private String[] managedParties;
 
-    @Schema(description = "encrypted payload hash", format = "base64")
+    @Schema(description = "public key of the transaction sender", format = "base64")
     private String sender;
 
     public SendResponse(final String key, final String[] managedParties, final String sender) {

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/SendResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/SendResponse.java
@@ -15,9 +15,13 @@ public class SendResponse {
     @Schema(description = "participant public keys managed by the enclave of this Tessera node", format = "base64")
     private String[] managedParties;
 
-    public SendResponse(final String key, final String[] managedParties) {
+    @Schema(description = "encrypted payload hash", format = "base64")
+    private String sender;
+
+    public SendResponse(final String key, final String[] managedParties, final String sender) {
         this.key = key;
         this.managedParties = managedParties;
+        this.sender = sender;
     }
 
     public SendResponse() {}
@@ -36,5 +40,13 @@ public class SendResponse {
 
     public void setManagedParties(final String[] managedParties) {
         this.managedParties = managedParties;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
     }
 }

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/ApiObjectTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/ApiObjectTest.java
@@ -21,15 +21,20 @@ public class ApiObjectTest {
 
     @Test
     public void nonEmptyConstructor() {
-        assertThat(new SendResponse("Data", new String[] {"arbitrary"}))
+        assertThat(new SendResponse("Data", new String[] {"arbitrary"}, "senderKey"))
                 .isNotNull()
                 .extracting(SendResponse::getKey)
                 .isNotNull();
 
-        assertThat(new SendResponse("Data", new String[] {"arbitrary"}))
+        assertThat(new SendResponse("Data", new String[] {"arbitrary"}, "senderKey"))
                 .isNotNull()
                 .extracting(SendResponse::getManagedParties)
                 .isNotNull();
+
+        assertThat(new SendResponse("Data", new String[] {"arbitrary"}, "senderKey"))
+                .isNotNull()
+                .extracting(SendResponse::getSender)
+                .containsExactly("senderKey");
 
         assertThat(new StoreRawResponse("Data".getBytes()))
                 .isNotNull()

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource.java
@@ -116,7 +116,7 @@ public class TransactionResource {
                         .map(com.quorum.tessera.transaction.SendResponse::getTransactionHash)
                         .map(MessageHash::getHashBytes)
                         .map(Base64.getEncoder()::encodeToString)
-                        .map(messageHash -> new SendResponse(messageHash, null))
+                        .map(messageHash -> new SendResponse(messageHash, null, null))
                         .get();
 
         final URI location =

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
@@ -267,6 +267,7 @@ public class TransactionResource3 {
         final SendResponse responseEntity = new SendResponse();
         responseEntity.setKey(encodedTransactionHash);
         responseEntity.setManagedParties(managedParties);
+        responseEntity.setSender(response.getSender().encodeToBase64());
 
         LOGGER.debug("Encoded key: {}", encodedTransactionHash);
 

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
@@ -61,15 +61,22 @@ public class TransactionResource3 {
         this.transactionManager = Objects.requireNonNull(transactionManager);
     }
 
-    // path /send is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
+    // path /send is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot
+    // handle situations like this so this operation documents both
     @Operation(
             summary = "/send",
             operationId = "encryptStoreAndSendJson",
             description = "encrypts a payload, stores result in database, and publishes result to recipients",
-            requestBody = @RequestBody(content = {
-                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendRequest.class)),
-                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendRequest.class))
-            }))
+            requestBody =
+                    @RequestBody(
+                            content = {
+                                @Content(
+                                        mediaType = APPLICATION_JSON,
+                                        schema = @Schema(implementation = SendRequest.class)),
+                                @Content(
+                                        mediaType = MIME_TYPE_JSON_2_1,
+                                        schema = @Schema(implementation = SendRequest.class))
+                            }))
     @ApiResponse(
             responseCode = "201",
             description = "encrypted payload hash",
@@ -148,35 +155,59 @@ public class TransactionResource3 {
         return Response.created(location).entity(sendResponse).build();
     }
 
-    // path /sendsignedtx is overloaded (application/octet-stream, application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
+    // path /sendsignedtx is overloaded (application/octet-stream, application/json and
+    // application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation
+    // documents both
     @Operation(
-        operationId = "sendStored",
-        summary = "/sendsignedtx",
-        description =
-            "re-wraps a pre-stored & pre-encrypted payload, stores result in database, and publishes result to recipients",
-        requestBody =
-        @RequestBody(
+            operationId = "sendStored",
+            summary = "/sendsignedtx",
+            description =
+                    "re-wraps a pre-stored & pre-encrypted payload, stores result in database, and publishes result to recipients",
+            requestBody =
+                    @RequestBody(
+                            content = {
+                                @Content(
+                                        mediaType = APPLICATION_JSON,
+                                        schema = @Schema(implementation = SendSignedRequest.class)),
+                                @Content(
+                                        mediaType = MIME_TYPE_JSON_2_1,
+                                        schema = @Schema(implementation = SendSignedRequest.class)),
+                                @Content(
+                                        mediaType = APPLICATION_OCTET_STREAM,
+                                        array =
+                                                @ArraySchema(
+                                                        schema =
+                                                                @Schema(
+                                                                        description = "hash of pre-stored payload",
+                                                                        type = "string",
+                                                                        format = "base64")))
+                            }))
+    @ApiResponse(
+            responseCode = "200",
+            description = "hash of rewrapped payload (for application/octet-stream requests)",
+            content =
+                    @Content(
+                            mediaType = APPLICATION_OCTET_STREAM,
+                            schema =
+                                    @Schema(
+                                            description = "hash of rewrapped payload",
+                                            type = "string",
+                                            format = "base64")))
+    @ApiResponse(
+            responseCode = "201",
+            description = "hash of rewrapped payload",
             content = {
-                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendSignedRequest.class)),
-                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendSignedRequest.class)),
                 @Content(
-                    mediaType = APPLICATION_OCTET_STREAM,
-                    array =
-                    @ArraySchema(
-                        schema = @Schema(description = "hash of pre-stored payload", type = "string", format = "base64")))
-            }))
-    @ApiResponse(
-        responseCode = "200",
-        description = "hash of rewrapped payload (for application/octet-stream requests)",
-        content =
-        @Content(mediaType = APPLICATION_OCTET_STREAM, schema = @Schema(description = "hash of rewrapped payload", type = "string", format = "base64")))
-    @ApiResponse(
-        responseCode = "201",
-        description = "hash of rewrapped payload",
-        content = {
-            @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SendResponse.class, description = "hash of rewrapped payload")),
-            @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = SendResponse.class, description = "hash of rewrapped payload"))
-        })
+                        mediaType = APPLICATION_JSON,
+                        schema =
+                                @Schema(
+                                        implementation = SendResponse.class,
+                                        description = "hash of rewrapped payload")),
+                @Content(
+                        mediaType = MIME_TYPE_JSON_2_1,
+                        schema =
+                                @Schema(implementation = SendResponse.class, description = "hash of rewrapped payload"))
+            })
     @POST
     @Path("sendsignedtx")
     @Consumes(MIME_TYPE_JSON_2_1)
@@ -242,19 +273,19 @@ public class TransactionResource3 {
         return Response.created(location).entity(responseEntity).build();
     }
 
-    // path /transaction/{hash} is overloaded (application/json and application/vnd.tessera-2.1+json); swagger annotations cannot handle situations like this so this operation documents both
+    // path /transaction/{hash} is overloaded (application/json and application/vnd.tessera-2.1+json); swagger
+    // annotations cannot handle situations like this so this operation documents both
     @Operation(
-        summary = "/transaction/{hash}",
-        operationId = "getDecryptedPayloadJsonUrl",
-        description = "get payload from database, decrypt, and return"
-    )
+            summary = "/transaction/{hash}",
+            operationId = "getDecryptedPayloadJsonUrl",
+            description = "get payload from database, decrypt, and return")
     @ApiResponse(
-        responseCode = "200",
-        description = "decrypted payload",
-        content = {
-            @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ReceiveResponse.class)),
-            @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = ReceiveResponse.class))
-        })
+            responseCode = "200",
+            description = "decrypted payload",
+            content = {
+                @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ReceiveResponse.class)),
+                @Content(mediaType = MIME_TYPE_JSON_2_1, schema = @Schema(implementation = ReceiveResponse.class))
+            })
     @GET
     @Path("/transaction/{hash}")
     @Produces(MIME_TYPE_JSON_2_1)
@@ -299,6 +330,7 @@ public class TransactionResource3 {
         com.quorum.tessera.transaction.ReceiveResponse response = transactionManager.receive(request);
 
         final ReceiveResponse receiveResponse = new ReceiveResponse();
+        receiveResponse.setSender(response.sender().encodeToBase64());
         receiveResponse.setPayload(response.getUnencryptedTransactionData());
         receiveResponse.setAffectedContractTransactions(
                 response.getAffectedTransactions().stream()

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource3.java
@@ -146,7 +146,7 @@ public class TransactionResource3 {
                         .map(com.quorum.tessera.transaction.SendResponse::getTransactionHash)
                         .map(MessageHash::getHashBytes)
                         .map(base64Encoder::encodeToString)
-                        .map(messageHash -> new SendResponse(messageHash, managedParties))
+                        .map(messageHash -> new SendResponse(messageHash, managedParties, sender.encodeToBase64()))
                         .get();
 
         final URI location =

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/EncodedPayloadResourceTest.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/EncodedPayloadResourceTest.java
@@ -180,6 +180,7 @@ public class EncodedPayloadResourceTest {
                         .withAffectedTransactions(
                                 Set.of(new MessageHash("tx1val".getBytes()), new MessageHash("tx2val".getBytes())))
                         .withExecHash("execHash".getBytes())
+                        .withSender(PublicKey.from(request.getSenderKey()))
                         .build();
 
         when(encodedPayloadManager.decrypt(any(), eq(null))).thenReturn(response);
@@ -326,6 +327,7 @@ public class EncodedPayloadResourceTest {
                         .withAffectedTransactions(
                                 Set.of(new MessageHash("tx1val".getBytes()), new MessageHash("tx2val".getBytes())))
                         .withExecHash("execHash".getBytes())
+                        .withSender(PublicKey.from(request.getSenderKey()))
                         .build();
 
         when(encodedPayloadManager.decrypt(any(), eq(null))).thenReturn(response);

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource3Test.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource3Test.java
@@ -312,6 +312,7 @@ public class TransactionResource3Test {
     @Test
     public void sendSignedTransactionEmptyRecipients() {
 
+        final PublicKey sender = PublicKey.from("sender".getBytes());
         com.quorum.tessera.transaction.SendResponse sendResponse =
                 mock(com.quorum.tessera.transaction.SendResponse.class);
 
@@ -321,6 +322,7 @@ public class TransactionResource3Test {
         when(transactionHash.getHashBytes()).thenReturn(transactionHashData);
 
         when(sendResponse.getTransactionHash()).thenReturn(transactionHash);
+        when(sendResponse.getSender()).thenReturn(sender);
 
         when(transactionManager.sendSignedTransaction(any(com.quorum.tessera.transaction.SendSignedRequest.class)))
                 .thenReturn(sendResponse);
@@ -340,6 +342,7 @@ public class TransactionResource3Test {
         SendResponse resultResponse = result.readEntity(SendResponse.class);
 
         assertThat(resultResponse.getKey()).isEqualTo(base64EncodedTransactionHAshData);
+        assertThat(resultResponse.getSender()).isEqualTo(sender.encodeToBase64());
 
         assertThat(result.getLocation()).hasPath("/transaction/".concat(base64EncodedTransactionHAshData));
 
@@ -373,6 +376,7 @@ public class TransactionResource3Test {
 
         when(sendResponse.getTransactionHash()).thenReturn(transactionHash);
         when(sendResponse.getManagedParties()).thenReturn(Set.of(sender));
+        when(sendResponse.getSender()).thenReturn(sender);
 
         when(transactionManager.sendSignedTransaction(any(com.quorum.tessera.transaction.SendSignedRequest.class)))
                 .thenReturn(sendResponse);
@@ -392,6 +396,7 @@ public class TransactionResource3Test {
 
         assertThat(resultResponse.getKey()).isEqualTo(base64EncodedTransactionHAshData);
         assertThat(resultResponse.getManagedParties()).containsExactlyInAnyOrder(sender.encodeToBase64());
+        assertThat(resultResponse.getSender()).isEqualTo(sender.encodeToBase64());
 
         assertThat(result.getLocation()).hasPath("/transaction/".concat(base64EncodedTransactionHAshData));
 
@@ -412,6 +417,9 @@ public class TransactionResource3Test {
 
     @Test
     public void sendSignedTransactionWithPrivacy() {
+        final PublicKey sender =
+                PublicKey.from(Base64.getDecoder().decode("QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc="));
+
         com.quorum.tessera.transaction.SendResponse sendResponse =
                 mock(com.quorum.tessera.transaction.SendResponse.class);
 
@@ -421,6 +429,7 @@ public class TransactionResource3Test {
         when(transactionHash.getHashBytes()).thenReturn(transactionHashData);
 
         when(sendResponse.getTransactionHash()).thenReturn(transactionHash);
+        when(sendResponse.getSender()).thenReturn(sender);
 
         when(transactionManager.sendSignedTransaction(any(com.quorum.tessera.transaction.SendSignedRequest.class)))
                 .thenReturn(sendResponse);
@@ -445,6 +454,7 @@ public class TransactionResource3Test {
         SendResponse resultResponse = result.readEntity(SendResponse.class);
 
         assertThat(resultResponse.getKey()).isEqualTo(base64EncodedTransactionHAshData);
+        assertThat(resultResponse.getSender()).isEqualTo(sender.encodeToBase64());
 
         assertThat(result.getLocation()).hasPath("/transaction/".concat(base64EncodedTransactionHAshData));
 

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource3Test.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource3Test.java
@@ -76,6 +76,7 @@ public class TransactionResource3Test {
                         .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
                         .withUnencryptedTransactionData("Result".getBytes())
                         .withManagedParties(Set.of(senderPublicKey))
+                        .withSender(senderPublicKey)
                         .build();
         when(transactionManager.receive(any())).thenReturn(receiveResponse);
 
@@ -89,6 +90,7 @@ public class TransactionResource3Test {
         assertThat(resultResponse.getPrivacyFlag()).isEqualTo(PrivacyMode.STANDARD_PRIVATE.getPrivacyFlag());
         assertThat(resultResponse.getPayload()).isEqualTo("Result".getBytes());
         assertThat(resultResponse.getManagedParties()).containsExactlyInAnyOrder(senderPublicKey.encodeToBase64());
+        assertThat(resultResponse.getSender()).isEqualTo(senderPublicKey.encodeToBase64());
 
         verify(transactionManager).receive(any(com.quorum.tessera.transaction.ReceiveRequest.class));
     }
@@ -104,6 +106,7 @@ public class TransactionResource3Test {
                         .withUnencryptedTransactionData("Success".getBytes())
                         .withExecHash("execHash".getBytes())
                         .withManagedParties(Set.of(senderPublicKey))
+                        .withSender(senderPublicKey)
                         .build();
 
         when(transactionManager.receive(any(com.quorum.tessera.transaction.ReceiveRequest.class))).thenReturn(response);
@@ -122,16 +125,19 @@ public class TransactionResource3Test {
         assertThat(resultResponse.getAffectedContractTransactions()).isNullOrEmpty();
         assertThat(resultResponse.getPayload()).isEqualTo("Success".getBytes());
         assertThat(resultResponse.getManagedParties()).containsExactlyInAnyOrder(senderPublicKey.encodeToBase64());
+        assertThat(resultResponse.getSender()).isEqualTo(senderPublicKey.encodeToBase64());
 
         verify(transactionManager).receive(any(com.quorum.tessera.transaction.ReceiveRequest.class));
     }
 
     @Test
     public void receive() {
+        PublicKey sender = PublicKey.from("sender".getBytes());
 
         ReceiveResponse response = mock(ReceiveResponse.class);
         when(response.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
         when(response.getUnencryptedTransactionData()).thenReturn("Success".getBytes());
+        when(response.sender()).thenReturn(sender);
 
         when(transactionManager.receive(any(com.quorum.tessera.transaction.ReceiveRequest.class))).thenReturn(response);
 
@@ -149,6 +155,7 @@ public class TransactionResource3Test {
         assertThat(resultResponse.getExecHash()).isNull();
         assertThat(resultResponse.getAffectedContractTransactions()).isNull();
         assertThat(resultResponse.getPayload()).isEqualTo("Success".getBytes());
+        assertThat(resultResponse.getSender()).isEqualTo(sender.encodeToBase64());
 
         verify(transactionManager).receive(any(com.quorum.tessera.transaction.ReceiveRequest.class));
     }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/multitenancy/ReceiveIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/multitenancy/ReceiveIT.java
@@ -88,6 +88,7 @@ public class ReceiveIT {
 
         assertThat(result.getPayload()).isEqualTo(transactionData);
         assertThat(result.getManagedParties()).containsExactly(partyOne.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(partyOne.getPublicKey());
     }
 
     @Test
@@ -109,6 +110,7 @@ public class ReceiveIT {
 
         assertThat(result.getPayload()).isEqualTo(transactionData);
         assertThat(result.getManagedParties()).containsExactly(partyTwo.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(partyOne.getPublicKey());
     }
 
     @Test
@@ -131,6 +133,7 @@ public class ReceiveIT {
 
         assertThat(result.getPayload()).isEqualTo(transactionData);
         assertThat(result.getManagedParties()).containsExactly(partyOne.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(partyOne.getPublicKey());
     }
 
     @Test

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/multitenancy/SendIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/multitenancy/SendIT.java
@@ -66,6 +66,7 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(firstParty.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(firstParty.getPublicKey());
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
@@ -123,6 +124,7 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(sendingParty.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(sendingParty.getPublicKey());
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
         URI location = response.getLocation();
@@ -133,6 +135,7 @@ public class SendIT {
             ReceiveResponse receiveResponse = checkPersistedTxnResponse.readEntity(ReceiveResponse.class);
             assertThat(receiveResponse.getPayload()).isEqualTo(transactionData);
             assertThat(result.getManagedParties()).containsExactlyInAnyOrder(sendingParty.getPublicKey());
+            assertThat(result.getSender()).isEqualTo(sendingParty.getPublicKey());
         }
         {
             String encodedId = URLEncoder.encode(result.getKey(), StandardCharsets.UTF_8.toString());
@@ -148,6 +151,7 @@ public class SendIT {
                                 ReceiveResponse receiveResponse = r.readEntity(ReceiveResponse.class);
                                 assertThat(receiveResponse.getManagedParties())
                                         .containsExactlyInAnyOrder(recipientPublicKeys);
+                                assertThat(receiveResponse.getSender()).isEqualTo(sendingParty.getPublicKey());
                             });
         }
     }
@@ -185,16 +189,18 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(recipientPublicKeys);
+        assertThat(result.getSender()).isEqualTo(recipientPublicKeys[0]);
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
         URI location = response.getLocation();
 
         {
-            final Response checkPersistedTxnResponse = client.target(location).request().get();
+            final Response checkPersistedTxnResponse =
+                    client.target(location).request().accept(MIME_TYPE_JSON_2_1).get();
             assertThat(checkPersistedTxnResponse.getStatus()).isEqualTo(200);
             ReceiveResponse receiveResponse = checkPersistedTxnResponse.readEntity(ReceiveResponse.class);
             assertThat(receiveResponse.getPayload()).isEqualTo(transactionData);
-            assertThat(result.getManagedParties()).containsExactlyInAnyOrder(recipientPublicKeys);
+            assertThat(receiveResponse.getManagedParties()).containsExactlyInAnyOrder(recipientPublicKeys);
         }
         {
             String encodedId = URLEncoder.encode(result.getKey(), StandardCharsets.UTF_8.toString());
@@ -210,6 +216,7 @@ public class SendIT {
                                 ReceiveResponse receiveResponse = r.readEntity(ReceiveResponse.class);
                                 assertThat(receiveResponse.getManagedParties())
                                         .containsExactlyInAnyOrder(recipientPublicKeys);
+                                assertThat(receiveResponse.getSender()).isEqualTo(recipientPublicKeys[0]);
                             });
         }
     }
@@ -242,6 +249,7 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(sendingParty.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(sendingParty.getPublicKey());
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
@@ -282,6 +290,7 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(recipient.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(recipient.getPublicKey());
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
@@ -316,6 +325,7 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(sendingParty.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(sendingParty.getPublicKey());
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
@@ -444,6 +454,7 @@ public class SendIT {
         final SendResponse result = response.readEntity(SendResponse.class);
         assertThat(result.getKey()).isNotNull().isNotBlank();
         assertThat(result.getManagedParties()).containsExactlyInAnyOrder(sender.getPublicKey());
+        assertThat(result.getSender()).isEqualTo(sender.getPublicKey());
 
         // Party one received by always send to
         utils.findTransaction(result.getKey(), sender, recipient, partyHelper.findByAlias("A"))


### PR DESCRIPTION
This PR adds the sender of a given transaction to the send/receive Q2T API response, which will be used in Quorum to facilitate the contract extension under multitenancy.

This new field will only be present in the `2.1` API version, and not the existing endpoints.