### PR TITLE
Fix flaky server tests

### DIFF
--- a/server/jersey-server/build.gradle
+++ b/server/jersey-server/build.gradle
@@ -22,3 +22,7 @@ description = 'jersey-server'
 jacocoTestCoverageVerification {
     enabled false
 }
+
+test {
+    systemProperty "sun.net.http.allowRestrictedHeaders", true
+}

--- a/server/jersey-server/pom.xml
+++ b/server/jersey-server/pom.xml
@@ -136,6 +136,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Set `allowRestrictedHeaders` to true as required in version test