### PR TITLE
Fix OSS vunerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ subprojects {
         configFile project.getRootProject().file('checkstyle.xml')
         configProperties.put('checkstyle.suppressions.file',project.getRootProject().file('checkstyle-suppressions.xml'))
         dependencies{
-            checkstyle "com.puppycrawl.tools:checkstyle:8.30"
+            checkstyle "com.puppycrawl.tools:checkstyle:8.38"
             checkstyle "com.github.sevntu-checkstyle:sevntu-checks:1.37.1"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ allprojects {
 
                 compile "org.glassfish:jsonp-jaxrs:1.1.6"
 
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.4'
+                implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.6'
                 implementation 'com.squareup.retrofit2:adapter-rxjava:2.5.0'
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ allprojects {
 
                 compile "org.glassfish:jsonp-jaxrs:1.1.6"
 
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.6'
+                implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
                 implementation 'com.squareup.retrofit2:adapter-rxjava:2.5.0'
             }
         }

--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -8,4 +8,8 @@
     <suppress>
         <cpe>cpe:/a:checkstyle:checkstyle:1.37.1</cpe>
     </suppress>
+    <suppress>
+        <cpe>cpe:2.3:a:google:guava:1.0.1:*:*:*:*:*:*:*</cpe>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <owasp.plugin.version>5.0.0-M2</owasp.plugin.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.10.6</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
         <project.scm.id>github</project.scm.id>
         <asm.version>7.0</asm.version>
         <jasypt.version>1.9.3</jasypt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <owasp.plugin.version>5.0.0-M2</owasp.plugin.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.10.4</jackson.version>
+        <jackson.version>2.10.6</jackson.version>
         <project.scm.id>github</project.scm.id>
         <asm.version>7.0</asm.version>
         <jasypt.version>1.9.3</jasypt.version>

--- a/tests/jmeter-test/build.gradle
+++ b/tests/jmeter-test/build.gradle
@@ -4,5 +4,5 @@
 
 dependencies {
     testImplementation project(':tessera-dist:tessera-app')
-    testImplementation 'org.codehaus.groovy:groovy-all:2.4.16'
+    testImplementation 'org.codehaus.groovy:groovy-all:2.4.21'
 }

--- a/tests/jmeter-test/pom.xml
+++ b/tests/jmeter-test/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.16</version>
+            <version>2.4.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Bump following dependencies fixing OSS vulnerabilities
- jackson-databind (fix [CVE-2020-25649](https://ossindex.sonatype.org/vuln/f582b4ea-ef28-4d6e-93ad-15034025df21?component-type=maven&component-name=com.fasterxml.jackson.core.jackson-databind&utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1))
- groovy (fix [CVE-2020-17521](https://ossindex.sonatype.org/vuln/3c116113-715b-40df-b5bc-c64dfc3c9169?component-type=maven&component-name=org.codehaus.groovy.groovy-all&utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1))