### PR TITLE
Move version cmd test to an acceptance test

### DIFF
--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/PicoCliDelegateTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/PicoCliDelegateTest.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 import static com.quorum.tessera.test.util.ElUtil.createAndPopulatePaths;
 import static org.assertj.core.api.Assertions.*;
@@ -55,26 +54,6 @@ public class PicoCliDelegateTest {
         cliDelegate = new PicoCliDelegate();
         this.systemErrOutput.clearLog();
         this.systemOutOutput.clearLog();
-    }
-
-    @Test
-    public void version() throws Exception {
-        final CliResult result = cliDelegate.execute("version");
-
-        assertThat(result).isNotNull();
-        assertThat(result.getConfig()).isNotPresent();
-        assertThat(result.getStatus()).isEqualTo(0);
-        assertThat(result.isSuppressStartup()).isTrue();
-
-        final String syserr = systemErrOutput.getLog();
-        assertThat(syserr).isEmpty();
-
-        final String sysout = systemOutOutput.getLogWithNormalizedLineSeparator();
-        assertThat(sysout).isNotEmpty();
-
-        final String sysoutNoNewLine = sysout.replace("\n", "");
-
-        assertThat(sysoutNoNewLine).matches(Pattern.compile("^.*[0-9]{2}\\.[0-9]{1,2}(\\.[0-9]{1,2})?(-SNAPSHOT)?$"));
     }
 
     @Test

--- a/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/VersionCommandTest.java
+++ b/cli/config-cli/src/test/java/com/quorum/tessera/config/cli/VersionCommandTest.java
@@ -1,0 +1,19 @@
+package com.quorum.tessera.config.cli;
+
+import com.quorum.tessera.cli.CliResult;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionCommandTest {
+
+    @Test
+    public void call() {
+        VersionCommand cmd = new VersionCommand();
+
+        CliResult result = cmd.call();
+
+        CliResult want = new CliResult(0, true, null);
+        assertThat(result).isEqualToComparingFieldByField(want);
+    }
+}

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -75,6 +75,7 @@ test {
             '**/CucumberWhitelistIT.class',
             '**/ConfigMigrationIT.class',
             '**/CucumberFileKeyGenerationIT.class',
+            '**/CucumberVersionCliIT.class',
             '**/P2pTestSuite.class',
             '**/RunAwsIT.class',
             '**/RunAzureIT.class'

--- a/tests/acceptance-test/pom.xml
+++ b/tests/acceptance-test/pom.xml
@@ -208,6 +208,7 @@
                     <includes>
                         <include>RecoverIT</include>
                         <include>CucumberFileKeyGenerationIT</include>
+                        <include>CucumberVersionCliIT</include>
                         <include>RestSuiteHttpH2</include>
                         <include>RestSuiteHttpHSQL</include>
                         <include>RestSuiteHttpSqllite</include>
@@ -354,6 +355,7 @@
                             <rerunFailingTestsCount>0</rerunFailingTestsCount>
                             <includes>
                                 <include>CucumberFileKeyGenerationIT</include>
+                                <include>CucumberVersionCliIT</include>
                                 <include>AdminRestSuite</include>
                                 <include>RestSuiteSimple</include>
                                 <include>RestSuiteUnixH2</include>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/cli/CucumberVersionCliIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/cli/CucumberVersionCliIT.java
@@ -1,0 +1,13 @@
+package com.quorum.tessera.test.cli;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        glue = "com.quorum.tessera.test.cli.version",
+        features = "classpath:features/cli/version.feature",
+        monochrome = true,
+        plugin = {"progress"})
+public class CucumberVersionCliIT {}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/cli/version/VersionSteps.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/cli/version/VersionSteps.java
@@ -1,0 +1,87 @@
+package com.quorum.tessera.test.cli.version;
+
+import cucumber.api.java8.En;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionSteps implements En {
+
+    private static final URL logbackConfigFile = VersionSteps.class.getResource("/logback-node.xml");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VersionSteps.class);
+
+    private Process process;
+
+    private String capturedVersion;
+
+    public VersionSteps() {
+        When(
+                "^Tessera is started with \"([^\"]*)\" subcommand$",
+                (String subcmd) -> {
+                    final String appPath = System.getProperty("application.jar");
+
+                    if (Objects.equals("", appPath)) {
+                        throw new IllegalStateException("No application.jar system property defined");
+                    }
+
+                    final Path applicationJar = Paths.get(appPath);
+
+                    List<String> cmd =
+                            new ArrayList<>(
+                                    Arrays.asList(
+                                            "java",
+                                            "-Dlogback.configurationFile=" + logbackConfigFile.getFile(),
+                                            "-Dnode.number=versioncmd",
+                                            "-jar",
+                                            applicationJar.toString(),
+                                            subcmd));
+
+                    final ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+
+                    process = processBuilder.start();
+
+                    int exitCode = process.waitFor();
+
+                    assertThat(exitCode).isZero();
+                });
+
+        Then(
+            "^the distribution version is printed to stdout$",
+            () -> {
+                InputStream is = process.getInputStream();
+
+                List<String> cmdOutput =
+                    new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
+                        .lines()
+                        .collect(Collectors.toList());
+
+                LOGGER.info("tessera version cmd output: {}", String.join("\n", cmdOutput));
+
+                assertThat(cmdOutput).hasSize(1);
+                capturedVersion = cmdOutput.get(0);
+            });
+
+        Then(
+                "^the distribution version is in CalVer format$",
+                () -> {
+                    assertThat(capturedVersion)
+                            .matches(Pattern.compile("^[0-9]{2}\\.[0-9]{1,2}\\.[0-9]+(-SNAPSHOT)?$"));
+                });
+    }
+}

--- a/tests/acceptance-test/src/test/resources/features/cli/version.feature
+++ b/tests/acceptance-test/src/test/resources/features/cli/version.feature
@@ -1,0 +1,6 @@
+Feature: Version CLI
+
+    Scenario: User can get distribution version from CLI
+        When Tessera is started with "version" subcommand
+        Then the distribution version is printed to stdout
+        And the distribution version is in CalVer format


### PR DESCRIPTION
The `version` command relies on manifest file which requires the jar to be built.  Move the test to an acceptance test so that we can reliably test against the built jar's manifest.