### PR TITLE
Include PrivacyGroupId in payload

### DIFF
--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/Enclave.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/Enclave.java
@@ -42,18 +42,14 @@ public interface Enclave extends Service {
      * @param message the message to be encrypted
      * @param senderPublicKey the public key which this enclave manages
      * @param recipientPublicKeys the recipients to encrypt this message for
-     * @param privacyMode the privacy flag of the transaction
-     * @param affectedContractTransactions the map of tx hash to encoded payloads
-     * @param execHash execution hash for psv transactions
+     * @param privacyMetadata privacy metadata of the transaction
      * @return the encrypted information, represented by an {@link EncodedPayload}
      */
     EncodedPayload encryptPayload(
             byte[] message,
             PublicKey senderPublicKey,
             List<PublicKey> recipientPublicKeys,
-            PrivacyMode privacyMode,
-            List<AffectedTransaction> affectedContractTransactions,
-            byte[] execHash);
+            PrivacyMetadata privacyMetadata);
 
     /**
      * Decrypts a {@link RawTransaction} so that it can be re-encrypted into a {@link EncodedPayload} with the given
@@ -61,14 +57,11 @@ public interface Enclave extends Service {
      *
      * @param rawTransaction the transaction to decrypt and re-encrypt with recipients
      * @param recipientPublicKeys the recipients to encrypt the transaction for
+     * @param privacyMetadata privacy metadata of the transaction
      * @return the encrypted information, represented by an {@link EncodedPayload}
      */
     EncodedPayload encryptPayload(
-            RawTransaction rawTransaction,
-            List<PublicKey> recipientPublicKeys,
-            PrivacyMode privacyMode,
-            List<AffectedTransaction> affectedContractTransactions,
-            byte[] execHash);
+            RawTransaction rawTransaction, List<PublicKey> recipientPublicKeys, PrivacyMetadata privacyMetadata);
 
     /**
      * Filters the affectedContractTransaction hashes by removing those that do not pass the security hash validation
@@ -92,8 +85,8 @@ public interface Enclave extends Service {
 
     /**
      * Decrypt a transaction and fetch the original message using the given public key. Throws an {@link
-     * com.quorum.tessera.encryption.EncryptorException} if the provided public key OR one of the Enclave's managed keys cannot be
-     * used to decrypt the payload
+     * com.quorum.tessera.encryption.EncryptorException} if the provided public key OR one of the Enclave's managed keys
+     * cannot be used to decrypt the payload
      *
      * @param payload the encrypted payload
      * @param providedKey the key to use for decryption, if the payload wasn't sent by this Enclave
@@ -102,8 +95,9 @@ public interface Enclave extends Service {
     byte[] unencryptTransaction(EncodedPayload payload, PublicKey providedKey);
 
     /**
-     * Decrypt a raw payload and fetch the original message. Throws an {@link com.quorum.tessera.encryption.EncryptorException} if
-     * the provided public key OR one of the Enclave's managed keys cannot be used to decrypt the payload
+     * Decrypt a raw payload and fetch the original message. Throws an {@link
+     * com.quorum.tessera.encryption.EncryptorException} if the provided public key OR one of the Enclave's managed keys
+     * cannot be used to decrypt the payload
      *
      * @param payload the encrypted raw payload
      * @return the original, decrypted message

--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/Enclave.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/Enclave.java
@@ -59,7 +59,7 @@ public interface Enclave extends Service {
      * Decrypts a {@link RawTransaction} so that it can be re-encrypted into a {@link EncodedPayload} with the given
      * recipient list
      *
-     * @param rawTransaction the transactiopn to decrypt and re-encrypt with recipients
+     * @param rawTransaction the transaction to decrypt and re-encrypt with recipients
      * @param recipientPublicKeys the recipients to encrypt the transaction for
      * @return the encrypted information, represented by an {@link EncodedPayload}
      */
@@ -92,7 +92,7 @@ public interface Enclave extends Service {
 
     /**
      * Decrypt a transaction and fetch the original message using the given public key. Throws an {@link
-     * com.quorum.tessera.nacl.NaclException} if the provided public key OR one of the Enclave's managed keys cannot be
+     * com.quorum.tessera.encryption.EncryptorException} if the provided public key OR one of the Enclave's managed keys cannot be
      * used to decrypt the payload
      *
      * @param payload the encrypted payload
@@ -102,7 +102,7 @@ public interface Enclave extends Service {
     byte[] unencryptTransaction(EncodedPayload payload, PublicKey providedKey);
 
     /**
-     * Decrypt a raw payload and fetch the original message. Throws an {@link com.quorum.tessera.nacl.NaclException} if
+     * Decrypt a raw payload and fetch the original message. Throws an {@link com.quorum.tessera.encryption.EncryptorException} if
      * the provided public key OR one of the Enclave's managed keys cannot be used to decrypt the payload
      *
      * @param payload the encrypted raw payload

--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/EncodedPayload.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/EncodedPayload.java
@@ -30,16 +30,16 @@ public class EncodedPayload {
     private final PrivacyGroup.Id privacyGroupId;
 
     private EncodedPayload(
-        final PublicKey senderKey,
-        final byte[] cipherText,
-        final Nonce cipherTextNonce,
-        final List<RecipientBox> recipientBoxes,
-        final Nonce recipientNonce,
-        final List<PublicKey> recipientKeys,
-        final PrivacyMode privacyMode,
-        final Map<TxHash, SecurityHash> affectedContractTransactions,
-        final byte[] execHash,
-        final PrivacyGroup.Id privacyGroupId) {
+            final PublicKey senderKey,
+            final byte[] cipherText,
+            final Nonce cipherTextNonce,
+            final List<RecipientBox> recipientBoxes,
+            final Nonce recipientNonce,
+            final List<PublicKey> recipientKeys,
+            final PrivacyMode privacyMode,
+            final Map<TxHash, SecurityHash> affectedContractTransactions,
+            final byte[] execHash,
+            final PrivacyGroup.Id privacyGroupId) {
         this.senderKey = senderKey;
         this.cipherText = cipherText;
         this.cipherTextNonce = cipherTextNonce;
@@ -103,22 +103,22 @@ public class EncodedPayload {
         public static Builder from(EncodedPayload encodedPayload) {
 
             final Map<TxHash, byte[]> affectedContractTransactionMap =
-                encodedPayload.getAffectedContractTransactions().entrySet().stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getData()));
+                    encodedPayload.getAffectedContractTransactions().entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getData()));
 
             final Builder builder =
-                create().withSenderKey(encodedPayload.getSenderKey())
-                    .withRecipientNonce(encodedPayload.getRecipientNonce())
-                    .withRecipientKeys(encodedPayload.getRecipientKeys())
-                    .withRecipientBoxes(
-                        encodedPayload.getRecipientBoxes().stream()
-                            .map(RecipientBox::getData)
-                            .collect(Collectors.toList()))
-                    .withCipherText(encodedPayload.getCipherText())
-                    .withCipherTextNonce(encodedPayload.getCipherTextNonce())
-                    .withPrivacyMode(encodedPayload.getPrivacyMode())
-                    .withAffectedContractTransactions(affectedContractTransactionMap)
-                    .withExecHash(encodedPayload.getExecHash());
+                    create().withSenderKey(encodedPayload.getSenderKey())
+                            .withRecipientNonce(encodedPayload.getRecipientNonce())
+                            .withRecipientKeys(encodedPayload.getRecipientKeys())
+                            .withRecipientBoxes(
+                                    encodedPayload.getRecipientBoxes().stream()
+                                            .map(RecipientBox::getData)
+                                            .collect(Collectors.toList()))
+                            .withCipherText(encodedPayload.getCipherText())
+                            .withCipherTextNonce(encodedPayload.getCipherTextNonce())
+                            .withPrivacyMode(encodedPayload.getPrivacyMode())
+                            .withAffectedContractTransactions(affectedContractTransactionMap)
+                            .withExecHash(encodedPayload.getExecHash());
 
             encodedPayload.getPrivacyGroupId().ifPresent(builder::withPrivacyGroupId);
 
@@ -229,29 +229,29 @@ public class EncodedPayload {
         public EncodedPayload build() {
 
             Map<TxHash, SecurityHash> affectedTransactions =
-                affectedContractTransactions.entrySet().stream()
-                    .collect(
-                        Collectors.toUnmodifiableMap(
-                            Map.Entry::getKey, e -> SecurityHash.from(e.getValue())));
+                    affectedContractTransactions.entrySet().stream()
+                            .collect(
+                                    Collectors.toUnmodifiableMap(
+                                            Map.Entry::getKey, e -> SecurityHash.from(e.getValue())));
 
             List<RecipientBox> recipientBoxes =
-                this.recipientBoxes.stream().map(RecipientBox::from).collect(Collectors.toList());
+                    this.recipientBoxes.stream().map(RecipientBox::from).collect(Collectors.toList());
 
             if ((privacyMode == PrivacyMode.PRIVATE_STATE_VALIDATION) == (execHash.length == 0)) {
                 throw new RuntimeException("ExecutionHash data is invalid");
             }
 
             return new EncodedPayload(
-                senderKey,
-                cipherText,
-                cipherTextNonce,
-                recipientBoxes,
-                recipientNonce,
-                recipientKeys,
-                privacyMode,
-                affectedTransactions,
-                execHash,
-                privacyGroupId);
+                    senderKey,
+                    cipherText,
+                    cipherTextNonce,
+                    recipientBoxes,
+                    recipientNonce,
+                    recipientKeys,
+                    privacyMode,
+                    affectedTransactions,
+                    execHash,
+                    privacyGroupId);
         }
     }
 
@@ -261,27 +261,27 @@ public class EncodedPayload {
         if (o == null || getClass() != o.getClass()) return false;
         EncodedPayload that = (EncodedPayload) o;
         return Objects.equals(senderKey, that.senderKey)
-            && Arrays.equals(cipherText, that.cipherText)
-            && Objects.equals(cipherTextNonce, that.cipherTextNonce)
-            && Objects.equals(recipientBoxes, that.recipientBoxes)
-            && Objects.equals(recipientNonce, that.recipientNonce)
-            && Objects.equals(recipientKeys, that.recipientKeys)
-            && privacyMode == that.privacyMode
-            && Arrays.equals(execHash, that.execHash)
-            && Objects.equals(privacyGroupId, that.privacyGroupId);
+                && Arrays.equals(cipherText, that.cipherText)
+                && Objects.equals(cipherTextNonce, that.cipherTextNonce)
+                && Objects.equals(recipientBoxes, that.recipientBoxes)
+                && Objects.equals(recipientNonce, that.recipientNonce)
+                && Objects.equals(recipientKeys, that.recipientKeys)
+                && privacyMode == that.privacyMode
+                && Arrays.equals(execHash, that.execHash)
+                && Objects.equals(privacyGroupId, that.privacyGroupId);
     }
 
     @Override
     public int hashCode() {
         int result =
-            Objects.hash(
-                senderKey,
-                cipherTextNonce,
-                recipientBoxes,
-                recipientNonce,
-                recipientKeys,
-                privacyMode,
-                privacyGroupId);
+                Objects.hash(
+                        senderKey,
+                        cipherTextNonce,
+                        recipientBoxes,
+                        recipientNonce,
+                        recipientKeys,
+                        privacyMode,
+                        privacyGroupId);
         result = 31 * result + Arrays.hashCode(cipherText);
         result = 31 * result + Arrays.hashCode(execHash);
         return result;

--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/PrivacyMetadata.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/PrivacyMetadata.java
@@ -1,0 +1,87 @@
+package com.quorum.tessera.enclave;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public interface PrivacyMetadata {
+
+    PrivacyMode getPrivacyMode();
+
+    List<AffectedTransaction> getAffectedContractTransactions();
+
+    byte[] getExecHash();
+
+    Optional<PrivacyGroup.Id> getPrivacyGroupId();
+
+    class Builder {
+
+        private PrivacyMode privacyMode;
+
+        private List<AffectedTransaction> affectedTransactions = Collections.emptyList();
+
+        private byte[] execHash = new byte[0];
+
+        private PrivacyGroup.Id privacyGroupId;
+
+        public static Builder create() {
+            return new Builder();
+        }
+
+        public Builder withPrivacyMode(PrivacyMode privacyMode) {
+            this.privacyMode = privacyMode;
+            return this;
+        }
+
+        public Builder withAffectedTransactions(List<AffectedTransaction> affectedTransactions) {
+            this.affectedTransactions = affectedTransactions;
+            return this;
+        }
+
+        public Builder withExecHash(byte[] execHash) {
+            this.execHash = execHash;
+            return this;
+        }
+
+        public Builder withPrivacyGroupId(PrivacyGroup.Id privacyGroupId) {
+            this.privacyGroupId = privacyGroupId;
+            return this;
+        }
+
+        public PrivacyMetadata build() {
+
+            Objects.requireNonNull(privacyMode, "privacyMode is required");
+
+            if ((privacyMode == PrivacyMode.PRIVATE_STATE_VALIDATION) == (execHash == null || execHash.length == 0)) {
+                throw new RuntimeException("ExecutionHash data is invalid");
+            }
+
+            return new PrivacyMetadata() {
+                @Override
+                public PrivacyMode getPrivacyMode() {
+                    return privacyMode;
+                }
+
+                @Override
+                public List<AffectedTransaction> getAffectedContractTransactions() {
+                    return affectedTransactions;
+                }
+
+                @Override
+                public byte[] getExecHash() {
+                    return execHash;
+                }
+
+                @Override
+                public Optional<PrivacyGroup.Id> getPrivacyGroupId() {
+                    return Optional.ofNullable(privacyGroupId);
+                }
+            };
+        }
+
+        public static Builder forStandardPrivate() {
+            return create().withPrivacyMode(PrivacyMode.STANDARD_PRIVATE);
+        }
+    }
+}

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/EnclaveTest.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/EnclaveTest.java
@@ -564,14 +564,11 @@ public class EnclaveTest {
         byte[] encryptedMasterKeys = "encryptedMasterKeys".getBytes();
         when(nacl.sealAfterPrecomputation(masterKeyBytes, recipientNonce, sharedKey)).thenReturn(encryptedMasterKeys);
 
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create().withPrivacyMode(PrivacyMode.STANDARD_PRIVATE).build();
+
         EncodedPayload result =
-                enclave.encryptPayload(
-                        message,
-                        senderPublicKey,
-                        Arrays.asList(recipientPublicKey),
-                        PrivacyMode.STANDARD_PRIVATE,
-                        emptyList(),
-                        null);
+                enclave.encryptPayload(message, senderPublicKey, Arrays.asList(recipientPublicKey), metaData);
 
         assertThat(result).isNotNull();
         assertThat(result.getRecipientKeys()).containsExactly(recipientPublicKey);
@@ -579,6 +576,7 @@ public class EnclaveTest {
         assertThat(result.getCipherTextNonce()).isEqualTo(cipherNonce);
         assertThat(result.getSenderKey()).isEqualTo(senderPublicKey);
         assertThat(result.getRecipientBoxes()).containsExactly(RecipientBox.from(encryptedMasterKeys));
+        assertThat(result.getPrivacyGroupId()).isNotPresent();
 
         verify(nacl).createMasterKey();
         verify(nacl, times(2)).randomNonce();
@@ -639,14 +637,14 @@ public class EnclaveTest {
 
         List<AffectedTransaction> affectedContractTransactions = List.of(affectedTransaction);
 
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedTransactions(affectedContractTransactions)
+                        .build();
+
         final EncodedPayload result =
-                enclave.encryptPayload(
-                        message,
-                        senderPublicKey,
-                        Arrays.asList(recipientPublicKey),
-                        PrivacyMode.STANDARD_PRIVATE,
-                        affectedContractTransactions,
-                        new byte[0]);
+                enclave.encryptPayload(message, senderPublicKey, Arrays.asList(recipientPublicKey), metaData);
 
         assertThat(result).isNotNull();
         assertThat(result.getRecipientKeys()).containsExactly(recipientPublicKey);
@@ -664,6 +662,61 @@ public class EnclaveTest {
         verify(nacl, times(2)).computeSharedKey(recipientPublicKey, senderPrivateKey);
         verify(keyManager, times(2)).getPrivateKeyForPublicKey(senderPublicKey);
         verify(keyManager).getPublicKeys();
+    }
+
+    @Test
+    public void encryptPayloadWithPrivacyGroupId() {
+
+        byte[] message = "MESSAGE".getBytes();
+
+        PublicKey senderPublicKey = mock(PublicKey.class);
+        PublicKey recipientPublicKey = mock(PublicKey.class);
+
+        byte[] masterKeyBytes = "masterKeyBytes".getBytes();
+        MasterKey masterKey = MasterKey.from(masterKeyBytes);
+        Nonce cipherNonce = mock(Nonce.class);
+        Nonce recipientNonce = mock(Nonce.class);
+
+        byte[] cipherText = "cipherText".getBytes();
+
+        when(nacl.createMasterKey()).thenReturn(masterKey);
+        when(nacl.randomNonce()).thenReturn(cipherNonce, recipientNonce);
+
+        when(nacl.sealAfterPrecomputation(message, cipherNonce, masterKey)).thenReturn(cipherText);
+
+        PrivateKey senderPrivateKey = mock(PrivateKey.class);
+        when(keyManager.getPrivateKeyForPublicKey(senderPublicKey)).thenReturn(senderPrivateKey);
+
+        SharedKey sharedKey = mock(SharedKey.class);
+        when(nacl.computeSharedKey(recipientPublicKey, senderPrivateKey)).thenReturn(sharedKey);
+
+        byte[] encryptedMasterKeys = "encryptedMasterKeys".getBytes();
+        when(nacl.sealAfterPrecomputation(masterKeyBytes, recipientNonce, sharedKey)).thenReturn(encryptedMasterKeys);
+
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP".getBytes()))
+                        .build();
+
+        EncodedPayload result =
+                enclave.encryptPayload(message, senderPublicKey, Arrays.asList(recipientPublicKey), metaData);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getRecipientKeys()).containsExactly(recipientPublicKey);
+        assertThat(result.getCipherText()).isEqualTo(cipherText);
+        assertThat(result.getCipherTextNonce()).isEqualTo(cipherNonce);
+        assertThat(result.getSenderKey()).isEqualTo(senderPublicKey);
+        assertThat(result.getRecipientBoxes()).containsExactly(RecipientBox.from(encryptedMasterKeys));
+        assertThat(result.getPrivacyGroupId()).isPresent();
+        assertThat(result.getPrivacyGroupId().get()).isEqualTo(PrivacyGroup.Id.fromBytes("GROUP".getBytes()));
+
+        verify(nacl).createMasterKey();
+        verify(nacl, times(2)).randomNonce();
+        verify(nacl).sealAfterPrecomputation(message, cipherNonce, masterKey);
+        verify(nacl).sealAfterPrecomputation(masterKeyBytes, recipientNonce, sharedKey);
+        verify(nacl).computeSharedKey(recipientPublicKey, senderPrivateKey);
+        verify(keyManager).getPrivateKeyForPublicKey(senderPublicKey);
     }
 
     @Test
@@ -703,13 +756,10 @@ public class EnclaveTest {
         byte[] encryptedMasterKeys = "encryptedMasterKeys".getBytes();
         when(nacl.sealAfterPrecomputation(masterKeyBytes, recipientNonce, sharedKey)).thenReturn(encryptedMasterKeys);
 
-        EncodedPayload result =
-                enclave.encryptPayload(
-                        rawTransaction,
-                        Arrays.asList(recipientPublicKey),
-                        PrivacyMode.STANDARD_PRIVATE,
-                        emptyList(),
-                        new byte[0]);
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create().withPrivacyMode(PrivacyMode.STANDARD_PRIVATE).build();
+
+        EncodedPayload result = enclave.encryptPayload(rawTransaction, Arrays.asList(recipientPublicKey), metaData);
 
         assertThat(result).isNotNull();
         assertThat(result.getRecipientKeys()).containsExactly(recipientPublicKey);
@@ -717,6 +767,69 @@ public class EnclaveTest {
         assertThat(result.getCipherTextNonce()).isEqualTo(cipherNonce);
         assertThat(result.getSenderKey()).isEqualTo(senderPublicKey);
         assertThat(result.getRecipientBoxes()).containsExactly(RecipientBox.from(encryptedMasterKeys));
+        assertThat(result.getPrivacyGroupId()).isNotPresent();
+
+        verify(nacl).randomNonce();
+        verify(nacl).openAfterPrecomputation(encryptedKeyBytes, cipherNonce, sharedKeyForSender);
+        verify(nacl).sealAfterPrecomputation(masterKeyBytes, recipientNonce, sharedKey);
+        verify(nacl).computeSharedKey(recipientPublicKey, senderPrivateKey);
+        verify(nacl).computeSharedKey(senderPublicKey, senderPrivateKey);
+        verify(keyManager, times(2)).getPrivateKeyForPublicKey(senderPublicKey);
+    }
+
+    @Test
+    public void encryptPayloadRawTransactionWithPrivacyGroupId() {
+
+        byte[] message = "MESSAGE".getBytes();
+
+        byte[] masterKeyBytes = "masterKeyBytes".getBytes();
+        MasterKey masterKey = MasterKey.from(masterKeyBytes);
+        PublicKey senderPublicKey = PublicKey.from("SENDER".getBytes());
+        PrivateKey senderPrivateKey = mock(PrivateKey.class);
+
+        PublicKey recipientPublicKey = PublicKey.from("RECIPIENT".getBytes());
+        Nonce cipherNonce = new Nonce("NONCE".getBytes());
+        byte[] cipherText = "cipherText".getBytes();
+        byte[] encryptedKeyBytes = "ENCRYPTED_KEY".getBytes();
+
+        RawTransaction rawTransaction = new RawTransaction(cipherText, encryptedKeyBytes, cipherNonce, senderPublicKey);
+
+        Nonce recipientNonce = mock(Nonce.class);
+
+        when(keyManager.getPrivateKeyForPublicKey(senderPublicKey)).thenReturn(senderPrivateKey);
+
+        SharedKey sharedKeyForSender = mock(SharedKey.class);
+        when(nacl.computeSharedKey(senderPublicKey, senderPrivateKey)).thenReturn(sharedKeyForSender);
+
+        when(nacl.openAfterPrecomputation(encryptedKeyBytes, cipherNonce, sharedKeyForSender))
+                .thenReturn(masterKeyBytes);
+
+        when(nacl.randomNonce()).thenReturn(recipientNonce);
+
+        when(nacl.sealAfterPrecomputation(message, cipherNonce, masterKey)).thenReturn(cipherText);
+
+        SharedKey sharedKey = mock(SharedKey.class);
+        when(nacl.computeSharedKey(recipientPublicKey, senderPrivateKey)).thenReturn(sharedKey);
+
+        byte[] encryptedMasterKeys = "encryptedMasterKeys".getBytes();
+        when(nacl.sealAfterPrecomputation(masterKeyBytes, recipientNonce, sharedKey)).thenReturn(encryptedMasterKeys);
+
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()))
+                        .build();
+
+        EncodedPayload result = enclave.encryptPayload(rawTransaction, Arrays.asList(recipientPublicKey), metaData);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getRecipientKeys()).containsExactly(recipientPublicKey);
+        assertThat(result.getCipherText()).isEqualTo(cipherText);
+        assertThat(result.getCipherTextNonce()).isEqualTo(cipherNonce);
+        assertThat(result.getSenderKey()).isEqualTo(senderPublicKey);
+        assertThat(result.getRecipientBoxes()).containsExactly(RecipientBox.from(encryptedMasterKeys));
+        assertThat(result.getPrivacyGroupId()).isPresent();
+        assertThat(result.getPrivacyGroupId().get()).isEqualTo(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()));
 
         verify(nacl).randomNonce();
         verify(nacl).openAfterPrecomputation(encryptedKeyBytes, cipherNonce, sharedKeyForSender);

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/EnclaveTest.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/EnclaveTest.java
@@ -76,6 +76,7 @@ public class EnclaveTest {
                         .withRecipientNonce(recipientNonce)
                         .withRecipientKeys(List.of(recipientKey, senderKey))
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("EXEC_HASH".getBytes())
                         .build();
 
         final PrivateKey recipientPrivateKey = PrivateKey.from("private-key".getBytes());
@@ -122,6 +123,7 @@ public class EnclaveTest {
                         .withRecipientNonce(recipientNonce)
                         .withRecipientKeys(List.of(recipientKey, senderKey))
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("EXEC_HASH".getBytes())
                         .build();
 
         final Throwable throwable = catchThrowable(() -> enclave.unencryptTransaction(payload, nonRecipientKey));

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/EncodedPayloadBuilderTest.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/EncodedPayloadBuilderTest.java
@@ -100,4 +100,63 @@ public class EncodedPayloadBuilderTest {
                 .usingGetClass()
                 .verify();
     }
+
+    @Test
+    public void withPrivacyGroupId() {
+        final EncodedPayload sample =
+            EncodedPayload.Builder.create()
+                .withSenderKey(senderKey)
+                .withCipherText(cipherText)
+                .withCipherTextNonce(cipherTextNonce)
+                .withRecipientBox(recipientBox)
+                .withRecipientNonce(recipientNonce)
+                .withPrivacyFlag(3)
+                .withAffectedContractTransactions(affectedContractTransactionsRaw)
+                .withExecHash(execHash)
+                .withRecipientKey(recipientKey)
+                .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("PRIVACYGROUPID".getBytes()))
+                .build();
+
+        final EncodedPayload result = EncodedPayload.Builder.from(sample).build();
+        assertThat(result).isNotSameAs(sample).isEqualTo(sample);
+
+        EqualsVerifier.forClass(EncodedPayload.class)
+            .withIgnoredFields("affectedContractTransactions")
+            .usingGetClass()
+            .verify();
+
+        assertThat(result.getPrivacyGroupId()).isPresent();
+        assertThat(result.getPrivacyGroupId().get()).isEqualTo(PrivacyGroup.Id.fromBytes("PRIVACYGROUPID".getBytes()));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void nonPSVButExecHashPresent() {
+        EncodedPayload.Builder.create()
+            .withSenderKey(senderKey)
+            .withCipherText(cipherText)
+            .withCipherTextNonce(cipherTextNonce)
+            .withRecipientBox(recipientBox)
+            .withRecipientNonce(recipientNonce)
+            .withPrivacyFlag(1)
+            .withAffectedContractTransactions(affectedContractTransactionsRaw)
+            .withExecHash(execHash)
+            .withRecipientKey(recipientKey)
+            .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("PRIVACYGROUPID".getBytes()))
+            .build();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void psvTxWithoutExecHash() {
+        EncodedPayload.Builder.create()
+            .withSenderKey(senderKey)
+            .withCipherText(cipherText)
+            .withCipherTextNonce(cipherTextNonce)
+            .withRecipientBox(recipientBox)
+            .withRecipientNonce(recipientNonce)
+            .withPrivacyFlag(3)
+            .withAffectedContractTransactions(affectedContractTransactionsRaw)
+            .withRecipientKey(recipientKey)
+            .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("PRIVACYGROUPID".getBytes()))
+            .build();
+    }
 }

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/PrivacyMetadataTest.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/PrivacyMetadataTest.java
@@ -1,0 +1,74 @@
+package com.quorum.tessera.enclave;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class PrivacyMetadataTest {
+
+    @Test
+    public void forStandardPrivate() {
+        final PrivacyMetadata metaData = PrivacyMetadata.Builder.forStandardPrivate().build();
+
+        assertThat(metaData).isNotNull();
+        assertThat(metaData.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(metaData.getPrivacyGroupId()).isNotPresent();
+    }
+
+    @Test
+    public void forStandardPrivateWithGroupId() {
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()))
+                        .build();
+
+        assertThat(metaData).isNotNull();
+        assertThat(metaData.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(metaData.getPrivacyGroupId()).isPresent();
+        assertThat(metaData.getPrivacyGroupId().get()).isEqualTo(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void forPartyProtectionInvalid() {
+        PrivacyMetadata.Builder.create()
+                .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                .withExecHash("hash".getBytes())
+                .build();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void forPsvInvalid() {
+        PrivacyMetadata.Builder.create()
+                .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()))
+                .withExecHash(null)
+                .build();
+    }
+
+    @Test
+    public void withEverything() {
+
+        final AffectedTransaction affected = mock(AffectedTransaction.class);
+
+        PrivacyGroup.Id id = PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes());
+
+        final PrivacyMetadata metaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withAffectedTransactions(List.of(affected))
+                        .withExecHash("execHash".getBytes())
+                        .withPrivacyGroupId(id)
+                        .build();
+
+        assertThat(metaData).isNotNull();
+        assertThat(metaData.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        assertThat(metaData.getAffectedContractTransactions()).containsExactly(affected);
+        assertThat(metaData.getExecHash()).isEqualTo("execHash".getBytes());
+        assertThat(metaData.getPrivacyGroupId()).isPresent();
+        assertThat(metaData.getPrivacyGroupId().get()).isEqualTo(id);
+    }
+}

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/EncoderCompatibilityTest.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/EncoderCompatibilityTest.java
@@ -1,0 +1,414 @@
+package com.quorum.tessera.enclave.encoder;
+
+import com.quorum.tessera.enclave.*;
+import com.quorum.tessera.encryption.Nonce;
+import com.quorum.tessera.encryption.PublicKey;
+import org.junit.Test;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EncoderCompatibilityTest {
+
+    private final LegacyPayloadEncoder legacyEncoder = new LegacyPayloadEncoder();
+
+    private final V2PayloadEncoder v2Encoder = new V2PayloadEncoder();
+
+    private final PayloadEncoder v3Encoder = new PayloadEncoderImpl();
+
+    @Test
+    public void test() {
+        String base64 =
+                "AAAAAAAAACAFQt5HwnJRaGK64IxT8csDRDmnORhP5wcgjdkoF7LcGgAAAAAAAAATTb9YJCMFHIPnjgOuf8kt2wQqYwAAAAAAAAAYs5vt/PiGQuNtk8T1mcgmqlBGOjoxvDabAAAAAAAAAAIAAAAAAAAAMPofTMvARcZ9sj+YTQjJ0ZVJboAWU/mQc/mWb+/A4UUcx/2QU8V5+BqJDTdZ0BkDFAAAAAAAAAAww5Ht0Fw6akO6sHuM6sosDQrV4RE6Co+9HL4uEgmEUs7s2qHtq2NwtPNSKarpH/sZAAAAAAAAABhrgQ71zS29K4OsrEeTiz0sYEyMSFD82XUAAAAAAAAAAgAAAAAAAAAgBULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3BoAAAAAAAAAIEH3gwMrPTDw7NlxxMbXPOIyhh8WYP2o+dg04dL7QN13AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAIPKMPIbszi5wrhf9FjbCF9F3G90JGHrpaZ0BxVWTw6zu";
+
+        byte[] encoded = Base64.getDecoder().decode(base64);
+
+        EncodedPayload payload = v3Encoder.decode(encoded);
+
+        System.out.println("Test");
+    }
+
+    @Test
+    public void legacyToV2() {
+
+        final LegacyEncodedPayload legacyPayload =
+                new LegacyEncodedPayload(
+                        PublicKey.from("SENDER".getBytes()),
+                        "cipherText".getBytes(),
+                        new Nonce("cipherTextNonce".getBytes()),
+                        List.of("box".getBytes()),
+                        new Nonce("recipientNonce".getBytes()),
+                        List.of(PublicKey.from("RECIPIENT".getBytes())));
+
+        final byte[] encoded = legacyEncoder.encode(legacyPayload);
+
+        final V2EncodedPayload v2Payload = v2Encoder.decode(encoded);
+
+        final List<RecipientBox> boxes =
+                legacyPayload.getRecipientBoxes().stream().map(RecipientBox::from).collect(Collectors.toList());
+
+        assertThat(v2Payload.getSenderKey()).isEqualTo(legacyPayload.getSenderKey());
+        assertThat(v2Payload.getCipherText()).isEqualTo(legacyPayload.getCipherText());
+        assertThat(v2Payload.getCipherTextNonce()).isEqualTo(legacyPayload.getCipherTextNonce());
+        assertThat(v2Payload.getRecipientBoxes()).isEqualTo(boxes);
+        assertThat(v2Payload.getRecipientNonce()).isEqualTo(legacyPayload.getRecipientNonce());
+        assertThat(v2Payload.getRecipientKeys()).isEqualTo(legacyPayload.getRecipientKeys());
+
+        // Default enhanced privacy values
+        assertThat(v2Payload.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(v2Payload.getAffectedContractTransactions()).isEmpty();
+        assertThat(v2Payload.getExecHash()).isNullOrEmpty();
+    }
+
+    @Test
+    public void v2ToLegacy() {
+
+        final V2EncodedPayload v2Payload =
+                V2EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptyMap())
+                        .build();
+
+        final byte[] encoded = v2Encoder.encode(v2Payload);
+
+        final LegacyEncodedPayload legacyPayload = legacyEncoder.decode(encoded);
+
+        final List<RecipientBox> boxes =
+                legacyPayload.getRecipientBoxes().stream().map(RecipientBox::from).collect(Collectors.toList());
+
+        assertThat(legacyPayload.getSenderKey()).isEqualTo(v2Payload.getSenderKey());
+        assertThat(legacyPayload.getCipherText()).isEqualTo(v2Payload.getCipherText());
+        assertThat(legacyPayload.getCipherTextNonce()).isEqualTo(v2Payload.getCipherTextNonce());
+        assertThat(boxes).isEqualTo(v2Payload.getRecipientBoxes());
+        assertThat(legacyPayload.getRecipientNonce()).isEqualTo(v2Payload.getRecipientNonce());
+        assertThat(legacyPayload.getRecipientKeys()).isEqualTo(v2Payload.getRecipientKeys());
+    }
+
+    @Test
+    public void v2toV3NonPsv() {
+
+        final V2EncodedPayload v2Payload =
+                V2EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedContractTransactions(Map.of(TxHash.from("hash".getBytes()), "hash".getBytes()))
+                        .build();
+
+        final byte[] encoded = v2Encoder.encode(v2Payload);
+
+        final EncodedPayload encodedPayload = v3Encoder.decode(encoded);
+
+        assertThat(encodedPayload.getSenderKey()).isEqualTo(v2Payload.getSenderKey());
+        assertThat(encodedPayload.getCipherText()).isEqualTo(v2Payload.getCipherText());
+        assertThat(encodedPayload.getCipherTextNonce()).isEqualTo(v2Payload.getCipherTextNonce());
+        assertThat(encodedPayload.getRecipientBoxes()).isEqualTo(v2Payload.getRecipientBoxes());
+        assertThat(encodedPayload.getRecipientNonce()).isEqualTo(v2Payload.getRecipientNonce());
+        assertThat(encodedPayload.getRecipientKeys()).isEqualTo(v2Payload.getRecipientKeys());
+
+        // Enhanced privacy values
+        assertThat(encodedPayload.getPrivacyMode()).isEqualTo(v2Payload.getPrivacyMode());
+        assertThat(encodedPayload.getAffectedContractTransactions())
+                .isEqualTo(v2Payload.getAffectedContractTransactions());
+        assertThat(encodedPayload.getExecHash()).isNullOrEmpty();
+
+        assertThat(encodedPayload.getPrivacyGroupId()).isEmpty();
+    }
+
+    @Test
+    public void v2toV3Psv() {
+
+        final V2EncodedPayload v2Payload =
+                V2EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withAffectedContractTransactions(Map.of(TxHash.from("hash".getBytes()), "hash".getBytes()))
+                        .withExecHash("execHash".getBytes())
+                        .build();
+
+        final byte[] encoded = v2Encoder.encode(v2Payload);
+
+        final EncodedPayload encodedPayload = v3Encoder.decode(encoded);
+
+        assertThat(encodedPayload.getSenderKey()).isEqualTo(v2Payload.getSenderKey());
+        assertThat(encodedPayload.getCipherText()).isEqualTo(v2Payload.getCipherText());
+        assertThat(encodedPayload.getCipherTextNonce()).isEqualTo(v2Payload.getCipherTextNonce());
+        assertThat(encodedPayload.getRecipientBoxes()).isEqualTo(v2Payload.getRecipientBoxes());
+        assertThat(encodedPayload.getRecipientNonce()).isEqualTo(v2Payload.getRecipientNonce());
+        assertThat(encodedPayload.getRecipientKeys()).isEqualTo(v2Payload.getRecipientKeys());
+
+        // Enhanced privacy values
+        assertThat(encodedPayload.getPrivacyMode()).isEqualTo(v2Payload.getPrivacyMode());
+        assertThat(encodedPayload.getAffectedContractTransactions())
+                .isEqualTo(v2Payload.getAffectedContractTransactions());
+        assertThat(encodedPayload.getExecHash()).isEqualTo(v2Payload.getExecHash());
+
+        assertThat(encodedPayload.getPrivacyGroupId()).isEmpty();
+    }
+
+    @Test
+    public void v3ToV2NonPsv() {
+
+        // Payload to a v2 node should not have privacyGroupId
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedContractTransactions(Map.of(TxHash.from("hash".getBytes()), "hash".getBytes()))
+                        //                .withPrivacyGroupId(PublicKey.from("GROUP_ID".getBytes()))
+                        .build();
+
+        final byte[] encoded = v3Encoder.encode(payload);
+
+        final V2EncodedPayload v2Payload = v2Encoder.decode(encoded);
+
+        assertThat(v2Payload.getSenderKey()).isEqualTo(payload.getSenderKey());
+        assertThat(v2Payload.getCipherText()).isEqualTo(payload.getCipherText());
+        assertThat(v2Payload.getCipherTextNonce()).isEqualTo(payload.getCipherTextNonce());
+        assertThat(v2Payload.getRecipientBoxes()).isEqualTo(payload.getRecipientBoxes());
+        assertThat(v2Payload.getRecipientNonce()).isEqualTo(payload.getRecipientNonce());
+        assertThat(v2Payload.getRecipientKeys()).isEqualTo(payload.getRecipientKeys());
+
+        // Enhanced privacy values
+        assertThat(v2Payload.getPrivacyMode()).isEqualTo(payload.getPrivacyMode());
+        assertThat(v2Payload.getAffectedContractTransactions()).isEqualTo(payload.getAffectedContractTransactions());
+        assertThat(v2Payload.getExecHash()).isNullOrEmpty();
+    }
+
+    @Test
+    public void v3ToV2Psv() {
+
+        // Payload to a v2 node should not have privacyGroupId
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withAffectedContractTransactions(Map.of(TxHash.from("hash".getBytes()), "hash".getBytes()))
+                        .withExecHash("EXEC_HASH".getBytes())
+                        //                .withPrivacyGroupId(PublicKey.from("GROUP_ID".getBytes()))
+                        .build();
+
+        final byte[] encoded = v3Encoder.encode(payload);
+
+        final V2EncodedPayload v2Payload = v2Encoder.decode(encoded);
+
+        assertThat(v2Payload.getSenderKey()).isEqualTo(payload.getSenderKey());
+        assertThat(v2Payload.getCipherText()).isEqualTo(payload.getCipherText());
+        assertThat(v2Payload.getCipherTextNonce()).isEqualTo(payload.getCipherTextNonce());
+        assertThat(v2Payload.getRecipientBoxes()).isEqualTo(payload.getRecipientBoxes());
+        assertThat(v2Payload.getRecipientNonce()).isEqualTo(payload.getRecipientNonce());
+        assertThat(v2Payload.getRecipientKeys()).isEqualTo(payload.getRecipientKeys());
+
+        // Enhanced privacy values
+        assertThat(v2Payload.getPrivacyMode()).isEqualTo(payload.getPrivacyMode());
+        assertThat(v2Payload.getAffectedContractTransactions()).isEqualTo(payload.getAffectedContractTransactions());
+        assertThat(v2Payload.getExecHash()).isEqualTo(payload.getExecHash());
+    }
+
+    @Test
+    public void legacyToV3() {
+
+        final LegacyEncodedPayload legacyPayload =
+                new LegacyEncodedPayload(
+                        PublicKey.from("SENDER".getBytes()),
+                        "cipherText".getBytes(),
+                        new Nonce("cipherTextNonce".getBytes()),
+                        List.of("box".getBytes()),
+                        new Nonce("recipientNonce".getBytes()),
+                        List.of(PublicKey.from("RECIPIENT".getBytes())));
+
+        final byte[] encoded = legacyEncoder.encode(legacyPayload);
+
+        final EncodedPayload payload = v3Encoder.decode(encoded);
+
+        final List<RecipientBox> boxes =
+                legacyPayload.getRecipientBoxes().stream().map(RecipientBox::from).collect(Collectors.toList());
+
+        assertThat(payload.getSenderKey()).isEqualTo(legacyPayload.getSenderKey());
+        assertThat(payload.getCipherText()).isEqualTo(legacyPayload.getCipherText());
+        assertThat(payload.getCipherTextNonce()).isEqualTo(legacyPayload.getCipherTextNonce());
+        assertThat(payload.getRecipientBoxes()).isEqualTo(boxes);
+        assertThat(payload.getRecipientNonce()).isEqualTo(legacyPayload.getRecipientNonce());
+        assertThat(payload.getRecipientKeys()).isEqualTo(legacyPayload.getRecipientKeys());
+
+        // Default enhanced privacy values
+        assertThat(payload.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(payload.getAffectedContractTransactions()).isEmpty();
+        assertThat(payload.getExecHash()).isNullOrEmpty();
+
+        assertThat(payload.getPrivacyGroupId()).isEmpty();
+    }
+
+    @Test
+    public void v3ToLegacy() {
+
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptyMap())
+                        .build();
+
+        final byte[] encoded = v3Encoder.encode(payload);
+
+        final LegacyEncodedPayload legacy = legacyEncoder.decode(encoded);
+
+        final List<RecipientBox> boxes =
+                legacy.getRecipientBoxes().stream().map(RecipientBox::from).collect(Collectors.toList());
+
+        assertThat(legacy.getSenderKey()).isEqualTo(payload.getSenderKey());
+        assertThat(legacy.getCipherText()).isEqualTo(payload.getCipherText());
+        assertThat(legacy.getCipherTextNonce()).isEqualTo(payload.getCipherTextNonce());
+        assertThat(boxes).isEqualTo(payload.getRecipientBoxes());
+        assertThat(legacy.getRecipientNonce()).isEqualTo(payload.getRecipientNonce());
+        assertThat(legacy.getRecipientKeys()).isEqualTo(payload.getRecipientKeys());
+    }
+
+    @Test
+    public void encodeDecodeV3StandardPrivate() {
+
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptyMap())
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()))
+                        .build();
+
+        final byte[] encoded = v3Encoder.encode(payload);
+
+        final EncodedPayload result = v3Encoder.decode(encoded);
+
+        assertThat(result.getSenderKey()).isEqualTo(payload.getSenderKey());
+        assertThat(result.getCipherText()).isEqualTo(payload.getCipherText());
+        assertThat(result.getCipherTextNonce()).isEqualTo(payload.getCipherTextNonce());
+        assertThat(result.getRecipientBoxes()).isEqualTo(payload.getRecipientBoxes());
+        assertThat(result.getRecipientNonce()).isEqualTo(payload.getRecipientNonce());
+        assertThat(result.getRecipientKeys()).isEqualTo(payload.getRecipientKeys());
+
+        assertThat(result.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(result.getAffectedContractTransactions()).isEmpty();
+        assertThat(result.getExecHash()).isNullOrEmpty();
+
+        assertThat(result.getPrivacyGroupId()).isEqualTo(payload.getPrivacyGroupId());
+    }
+
+    @Test
+    public void encodeDecodeV3PartyProtection() {
+
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedContractTransactions(
+                                Map.of(
+                                        TxHash.from("hash1".getBytes()),
+                                        "1".getBytes(),
+                                        TxHash.from("hash2".getBytes()),
+                                        "2".getBytes()))
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()))
+                        .build();
+
+        final byte[] encoded = v3Encoder.encode(payload);
+
+        final EncodedPayload result = v3Encoder.decode(encoded);
+
+        assertThat(result.getSenderKey()).isEqualTo(payload.getSenderKey());
+        assertThat(result.getCipherText()).isEqualTo(payload.getCipherText());
+        assertThat(result.getCipherTextNonce()).isEqualTo(payload.getCipherTextNonce());
+        assertThat(result.getRecipientBoxes()).isEqualTo(payload.getRecipientBoxes());
+        assertThat(result.getRecipientNonce()).isEqualTo(payload.getRecipientNonce());
+        assertThat(result.getRecipientKeys()).isEqualTo(payload.getRecipientKeys());
+
+        assertThat(result.getPrivacyMode()).isEqualTo(PrivacyMode.PARTY_PROTECTION);
+        assertThat(result.getAffectedContractTransactions()).isEqualTo(payload.getAffectedContractTransactions());
+        assertThat(result.getExecHash()).isNullOrEmpty();
+
+        assertThat(result.getPrivacyGroupId()).isEqualTo(payload.getPrivacyGroupId());
+    }
+
+    @Test
+    public void encodeDecodeV3PrivateStateValidation() {
+
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(PublicKey.from("SENDER".getBytes()))
+                        .withCipherText("CIPHER_TEXT".getBytes())
+                        .withCipherTextNonce(new Nonce("NONCE".getBytes()))
+                        .withRecipientBoxes(singletonList("recipientBox".getBytes()))
+                        .withRecipientNonce(new Nonce("recipientNonce".getBytes()))
+                        .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withAffectedContractTransactions(
+                                Map.of(
+                                        TxHash.from("hash1".getBytes()),
+                                        "1".getBytes(),
+                                        TxHash.from("hash2".getBytes()),
+                                        "2".getBytes()))
+                        .withExecHash("EXEC_HASH".getBytes())
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("GROUP_ID".getBytes()))
+                        .build();
+
+        final byte[] encoded = v3Encoder.encode(payload);
+
+        final EncodedPayload result = v3Encoder.decode(encoded);
+
+        assertThat(result.getSenderKey()).isEqualTo(payload.getSenderKey());
+        assertThat(result.getCipherText()).isEqualTo(payload.getCipherText());
+        assertThat(result.getCipherTextNonce()).isEqualTo(payload.getCipherTextNonce());
+        assertThat(result.getRecipientBoxes()).isEqualTo(payload.getRecipientBoxes());
+        assertThat(result.getRecipientNonce()).isEqualTo(payload.getRecipientNonce());
+        assertThat(result.getRecipientKeys()).isEqualTo(payload.getRecipientKeys());
+
+        assertThat(result.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        assertThat(result.getAffectedContractTransactions()).isEqualTo(payload.getAffectedContractTransactions());
+        assertThat(result.getExecHash()).isEqualTo(payload.getExecHash());
+
+        assertThat(result.getPrivacyGroupId()).isEqualTo(payload.getPrivacyGroupId());
+    }
+}

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/EncoderCompatibilityTest.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/EncoderCompatibilityTest.java
@@ -5,7 +5,6 @@ import com.quorum.tessera.encryption.Nonce;
 import com.quorum.tessera.encryption.PublicKey;
 import org.junit.Test;
 
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -20,18 +19,6 @@ public class EncoderCompatibilityTest {
     private final V2PayloadEncoder v2Encoder = new V2PayloadEncoder();
 
     private final PayloadEncoder v3Encoder = new PayloadEncoderImpl();
-
-    @Test
-    public void test() {
-        String base64 =
-                "AAAAAAAAACAFQt5HwnJRaGK64IxT8csDRDmnORhP5wcgjdkoF7LcGgAAAAAAAAATTb9YJCMFHIPnjgOuf8kt2wQqYwAAAAAAAAAYs5vt/PiGQuNtk8T1mcgmqlBGOjoxvDabAAAAAAAAAAIAAAAAAAAAMPofTMvARcZ9sj+YTQjJ0ZVJboAWU/mQc/mWb+/A4UUcx/2QU8V5+BqJDTdZ0BkDFAAAAAAAAAAww5Ht0Fw6akO6sHuM6sosDQrV4RE6Co+9HL4uEgmEUs7s2qHtq2NwtPNSKarpH/sZAAAAAAAAABhrgQ71zS29K4OsrEeTiz0sYEyMSFD82XUAAAAAAAAAAgAAAAAAAAAgBULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3BoAAAAAAAAAIEH3gwMrPTDw7NlxxMbXPOIyhh8WYP2o+dg04dL7QN13AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAIPKMPIbszi5wrhf9FjbCF9F3G90JGHrpaZ0BxVWTw6zu";
-
-        byte[] encoded = Base64.getDecoder().decode(base64);
-
-        EncodedPayload payload = v3Encoder.decode(encoded);
-
-        System.out.println("Test");
-    }
 
     @Test
     public void legacyToV2() {
@@ -180,7 +167,6 @@ public class EncoderCompatibilityTest {
                         .withRecipientKeys(List.of(PublicKey.from("KEY1".getBytes())))
                         .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
                         .withAffectedContractTransactions(Map.of(TxHash.from("hash".getBytes()), "hash".getBytes()))
-                        //                .withPrivacyGroupId(PublicKey.from("GROUP_ID".getBytes()))
                         .build();
 
         final byte[] encoded = v3Encoder.encode(payload);
@@ -215,7 +201,6 @@ public class EncoderCompatibilityTest {
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                         .withAffectedContractTransactions(Map.of(TxHash.from("hash".getBytes()), "hash".getBytes()))
                         .withExecHash("EXEC_HASH".getBytes())
-                        //                .withPrivacyGroupId(PublicKey.from("GROUP_ID".getBytes()))
                         .build();
 
         final byte[] encoded = v3Encoder.encode(payload);

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/LegacyEncodedPayload.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/LegacyEncodedPayload.java
@@ -1,0 +1,60 @@
+package com.quorum.tessera.enclave.encoder;
+
+import com.quorum.tessera.encryption.Nonce;
+import com.quorum.tessera.encryption.PublicKey;
+
+import java.util.List;
+
+public class LegacyEncodedPayload {
+
+    private final PublicKey senderKey;
+
+    private final byte[] cipherText;
+
+    private final Nonce cipherTextNonce;
+
+    private final List<byte[]> recipientBoxes;
+
+    private final Nonce recipientNonce;
+
+    private final List<PublicKey> recipientKeys;
+
+    public LegacyEncodedPayload(
+            final PublicKey senderKey,
+            final byte[] cipherText,
+            final Nonce cipherTextNonce,
+            final List<byte[]> recipientBoxes,
+            final Nonce recipientNonce,
+            final List<PublicKey> recipientKeys) {
+        this.senderKey = senderKey;
+        this.cipherText = cipherText;
+        this.cipherTextNonce = cipherTextNonce;
+        this.recipientNonce = recipientNonce;
+        this.recipientBoxes = recipientBoxes;
+        this.recipientKeys = recipientKeys;
+    }
+
+    public PublicKey getSenderKey() {
+        return senderKey;
+    }
+
+    public byte[] getCipherText() {
+        return cipherText;
+    }
+
+    public Nonce getCipherTextNonce() {
+        return cipherTextNonce;
+    }
+
+    public List<byte[]> getRecipientBoxes() {
+        return recipientBoxes;
+    }
+
+    public Nonce getRecipientNonce() {
+        return recipientNonce;
+    }
+
+    public List<PublicKey> getRecipientKeys() {
+        return recipientKeys;
+    }
+}

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/LegacyPayloadEncoder.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/LegacyPayloadEncoder.java
@@ -1,0 +1,103 @@
+package com.quorum.tessera.enclave.encoder;
+
+import com.quorum.tessera.enclave.BinaryEncoder;
+import com.quorum.tessera.encryption.Nonce;
+import com.quorum.tessera.encryption.PublicKey;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Do NOT change as this is a copy of the legacy payload encoder. The tests will use these logic to ensure the legacy
+ * encoder is still able to understand new encoded payload and vice versa
+ */
+public class LegacyPayloadEncoder implements BinaryEncoder {
+
+    public byte[] encode(final LegacyEncodedPayload payload) {
+
+        final byte[] senderKey = encodeField(payload.getSenderKey().getKeyBytes());
+        final byte[] cipherText = encodeField(payload.getCipherText());
+        final byte[] nonce = encodeField(payload.getCipherTextNonce().getNonceBytes());
+        final byte[] recipientNonce = encodeField(payload.getRecipientNonce().getNonceBytes());
+        final byte[] recipients = encodeArray(payload.getRecipientBoxes());
+        final byte[] recipientBytes =
+                encodeArray(payload.getRecipientKeys().stream().map(PublicKey::getKeyBytes).collect(toList()));
+
+        return ByteBuffer.allocate(
+                        senderKey.length
+                                + cipherText.length
+                                + nonce.length
+                                + recipients.length
+                                + recipientNonce.length
+                                + recipientBytes.length)
+                .put(senderKey)
+                .put(cipherText)
+                .put(nonce)
+                .put(recipients)
+                .put(recipientNonce)
+                .put(recipientBytes)
+                .array();
+    }
+
+    public LegacyEncodedPayload decode(final byte[] input) {
+        final ByteBuffer buffer = ByteBuffer.wrap(input);
+
+        final long senderSize = buffer.getLong();
+        final byte[] senderKey = new byte[Math.toIntExact(senderSize)];
+        buffer.get(senderKey);
+
+        final long cipherTextSize = buffer.getLong();
+        final byte[] cipherText = new byte[Math.toIntExact(cipherTextSize)];
+        buffer.get(cipherText);
+
+        final long nonceSize = buffer.getLong();
+        final byte[] nonce = new byte[Math.toIntExact(nonceSize)];
+        buffer.get(nonce);
+
+        final long numberOfRecipients = buffer.getLong();
+        final List<byte[]> recipientBoxes = new ArrayList<>();
+        for (long i = 0; i < numberOfRecipients; i++) {
+            final long boxSize = buffer.getLong();
+            final byte[] box = new byte[Math.toIntExact(boxSize)];
+            buffer.get(box);
+            recipientBoxes.add(box);
+        }
+
+        final long recipientNonceSize = buffer.getLong();
+        final byte[] recipientNonce = new byte[Math.toIntExact(recipientNonceSize)];
+        buffer.get(recipientNonce);
+
+        // this means there are no recipients in the payload (which we receive when we are a participant)
+        if (!buffer.hasRemaining()) {
+            return new LegacyEncodedPayload(
+                    PublicKey.from(senderKey),
+                    cipherText,
+                    new Nonce(nonce),
+                    recipientBoxes,
+                    new Nonce(recipientNonce),
+                    emptyList());
+        }
+
+        final long recipientLength = buffer.getLong();
+
+        final List<byte[]> recipientKeys = new ArrayList<>();
+        for (long i = 0; i < recipientLength; i++) {
+            final long boxSize = buffer.getLong();
+            final byte[] box = new byte[Math.toIntExact(boxSize)];
+            buffer.get(box);
+            recipientKeys.add(box);
+        }
+
+        return new LegacyEncodedPayload(
+                PublicKey.from(senderKey),
+                cipherText,
+                new Nonce(nonce),
+                recipientBoxes,
+                new Nonce(recipientNonce),
+                recipientKeys.stream().map(PublicKey::from).collect(toList()));
+    }
+}

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/V2EncodedPayload.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/V2EncodedPayload.java
@@ -1,0 +1,259 @@
+package com.quorum.tessera.enclave.encoder;
+
+import com.quorum.tessera.enclave.PrivacyMode;
+import com.quorum.tessera.enclave.RecipientBox;
+import com.quorum.tessera.enclave.SecurityHash;
+import com.quorum.tessera.enclave.TxHash;
+import com.quorum.tessera.encryption.Nonce;
+import com.quorum.tessera.encryption.PublicKey;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/** This class contains the data that is sent to other nodes */
+public class V2EncodedPayload {
+
+    private final PublicKey senderKey;
+
+    private final byte[] cipherText;
+
+    private final Nonce cipherTextNonce;
+
+    private final List<RecipientBox> recipientBoxes;
+
+    private final Nonce recipientNonce;
+
+    private final List<PublicKey> recipientKeys;
+
+    private final PrivacyMode privacyMode;
+
+    private final Map<TxHash, SecurityHash> affectedContractTransactions;
+
+    private final byte[] execHash;
+
+    private V2EncodedPayload(
+            final PublicKey senderKey,
+            final byte[] cipherText,
+            final Nonce cipherTextNonce,
+            final List<RecipientBox> recipientBoxes,
+            final Nonce recipientNonce,
+            final List<PublicKey> recipientKeys,
+            final PrivacyMode privacyMode,
+            final Map<TxHash, SecurityHash> affectedContractTransactions,
+            final byte[] execHash) {
+        this.senderKey = senderKey;
+        this.cipherText = cipherText;
+        this.cipherTextNonce = cipherTextNonce;
+        this.recipientNonce = recipientNonce;
+        this.recipientBoxes = recipientBoxes;
+        this.recipientKeys = recipientKeys;
+        this.privacyMode = privacyMode;
+        this.affectedContractTransactions = affectedContractTransactions;
+        this.execHash = execHash;
+    }
+
+    public PublicKey getSenderKey() {
+        return senderKey;
+    }
+
+    public byte[] getCipherText() {
+        return cipherText;
+    }
+
+    public Nonce getCipherTextNonce() {
+        return cipherTextNonce;
+    }
+
+    public List<RecipientBox> getRecipientBoxes() {
+        return Collections.unmodifiableList(recipientBoxes);
+    }
+
+    public Nonce getRecipientNonce() {
+        return recipientNonce;
+    }
+
+    public List<PublicKey> getRecipientKeys() {
+        return recipientKeys;
+    }
+
+    public PrivacyMode getPrivacyMode() {
+        return privacyMode;
+    }
+
+    public Map<TxHash, SecurityHash> getAffectedContractTransactions() {
+        return Collections.unmodifiableMap(affectedContractTransactions);
+    }
+
+    public byte[] getExecHash() {
+        return execHash;
+    }
+
+    public static class Builder {
+
+        private Builder() {}
+
+        public static Builder create() {
+            return new Builder();
+        }
+
+        public static Builder from(V2EncodedPayload encodedPayload) {
+
+            final Map<TxHash, byte[]> affectedContractTransactionMap =
+                    encodedPayload.getAffectedContractTransactions().entrySet().stream()
+                            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getData()));
+
+            return create().withPrivacyMode(encodedPayload.getPrivacyMode())
+                    .withSenderKey(encodedPayload.getSenderKey())
+                    .withRecipientNonce(encodedPayload.getRecipientNonce())
+                    .withRecipientKeys(encodedPayload.getRecipientKeys())
+                    .withRecipientBoxes(
+                            encodedPayload.getRecipientBoxes().stream()
+                                    .map(RecipientBox::getData)
+                                    .collect(Collectors.toList()))
+                    .withPrivacyMode(encodedPayload.getPrivacyMode())
+                    .withExecHash(encodedPayload.getExecHash())
+                    .withCipherText(encodedPayload.getCipherText())
+                    .withCipherTextNonce(encodedPayload.getCipherTextNonce())
+                    .withAffectedContractTransactions(affectedContractTransactionMap);
+        }
+
+        private PublicKey senderKey;
+
+        private byte[] cipherText;
+
+        private Nonce cipherTextNonce;
+
+        private Nonce recipientNonce;
+
+        private List<byte[]> recipientBoxes = new ArrayList<>();
+
+        private List<PublicKey> recipientKeys = new ArrayList<>();
+
+        private PrivacyMode privacyMode = PrivacyMode.STANDARD_PRIVATE;
+
+        private Map<TxHash, byte[]> affectedContractTransactions = Collections.emptyMap();
+
+        private byte[] execHash = new byte[0];
+
+        public Builder withSenderKey(final PublicKey senderKey) {
+            this.senderKey = senderKey;
+            return this;
+        }
+
+        public Builder withCipherText(final byte[] cipherText) {
+            this.cipherText = cipherText;
+            return this;
+        }
+
+        public Builder withRecipientKey(PublicKey publicKey) {
+            this.recipientKeys.add(publicKey);
+            return this;
+        }
+
+        public Builder withRecipientKeys(final List<PublicKey> recipientKeys) {
+            this.recipientKeys.addAll(recipientKeys);
+            return this;
+        }
+
+        public Builder withNewRecipientKeys(final List<PublicKey> recipientKeys) {
+            this.recipientKeys = recipientKeys;
+            return this;
+        }
+
+        public Builder withCipherTextNonce(final Nonce cipherTextNonce) {
+            this.cipherTextNonce = cipherTextNonce;
+            return this;
+        }
+
+        public Builder withCipherTextNonce(final byte[] cipherTextNonce) {
+            this.cipherTextNonce = new Nonce(cipherTextNonce);
+            return this;
+        }
+
+        public Builder withRecipientNonce(final Nonce recipientNonce) {
+            this.recipientNonce = recipientNonce;
+            return this;
+        }
+
+        public Builder withRecipientNonce(final byte[] recipientNonce) {
+            this.recipientNonce = new Nonce(recipientNonce);
+            return this;
+        }
+
+        public Builder withRecipientBoxes(final List<byte[]> recipientBoxes) {
+            this.recipientBoxes = recipientBoxes;
+            return this;
+        }
+
+        public Builder withRecipientBox(byte[] newbox) {
+            this.recipientBoxes.add(newbox);
+            return this;
+        }
+
+        public Builder withPrivacyFlag(final int privacyFlag) {
+            return this.withPrivacyMode(PrivacyMode.fromFlag(privacyFlag));
+        }
+
+        public Builder withPrivacyMode(final PrivacyMode privacyMode) {
+            this.privacyMode = privacyMode;
+            return this;
+        }
+
+        public Builder withAffectedContractTransactions(final Map<TxHash, byte[]> affectedContractTransactions) {
+            this.affectedContractTransactions = affectedContractTransactions;
+            return this;
+        }
+
+        public Builder withExecHash(final byte[] execHash) {
+            this.execHash = execHash;
+            return this;
+        }
+
+        public V2EncodedPayload build() {
+
+            Map<TxHash, SecurityHash> affectedTxns =
+                    affectedContractTransactions.entrySet().stream()
+                            .collect(
+                                    Collectors.toUnmodifiableMap(
+                                            e -> e.getKey(), e -> SecurityHash.from(e.getValue())));
+
+            List<RecipientBox> recipientBoxes =
+                    this.recipientBoxes.stream().map(RecipientBox::from).collect(Collectors.toList());
+
+            return new V2EncodedPayload(
+                    senderKey,
+                    cipherText,
+                    cipherTextNonce,
+                    recipientBoxes,
+                    recipientNonce,
+                    recipientKeys,
+                    privacyMode,
+                    affectedTxns,
+                    execHash);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        V2EncodedPayload that = (V2EncodedPayload) o;
+        return Objects.equals(senderKey, that.senderKey)
+                && Arrays.equals(cipherText, that.cipherText)
+                && Objects.equals(cipherTextNonce, that.cipherTextNonce)
+                && Objects.equals(recipientBoxes, that.recipientBoxes)
+                && Objects.equals(recipientNonce, that.recipientNonce)
+                && Objects.equals(recipientKeys, that.recipientKeys)
+                && privacyMode == that.privacyMode
+                && Arrays.equals(execHash, that.execHash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result =
+                Objects.hash(senderKey, cipherTextNonce, recipientBoxes, recipientNonce, recipientKeys, privacyMode);
+        result = 31 * result + Arrays.hashCode(cipherText);
+        result = 31 * result + Arrays.hashCode(execHash);
+        return result;
+    }
+}

--- a/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/V2PayloadEncoder.java
+++ b/enclave/enclave-api/src/test/java/com/quorum/tessera/enclave/encoder/V2PayloadEncoder.java
@@ -1,5 +1,6 @@
-package com.quorum.tessera.enclave;
+package com.quorum.tessera.enclave.encoder;
 
+import com.quorum.tessera.enclave.*;
 import com.quorum.tessera.encryption.PublicKey;
 
 import java.nio.ByteBuffer;
@@ -7,12 +8,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.*;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
-public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
+public class V2PayloadEncoder implements BinaryEncoder {
 
-    @Override
-    public byte[] encode(final EncodedPayload payload) {
+    public byte[] encode(final V2EncodedPayload payload) {
 
         final byte[] senderKey = encodeField(payload.getSenderKey().getKeyBytes());
         final byte[] cipherText = encodeField(payload.getCipherText());
@@ -51,11 +52,6 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
             executionHash = encodeField(payload.getExecHash());
         }
 
-        byte[] privacyGroupId = payload.getPrivacyGroupId()
-            .map(PrivacyGroup.Id::getBytes)
-            .map(this::encodeField)
-            .orElse(new byte[0]);
-
         return ByteBuffer.allocate(
                         senderKey.length
                                 + cipherText.length
@@ -65,8 +61,7 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
                                 + recipientBytes.length
                                 + privacyModeByte.length
                                 + affectedContractsPayloadLength
-                                + executionHash.length
-                                + privacyGroupId.length)
+                                + executionHash.length)
                 .put(senderKey)
                 .put(cipherText)
                 .put(nonce)
@@ -76,12 +71,10 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
                 .put(privacyModeByte)
                 .put(affectedContractTxs.array())
                 .put(executionHash)
-                .put(privacyGroupId)
                 .array();
     }
 
-    @Override
-    public EncodedPayload decode(final byte[] input) {
+    public V2EncodedPayload decode(final byte[] input) {
         final ByteBuffer buffer = ByteBuffer.wrap(input);
 
         final long senderSize = buffer.getLong();
@@ -113,7 +106,7 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
         // TODO - not sure this is right
         if (!buffer.hasRemaining()) {
 
-            return EncodedPayload.Builder.create()
+            return V2EncodedPayload.Builder.create()
                     .withSenderKey(PublicKey.from(senderKey))
                     .withCipherText(cipherText)
                     .withCipherTextNonce(nonce)
@@ -138,7 +131,7 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
 
         if (!buffer.hasRemaining()) {
 
-            return EncodedPayload.Builder.create()
+            return V2EncodedPayload.Builder.create()
                     .withSenderKey(PublicKey.from(senderKey))
                     .withCipherText(cipherText)
                     .withCipherTextNonce(nonce)
@@ -151,9 +144,9 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
                     .build();
         }
 
-        final long privacyFlagLength = buffer.getLong();
-        final byte[] privacyFlag = new byte[Math.toIntExact(privacyFlagLength)];
-        buffer.get(privacyFlag);
+        final long privacyModeLength = buffer.getLong();
+        final byte[] privacyMode = new byte[Math.toIntExact(privacyModeLength)];
+        buffer.get(privacyMode);
 
         final long affectedContractTransactionsLength = buffer.getLong();
         final Map<TxHash, byte[]> affectedContractTransactions = new HashMap<>();
@@ -169,50 +162,27 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
             affectedContractTransactions.put(new TxHash(txHash), txSecHash);
         }
 
-        final PrivacyMode privacyMode = PrivacyMode.fromFlag(privacyFlag[0]);
-
         byte[] executionHash = new byte[0];
+
         if (buffer.hasRemaining()) {
-            if (privacyMode == PrivacyMode.PRIVATE_STATE_VALIDATION) {
-                final long executionHashSize = buffer.getLong();
-                executionHash = new byte[Math.toIntExact(executionHashSize)];
-                buffer.get(executionHash);
-            }
+            final long executionHashSize = buffer.getLong();
+            executionHash = new byte[Math.toIntExact(executionHashSize)];
+            buffer.get(executionHash);
         }
 
-        if (!buffer.hasRemaining()) {
-            return EncodedPayload.Builder.create()
-                    .withSenderKey(PublicKey.from(senderKey))
-                    .withCipherText(cipherText)
-                    .withCipherTextNonce(nonce)
-                    .withRecipientBoxes(recipientBoxes)
-                    .withRecipientNonce(recipientNonce)
-                    .withRecipientKeys(recipientKeys.stream().map(PublicKey::from).collect(toList()))
-                    .withPrivacyMode(privacyMode)
-                    .withAffectedContractTransactions(affectedContractTransactions)
-                    .withExecHash(executionHash)
-                    .build();
-        }
-
-        final long privacyGroupIdSize = buffer.getLong();
-        final byte[] privacyGroupId = new byte[Math.toIntExact(privacyGroupIdSize)];
-        buffer.get(privacyGroupId);
-
-        return EncodedPayload.Builder.create()
+        return V2EncodedPayload.Builder.create()
                 .withSenderKey(PublicKey.from(senderKey))
                 .withCipherText(cipherText)
                 .withCipherTextNonce(nonce)
                 .withRecipientBoxes(recipientBoxes)
                 .withRecipientNonce(recipientNonce)
                 .withRecipientKeys(recipientKeys.stream().map(PublicKey::from).collect(toList()))
-                .withPrivacyMode(privacyMode)
+                .withPrivacyMode(PrivacyMode.fromFlag(privacyMode[0]))
                 .withAffectedContractTransactions(affectedContractTransactions)
                 .withExecHash(executionHash)
-                .withPrivacyGroupId(PrivacyGroup.Id.fromBytes(privacyGroupId))
                 .build();
     }
 
-    @Override
     public EncodedPayload forRecipient(final EncodedPayload payload, final PublicKey recipient) {
 
         if (!payload.getRecipientKeys().contains(recipient)) {
@@ -237,23 +207,19 @@ public class PayloadEncoderImpl implements PayloadEncoder, BinaryEncoder {
                 payload.getAffectedContractTransactions().entrySet().stream()
                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getData()));
 
-        final EncodedPayload.Builder builder =
-                EncodedPayload.Builder.create()
-                        .withSenderKey(payload.getSenderKey())
-                        .withCipherText(payload.getCipherText())
-                        .withCipherTextNonce(payload.getCipherTextNonce())
-                        .withRecipientBoxes(singletonList(recipientBox))
-                        .withRecipientNonce(payload.getRecipientNonce())
-                        .withRecipientKeys(recipientList)
-                        .withPrivacyMode(payload.getPrivacyMode())
-                        .withAffectedContractTransactions(affectedTxnMap)
-                        .withExecHash(payload.getExecHash());
-        payload.getPrivacyGroupId().ifPresent(builder::withPrivacyGroupId);
-
-        return builder.build();
+        return EncodedPayload.Builder.create()
+                .withSenderKey(payload.getSenderKey())
+                .withCipherText(payload.getCipherText())
+                .withCipherTextNonce(payload.getCipherTextNonce())
+                .withRecipientBoxes(singletonList(recipientBox))
+                .withRecipientNonce(payload.getRecipientNonce())
+                .withRecipientKeys(recipientList)
+                .withPrivacyMode(payload.getPrivacyMode())
+                .withAffectedContractTransactions(affectedTxnMap)
+                .withExecHash(payload.getExecHash())
+                .build();
     }
 
-    @Override
     public EncodedPayload withRecipient(final EncodedPayload payload, final PublicKey recipient) {
         // this method is to be used for adding a recipient to an EncodedPayload that does not have any.
         if (!payload.getRecipientKeys().isEmpty()) {

--- a/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/EnclavePayload.java
+++ b/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/EnclavePayload.java
@@ -2,10 +2,10 @@ package com.quorum.tessera.enclave.rest;
 
 import com.quorum.tessera.enclave.PrivacyMode;
 
-import java.io.Serializable;
-import java.util.List;
 import javax.xml.bind.annotation.XmlMimeType;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.List;
 
 @XmlRootElement
 public class EnclavePayload implements Serializable {
@@ -25,6 +25,9 @@ public class EnclavePayload implements Serializable {
 
     @XmlMimeType("base64Binary")
     private byte[] execHash;
+
+    @XmlMimeType("base64Binary")
+    private byte[] privacyGroupId;
 
     public byte[] getData() {
         return data;
@@ -72,5 +75,13 @@ public class EnclavePayload implements Serializable {
 
     public void setExecHash(byte[] execHash) {
         this.execHash = execHash;
+    }
+
+    public byte[] getPrivacyGroupId() {
+        return privacyGroupId;
+    }
+
+    public void setPrivacyGroupId(byte[] privacyGroupId) {
+        this.privacyGroupId = privacyGroupId;
     }
 }

--- a/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/EnclaveRawPayload.java
+++ b/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/EnclaveRawPayload.java
@@ -2,9 +2,9 @@ package com.quorum.tessera.enclave.rest;
 
 import com.quorum.tessera.enclave.PrivacyMode;
 
-import java.util.List;
 import javax.xml.bind.annotation.XmlMimeType;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
 
 @XmlRootElement
 public class EnclaveRawPayload {
@@ -30,6 +30,9 @@ public class EnclaveRawPayload {
 
     @XmlMimeType("base64Binary")
     private byte[] execHash;
+
+    @XmlMimeType("base64Binary")
+    private byte[] privacyGroupId;
 
     public byte[] getEncryptedPayload() {
         return encryptedPayload;
@@ -93,5 +96,13 @@ public class EnclaveRawPayload {
 
     public void setExecHash(byte[] execHash) {
         this.execHash = execHash;
+    }
+
+    public byte[] getPrivacyGroupId() {
+        return privacyGroupId;
+    }
+
+    public void setPrivacyGroupId(byte[] privacyGroupId) {
+        this.privacyGroupId = privacyGroupId;
     }
 }

--- a/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/EnclaveResource.java
+++ b/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/EnclaveResource.java
@@ -5,14 +5,17 @@ import com.quorum.tessera.encryption.Nonce;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.service.Service;
 
+import javax.json.Json;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-import java.util.*;
-import java.util.stream.Collectors;
-import javax.json.Json;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.StreamingOutput;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Path("/")
 public class EnclaveResource {
@@ -52,7 +55,7 @@ public class EnclaveResource {
     public Response getForwardingKeys() {
 
         List<String> body =
-            enclave.getForwardingKeys().stream().map(PublicKey::encodeToBase64).collect(Collectors.toList());
+                enclave.getForwardingKeys().stream().map(PublicKey::encodeToBase64).collect(Collectors.toList());
 
         return Response.ok(Json.createArrayBuilder(body).build().toString(), MediaType.APPLICATION_JSON_TYPE).build();
     }
@@ -63,7 +66,7 @@ public class EnclaveResource {
     public Response getPublicKeys() {
 
         List<String> body =
-            enclave.getPublicKeys().stream().map(PublicKey::encodeToBase64).collect(Collectors.toList());
+                enclave.getPublicKeys().stream().map(PublicKey::encodeToBase64).collect(Collectors.toList());
 
         return Response.ok(Json.createArrayBuilder(body).build().toString(), MediaType.APPLICATION_JSON_TYPE).build();
     }
@@ -77,19 +80,24 @@ public class EnclaveResource {
         final PublicKey senderKey = PublicKey.from(payload.getSenderKey());
 
         final List<PublicKey> recipientPublicKeys =
-            payload.getRecipientPublicKeys().stream().map(PublicKey::from).collect(Collectors.toList());
+                payload.getRecipientPublicKeys().stream().map(PublicKey::from).collect(Collectors.toList());
 
         final List<AffectedTransaction> affectedTransactions =
-            convertToAffectedTransactions(payload.getAffectedContractTransactions());
+                convertToAffectedTransactions(payload.getAffectedContractTransactions());
+
+        final PrivacyMetadata.Builder privacyMetaDataBuilder =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(payload.getPrivacyMode())
+                        .withAffectedTransactions(affectedTransactions)
+                        .withExecHash(payload.getExecHash());
+
+        Optional.ofNullable(payload.getPrivacyGroupId())
+                .map(PrivacyGroup.Id::fromBytes)
+                .ifPresent(privacyMetaDataBuilder::withPrivacyGroupId);
 
         EncodedPayload outcome =
-            enclave.encryptPayload(
-                payload.getData(),
-                senderKey,
-                recipientPublicKeys,
-                payload.getPrivacyMode(),
-                affectedTransactions,
-                payload.getExecHash());
+                enclave.encryptPayload(
+                        payload.getData(), senderKey, recipientPublicKeys, privacyMetaDataBuilder.build());
 
         byte[] response = payloadEncoder.encode(outcome);
         final StreamingOutput streamingOutput = out -> out.write(response);
@@ -108,20 +116,25 @@ public class EnclaveResource {
         PublicKey from = PublicKey.from(enclaveRawPayload.getFrom());
 
         List<PublicKey> recipientPublicKeys =
-            enclaveRawPayload.getRecipientPublicKeys().stream().map(PublicKey::from).collect(Collectors.toList());
+                enclaveRawPayload.getRecipientPublicKeys().stream().map(PublicKey::from).collect(Collectors.toList());
 
         RawTransaction rawTransaction = new RawTransaction(encryptedPayload, encryptedKey, nonce, from);
 
         final List<AffectedTransaction> affectedTransactions =
-            convertToAffectedTransactions(enclaveRawPayload.getAffectedContractTransactions());
+                convertToAffectedTransactions(enclaveRawPayload.getAffectedContractTransactions());
+
+        final PrivacyMetadata.Builder privacyMetaDataBuilder =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(enclaveRawPayload.getPrivacyMode())
+                        .withAffectedTransactions(affectedTransactions)
+                        .withExecHash(enclaveRawPayload.getExecHash());
+
+        Optional.ofNullable(enclaveRawPayload.getPrivacyGroupId())
+                .map(PrivacyGroup.Id::fromBytes)
+                .ifPresent(privacyMetaDataBuilder::withPrivacyGroupId);
 
         EncodedPayload outcome =
-            enclave.encryptPayload(
-                rawTransaction,
-                recipientPublicKeys,
-                enclaveRawPayload.getPrivacyMode(),
-                affectedTransactions,
-                enclaveRawPayload.getExecHash());
+                enclave.encryptPayload(rawTransaction, recipientPublicKeys, privacyMetaDataBuilder.build());
 
         byte[] response = payloadEncoder.encode(outcome);
         final StreamingOutput streamingOutput = out -> out.write(response);
@@ -135,7 +148,7 @@ public class EnclaveResource {
     public Response encryptRawPayload(EnclavePayload payload) {
 
         RawTransaction rawTransaction =
-            enclave.encryptRawPayload(payload.getData(), PublicKey.from(payload.getSenderKey()));
+                enclave.encryptRawPayload(payload.getData(), PublicKey.from(payload.getSenderKey()));
 
         EnclaveRawPayload enclaveRawPayload = new EnclaveRawPayload();
         enclaveRawPayload.setFrom(rawTransaction.getFrom().getKeyBytes());
@@ -155,21 +168,21 @@ public class EnclaveResource {
         EncodedPayload encodedPayload = payloadEncoder.decode(payload.getEncodedPayload());
 
         List<AffectedTransaction> affectedTransactions =
-            payload.getAffectedContractTransactions().stream()
-                .map(
-                    keyValuePair ->
-                        AffectedTransaction.Builder.create()
-                            .withHash(keyValuePair.getKey())
-                            .withPayload(PayloadEncoder.create().decode(keyValuePair.getValue()))
-                            .build())
-                .collect(Collectors.toList());
+                payload.getAffectedContractTransactions().stream()
+                        .map(
+                                keyValuePair ->
+                                        AffectedTransaction.Builder.create()
+                                                .withHash(keyValuePair.getKey())
+                                                .withPayload(PayloadEncoder.create().decode(keyValuePair.getValue()))
+                                                .build())
+                        .collect(Collectors.toList());
 
         Set<TxHash> invalidSecurityHashes = enclave.findInvalidSecurityHashes(encodedPayload, affectedTransactions);
 
         EnclaveFindInvalidSecurityHashesResponsePayload responsePayload =
-            new EnclaveFindInvalidSecurityHashesResponsePayload();
+                new EnclaveFindInvalidSecurityHashesResponsePayload();
         responsePayload.setInvalidSecurityHashes(
-            invalidSecurityHashes.stream().map(TxHash::getBytes).collect(Collectors.toList()));
+                invalidSecurityHashes.stream().map(TxHash::getBytes).collect(Collectors.toList()));
 
         return Response.ok(responsePayload).build();
     }
@@ -181,11 +194,11 @@ public class EnclaveResource {
     public Response unencryptRawPayload(EnclaveRawPayload enclaveRawPayload) {
 
         RawTransaction rawTransaction =
-            new RawTransaction(
-                enclaveRawPayload.getEncryptedPayload(),
-                enclaveRawPayload.getEncryptedKey(),
-                new Nonce(enclaveRawPayload.getNonce()),
-                PublicKey.from(enclaveRawPayload.getFrom()));
+                new RawTransaction(
+                        enclaveRawPayload.getEncryptedPayload(),
+                        enclaveRawPayload.getEncryptedKey(),
+                        new Nonce(enclaveRawPayload.getNonce()),
+                        PublicKey.from(enclaveRawPayload.getFrom()));
 
         byte[] response = enclave.unencryptRawPayload(rawTransaction);
 
@@ -201,7 +214,7 @@ public class EnclaveResource {
 
         EncodedPayload payload = payloadEncoder.decode(enclaveUnencryptPayload.getData());
         PublicKey providedKey =
-            Optional.ofNullable(enclaveUnencryptPayload.getProvidedKey()).map(PublicKey::from).orElse(null);
+                Optional.ofNullable(enclaveUnencryptPayload.getProvidedKey()).map(PublicKey::from).orElse(null);
 
         byte[] response = enclave.unencryptTransaction(payload, providedKey);
 
@@ -225,11 +238,13 @@ public class EnclaveResource {
     }
 
     private List<AffectedTransaction> convertToAffectedTransactions(final List<KeyValuePair> keyValuePairs) {
-        return keyValuePairs.stream().map(
-            kvp -> AffectedTransaction.Builder.create()
-                .withHash(kvp.getKey())
-                .withPayload(payloadEncoder.decode(kvp.getValue()))
-                .build()
-        ).collect(Collectors.toUnmodifiableList());
+        return keyValuePairs.stream()
+                .map(
+                        kvp ->
+                                AffectedTransaction.Builder.create()
+                                        .withHash(kvp.getKey())
+                                        .withPayload(payloadEncoder.decode(kvp.getValue()))
+                                        .build())
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/RestfulEnclaveClient.java
+++ b/enclave/enclave-jaxrs/src/main/java/com/quorum/tessera/enclave/rest/RestfulEnclaveClient.java
@@ -1,26 +1,23 @@
 package com.quorum.tessera.enclave.rest;
 
 import com.quorum.tessera.enclave.*;
-import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.encryption.Nonce;
-import com.quorum.tessera.service.Service;
+import com.quorum.tessera.encryption.PublicKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.json.JsonArray;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RestfulEnclaveClient implements EnclaveClient {
 
@@ -71,7 +68,7 @@ public class RestfulEnclaveClient implements EnclaveClient {
                     JsonArray results = response.readEntity(JsonArray.class);
 
                     return IntStream.range(0, results.size())
-                            .mapToObj(i -> results.getString(i))
+                            .mapToObj(results::getString)
                             .map(s -> Base64.getDecoder().decode(s))
                             .map(PublicKey::from)
                             .collect(Collectors.toSet());
@@ -89,7 +86,7 @@ public class RestfulEnclaveClient implements EnclaveClient {
                     JsonArray results = response.readEntity(JsonArray.class);
 
                     return IntStream.range(0, results.size())
-                            .mapToObj(i -> results.getString(i))
+                            .mapToObj(results::getString)
                             .map(s -> Base64.getDecoder().decode(s))
                             .map(PublicKey::from)
                             .collect(Collectors.toSet());
@@ -98,12 +95,10 @@ public class RestfulEnclaveClient implements EnclaveClient {
 
     @Override
     public EncodedPayload encryptPayload(
-            byte[] message,
-            PublicKey senderPublicKey,
-            List<PublicKey> recipientPublicKeys,
-            PrivacyMode privacyMode,
-            List<AffectedTransaction> affectedContractTransactions,
-            byte[] execHash) {
+            final byte[] message,
+            final PublicKey senderPublicKey,
+            final List<PublicKey> recipientPublicKeys,
+            final PrivacyMetadata privacyMetaData) {
 
         return ClientCallback.execute(
                 () -> {
@@ -111,13 +106,15 @@ public class RestfulEnclaveClient implements EnclaveClient {
                     enclavePayload.setData(message);
                     enclavePayload.setSenderKey(senderPublicKey.getKeyBytes());
                     enclavePayload.setRecipientPublicKeys(
-                            recipientPublicKeys.stream()
-                                .map(PublicKey::getKeyBytes)
-                                .collect(Collectors.toList()));
-                    enclavePayload.setPrivacyMode(privacyMode);
+                            recipientPublicKeys.stream().map(PublicKey::getKeyBytes).collect(Collectors.toList()));
+                    enclavePayload.setPrivacyMode(privacyMetaData.getPrivacyMode());
                     enclavePayload.setAffectedContractTransactions(
-                            convertAffectedContractTransactions(affectedContractTransactions));
-                    enclavePayload.setExecHash(execHash);
+                            convertAffectedContractTransactions(privacyMetaData.getAffectedContractTransactions()));
+                    enclavePayload.setExecHash(privacyMetaData.getExecHash());
+                    privacyMetaData
+                            .getPrivacyGroupId()
+                            .map(PrivacyGroup.Id::getBytes)
+                            .ifPresent(enclavePayload::setPrivacyGroupId);
 
                     Response response = client.target(uri).path("encrypt").request().post(Entity.json(enclavePayload));
 
@@ -131,11 +128,9 @@ public class RestfulEnclaveClient implements EnclaveClient {
 
     @Override
     public EncodedPayload encryptPayload(
-            RawTransaction rawTransaction,
-            List<PublicKey> recipientPublicKeys,
-            PrivacyMode privacyMode,
-            List<AffectedTransaction> affectedContractTransactions,
-            byte[] execHash) {
+            final RawTransaction rawTransaction,
+            final List<PublicKey> recipientPublicKeys,
+            final PrivacyMetadata privacyMetaData) {
 
         return ClientCallback.execute(
                 () -> {
@@ -147,11 +142,16 @@ public class RestfulEnclaveClient implements EnclaveClient {
                     enclaveRawPayload.setEncryptedPayload(rawTransaction.getEncryptedPayload());
                     enclaveRawPayload.setEncryptedKey(rawTransaction.getEncryptedKey());
 
-                    enclaveRawPayload.setPrivacyMode(privacyMode);
-                    enclaveRawPayload.setExecHash(execHash);
+                    enclaveRawPayload.setPrivacyMode(privacyMetaData.getPrivacyMode());
+                    enclaveRawPayload.setExecHash(privacyMetaData.getExecHash());
 
                     enclaveRawPayload.setAffectedContractTransactions(
-                            convertAffectedContractTransactions(affectedContractTransactions));
+                            convertAffectedContractTransactions(privacyMetaData.getAffectedContractTransactions()));
+
+                    privacyMetaData
+                            .getPrivacyGroupId()
+                            .map(PrivacyGroup.Id::getBytes)
+                            .ifPresent(enclaveRawPayload::setPrivacyGroupId);
 
                     Response response =
                             client.target(uri)
@@ -284,17 +284,17 @@ public class RestfulEnclaveClient implements EnclaveClient {
      * @return Status
      */
     @Override
-    public Service.Status status() {
+    public Status status() {
 
-        Future<Service.Status> outcome =
+        Future<Status> outcome =
                 executorService.submit(
                         () -> {
                             Response response = client.target(uri).path("ping").request().get();
 
                             if (response.getStatus() == 200) {
-                                return Service.Status.STARTED;
+                                return Status.STARTED;
                             }
-                            return Service.Status.STOPPED;
+                            return Status.STOPPED;
                         });
 
         try {
@@ -302,7 +302,7 @@ public class RestfulEnclaveClient implements EnclaveClient {
             return outcome.get(2, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException ex) {
             LOGGER.trace(null, ex);
-            return Service.Status.STOPPED;
+            return Status.STOPPED;
         }
     }
 
@@ -318,11 +318,14 @@ public class RestfulEnclaveClient implements EnclaveClient {
         }
     }
 
-    private List<KeyValuePair> convertAffectedContractTransactions(List<AffectedTransaction> affectedContractTransactions) {
-        return affectedContractTransactions.stream().map(
-            affectedTransaction ->
-                new KeyValuePair(affectedTransaction.getHash().getBytes(),
-                    this.payloadEncoder.encode(affectedTransaction.getPayload())))
-            .collect(Collectors.toList());
+    private List<KeyValuePair> convertAffectedContractTransactions(
+            List<AffectedTransaction> affectedContractTransactions) {
+        return affectedContractTransactions.stream()
+                .map(
+                        affectedTransaction ->
+                                new KeyValuePair(
+                                        affectedTransaction.getHash().getBytes(),
+                                        this.payloadEncoder.encode(affectedTransaction.getPayload())))
+                .collect(Collectors.toList());
     }
 }

--- a/enclave/enclave-jaxrs/src/test/java/com/quorum/tessera/enclave/rest/EnclaveApplicationTest.java
+++ b/enclave/enclave-jaxrs/src/test/java/com/quorum/tessera/enclave/rest/EnclaveApplicationTest.java
@@ -81,7 +81,7 @@ public class EnclaveApplicationTest {
                             return pay;
                         })
                 .when(enclave)
-                .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(), anyList(), any());
+                .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any());
 
         PublicKey senderPublicKey = pay.getSenderKey();
         List<PublicKey> recipientPublicKeys = pay.getRecipientKeys();
@@ -96,20 +96,19 @@ public class EnclaveApplicationTest {
         when(acoth.getAffectedContractTransactions()).thenReturn(Collections.emptyMap());
         when(acoth.getExecHash()).thenReturn("0".getBytes());
 
-
         TxHash txHash = new TxHash("key".getBytes());
         AffectedTransaction affectedTransaction = mock(AffectedTransaction.class);
         when(affectedTransaction.getPayload()).thenReturn(acoth);
         when(affectedTransaction.getHash()).thenReturn(txHash);
 
+        PrivacyMetadata privacyMetaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedTransactions(List.of(affectedTransaction))
+                        .build();
+
         EncodedPayload result =
-                restfulEnclaveClient.encryptPayload(
-                        message,
-                        senderPublicKey,
-                        recipientPublicKeys,
-                        PrivacyMode.STANDARD_PRIVATE,
-                        List.of(affectedTransaction),
-                        new byte[0]);
+                restfulEnclaveClient.encryptPayload(message, senderPublicKey, recipientPublicKeys, privacyMetaData);
 
         assertThat(result.getSenderKey()).isNotNull().isEqualTo(pay.getSenderKey());
 
@@ -127,7 +126,7 @@ public class EnclaveApplicationTest {
 
         assertThat(results.get(0)).isEqualTo(message);
 
-        verify(enclave).encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(), anyList(), any());
+        verify(enclave).encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
     }
 
     @Test

--- a/enclave/enclave-jaxrs/src/test/java/com/quorum/tessera/enclave/rest/RestfulEnclaveClientTest.java
+++ b/enclave/enclave-jaxrs/src/test/java/com/quorum/tessera/enclave/rest/RestfulEnclaveClientTest.java
@@ -3,12 +3,12 @@ package com.quorum.tessera.enclave.rest;
 import com.quorum.tessera.enclave.*;
 import com.quorum.tessera.encryption.Nonce;
 import com.quorum.tessera.encryption.PublicKey;
-import com.quorum.tessera.service.Service;
 import com.quorum.tessera.service.Service.Status;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -17,8 +17,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -106,39 +105,86 @@ public class RestfulEnclaveClientTest {
                                 .withPayload(encodedPayload)
                                 .build());
 
-        when(enclave.encryptPayload(
-                        eq(message),
-                        eq(senderPublicKey),
-                        eq(recipientPublicKeys),
-                        any(),
-                        eq(affectedTransactions),
-                        any()))
+        when(enclave.encryptPayload(eq(message), eq(senderPublicKey), eq(recipientPublicKeys), any()))
                 .thenReturn(encodedPayload);
 
+        final PrivacyMetadata privacyMetaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedTransactions(affectedTransactions)
+                        .build();
+
         EncodedPayload result =
-                enclaveClient.encryptPayload(
-                        message,
-                        senderPublicKey,
-                        recipientPublicKeys,
-                        PrivacyMode.PARTY_PROTECTION,
-                        affectedTransactions,
-                        new byte[0]);
+                enclaveClient.encryptPayload(message, senderPublicKey, recipientPublicKeys, privacyMetaData);
 
         assertThat(result).isNotNull();
 
         byte[] encodedResult = PayloadEncoder.create().encode(result);
         byte[] encodedEncodedPayload = PayloadEncoder.create().encode(encodedPayload);
 
+        assertThat(result.getPrivacyGroupId()).isNotPresent();
+
         assertThat(encodedResult).isEqualTo(encodedEncodedPayload);
 
         verify(enclave)
-                .encryptPayload(
-                        eq(message),
-                        eq(senderPublicKey),
-                        eq(recipientPublicKeys),
-                        any(),
-                        eq(affectedTransactions),
-                        any());
+                .encryptPayload(eq(message), eq(senderPublicKey), eq(recipientPublicKeys), any(PrivacyMetadata.class));
+    }
+
+    @Test
+    public void encryptPayloadWithPrivacyGroupId() {
+
+        byte[] message = "HELLOW".getBytes();
+
+        PublicKey senderPublicKey = PublicKey.from("PublicKey".getBytes());
+        List<PublicKey> recipientPublicKeys = Arrays.asList(PublicKey.from("RecipientPublicKey".getBytes()));
+
+        final EncodedPayload payloadWithGroupId =
+                EncodedPayload.Builder.from(Fixtures.createSample())
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
+                        .build();
+
+        List<AffectedTransaction> affectedTransactions =
+                List.of(
+                        AffectedTransaction.Builder.create()
+                                .withHash("hash".getBytes())
+                                .withPayload(payloadWithGroupId)
+                                .build());
+
+        final PrivacyMetadata privacyMetaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedTransactions(affectedTransactions)
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
+                        .build();
+
+        when(enclave.encryptPayload(
+                        eq(message), eq(senderPublicKey), eq(recipientPublicKeys), any(PrivacyMetadata.class)))
+                .thenReturn(payloadWithGroupId);
+
+        EncodedPayload result =
+                enclaveClient.encryptPayload(message, senderPublicKey, recipientPublicKeys, privacyMetaData);
+
+        assertThat(result).isNotNull();
+
+        byte[] encodedResult = PayloadEncoder.create().encode(result);
+        byte[] encodedEncodedPayload = PayloadEncoder.create().encode(payloadWithGroupId);
+
+        assertThat(encodedResult).isEqualTo(encodedEncodedPayload);
+
+        ArgumentCaptor<PrivacyMetadata> argumentCaptor = ArgumentCaptor.forClass(PrivacyMetadata.class);
+
+        verify(enclave)
+                .encryptPayload(eq(message), eq(senderPublicKey), eq(recipientPublicKeys), argumentCaptor.capture());
+
+        final PrivacyMetadata passingThroughPrivacyData = argumentCaptor.getValue();
+        assertThat(passingThroughPrivacyData.getPrivacyGroupId())
+                .isPresent()
+                .get()
+                .isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
+        assertThat(passingThroughPrivacyData.getPrivacyMode()).isEqualTo(privacyMetaData.getPrivacyMode());
+        assertThat(passingThroughPrivacyData.getAffectedContractTransactions())
+                .isEqualTo(privacyMetaData.getAffectedContractTransactions());
+        assertThat(passingThroughPrivacyData.getExecHash()).isEqualTo(privacyMetaData.getExecHash());
     }
 
     @Test
@@ -165,16 +211,15 @@ public class RestfulEnclaveClientTest {
                                 .withPayload(encodedPayload)
                                 .build());
 
-        when(enclave.encryptPayload(any(RawTransaction.class), any(List.class), any(), eq(affectedTransactions), any()))
-                .thenReturn(encodedPayload);
+        final PrivacyMetadata privacyMetaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedTransactions(affectedTransactions)
+                        .build();
 
-        EncodedPayload result =
-                enclaveClient.encryptPayload(
-                        rawTransaction,
-                        recipientPublicKeys,
-                        PrivacyMode.PARTY_PROTECTION,
-                        affectedTransactions,
-                        new byte[0]);
+        when(enclave.encryptPayload(any(RawTransaction.class), any(List.class), any())).thenReturn(encodedPayload);
+
+        EncodedPayload result = enclaveClient.encryptPayload(rawTransaction, recipientPublicKeys, privacyMetaData);
 
         assertThat(result).isNotNull();
 
@@ -183,7 +228,68 @@ public class RestfulEnclaveClientTest {
 
         assertThat(encodedResult).isEqualTo(encodedEncodedPayload);
 
-        verify(enclave).encryptPayload(any(RawTransaction.class), any(List.class), any(), anyList(), any());
+        verify(enclave).encryptPayload(any(RawTransaction.class), any(List.class), any());
+    }
+
+    @Test
+    public void encryptPayloadRawWithPrivacyGroupId() {
+
+        byte[] message = "HELLOW".getBytes();
+
+        byte[] encryptedKey = "encryptedKey".getBytes();
+
+        Nonce nonce = new Nonce("Nonce".getBytes());
+
+        PublicKey senderPublicKey = PublicKey.from("SenderPublicKey".getBytes());
+
+        List<PublicKey> recipientPublicKeys = Arrays.asList(PublicKey.from("RecipientPublicKey".getBytes()));
+
+        RawTransaction rawTransaction = new RawTransaction(message, encryptedKey, nonce, senderPublicKey);
+
+        EncodedPayload encodedPayloadWithGroupId =
+                EncodedPayload.Builder.from(Fixtures.createSample())
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
+                        .build();
+
+        List<AffectedTransaction> affectedTransactions =
+                List.of(
+                        AffectedTransaction.Builder.create()
+                                .withHash("hash".getBytes())
+                                .withPayload(encodedPayloadWithGroupId)
+                                .build());
+
+        final PrivacyMetadata privacyMetaData =
+                PrivacyMetadata.Builder.create()
+                        .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
+                        .withAffectedTransactions(affectedTransactions)
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
+                        .build();
+
+        when(enclave.encryptPayload(any(RawTransaction.class), any(List.class), any()))
+                .thenReturn(encodedPayloadWithGroupId);
+
+        EncodedPayload result = enclaveClient.encryptPayload(rawTransaction, recipientPublicKeys, privacyMetaData);
+
+        assertThat(result).isNotNull();
+
+        byte[] encodedResult = PayloadEncoder.create().encode(result);
+        byte[] encodedEncodedPayload = PayloadEncoder.create().encode(encodedPayloadWithGroupId);
+
+        assertThat(encodedResult).isEqualTo(encodedEncodedPayload);
+
+        ArgumentCaptor<PrivacyMetadata> argumentCaptor = ArgumentCaptor.forClass(PrivacyMetadata.class);
+
+        verify(enclave).encryptPayload(any(RawTransaction.class), any(List.class), argumentCaptor.capture());
+
+        final PrivacyMetadata passingThroughPrivacyData = argumentCaptor.getValue();
+        assertThat(passingThroughPrivacyData.getPrivacyGroupId())
+                .isPresent()
+                .get()
+                .isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
+        assertThat(passingThroughPrivacyData.getPrivacyMode()).isEqualTo(privacyMetaData.getPrivacyMode());
+        assertThat(passingThroughPrivacyData.getAffectedContractTransactions())
+                .isEqualTo(privacyMetaData.getAffectedContractTransactions());
+        assertThat(passingThroughPrivacyData.getExecHash()).isEqualTo(privacyMetaData.getExecHash());
     }
 
     @Test
@@ -289,8 +395,8 @@ public class RestfulEnclaveClientTest {
 
     @Test
     public void statusStarted() {
-        when(enclave.status()).thenReturn(Service.Status.STARTED);
-        assertThat(enclaveClient.status()).isEqualTo(Service.Status.STARTED);
+        when(enclave.status()).thenReturn(Status.STARTED);
+        assertThat(enclaveClient.status()).isEqualTo(Status.STARTED);
 
         verify(enclave).status();
     }
@@ -299,7 +405,7 @@ public class RestfulEnclaveClientTest {
     public void statusStopped() {
 
         when(enclave.status()).thenThrow(RuntimeException.class);
-        assertThat(enclaveClient.status()).isEqualTo(Service.Status.STOPPED);
+        assertThat(enclaveClient.status()).isEqualTo(Status.STOPPED);
         verify(enclave).status();
     }
 
@@ -319,7 +425,7 @@ public class RestfulEnclaveClientTest {
 
         Status result = restfulEnclaveClient.status();
 
-        assertThat(result).isEqualTo(Service.Status.STOPPED);
+        assertThat(result).isEqualTo(Status.STOPPED);
     }
 
     @Test

--- a/migration/multitenancy/src/test/java/com/quorum/tessera/multitenancy/migration/EncryptedTransactionMigratorTest.java
+++ b/migration/multitenancy/src/test/java/com/quorum/tessera/multitenancy/migration/EncryptedTransactionMigratorTest.java
@@ -116,6 +116,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload secondaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(sender, recipient1, recipient2))
                         .withRecipientBoxes(List.of("boxSender".getBytes(), recipient1Box, "box2".getBytes()))
@@ -123,6 +124,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload primaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(recipient1, sender, recipient2))
                         .withRecipientBox(recipient1Box)
@@ -167,6 +169,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload primaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(sender, recipient1, recipient2))
                         .withRecipientBoxes(List.of("boxSender".getBytes(), recipient1Box, "box2".getBytes()))
@@ -174,6 +177,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload secondaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(recipient1, sender, recipient2))
                         .withRecipientBox(recipient1Box)
@@ -194,6 +198,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload secondaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(sender, recipient1, recipient2))
                         .withRecipientBoxes(List.of("boxSender".getBytes(), recipient1Box, "box2".getBytes()))
@@ -201,6 +206,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload primaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(recipient1, sender, recipient2))
                         .withRecipientBox(recipient1Box)
@@ -226,6 +232,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload primaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(recipient1, sender, recipient2))
                         .withRecipientBoxes(List.of(recipient1Box))
@@ -234,6 +241,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload secondaryPayload =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(recipient2, sender, recipient1))
                         .withRecipientBox(recipient2Box)
@@ -245,6 +253,7 @@ public class EncryptedTransactionMigratorTest {
         final EncodedPayload expected =
                 EncodedPayload.Builder.create()
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withSenderKey(sender)
                         .withNewRecipientKeys(List.of(recipient2, recipient1, sender))
                         .withRecipientBoxes(List.of(recipient2Box, recipient1Box))

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/ReceiveResponse.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/ReceiveResponse.java
@@ -1,13 +1,11 @@
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.data.MessageHash;
+import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 public interface ReceiveResponse {
 
@@ -23,6 +21,8 @@ public interface ReceiveResponse {
 
     PublicKey sender();
 
+    Optional<PrivacyGroup.Id> getPrivacyGroupId();
+
     class Builder {
 
         private byte[] unencryptedTransactionData;
@@ -36,6 +36,8 @@ public interface ReceiveResponse {
         private Set<PublicKey> managedParties = Collections.emptySet();
 
         private PublicKey sender;
+
+        private PrivacyGroup.Id privacyGroupId;
 
         private Builder() {}
 
@@ -70,6 +72,11 @@ public interface ReceiveResponse {
 
         public Builder withSender(PublicKey sender) {
             this.sender = sender;
+            return this;
+        }
+
+        public Builder withPrivacyGroupId(PrivacyGroup.Id privacyGroupId) {
+            this.privacyGroupId = privacyGroupId;
             return this;
         }
 
@@ -115,6 +122,11 @@ public interface ReceiveResponse {
                 @Override
                 public PublicKey sender() {
                     return sender;
+                }
+
+                @Override
+                public Optional<PrivacyGroup.Id> getPrivacyGroupId() {
+                    return Optional.ofNullable(privacyGroupId);
                 }
             };
         }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/SendRequest.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/SendRequest.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.data.MessageHash;
+import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 
@@ -20,6 +21,8 @@ public interface SendRequest {
 
     Set<MessageHash> getAffectedContractTransactions();
 
+    Optional<PrivacyGroup.Id> getPrivacyGroupId();
+
     class Builder {
 
         private PublicKey from;
@@ -33,6 +36,8 @@ public interface SendRequest {
         private byte[] execHash;
 
         private Set<MessageHash> affectedContractTransactions;
+
+        private PrivacyGroup.Id privacyGroupId;
 
         public static Builder create() {
             return new Builder() {};
@@ -65,6 +70,11 @@ public interface SendRequest {
 
         public Builder withPrivacyMode(PrivacyMode privacyMode) {
             this.privacyMode = privacyMode;
+            return this;
+        }
+
+        public Builder withPrivacyGroupId(PrivacyGroup.Id privacyGroupId) {
+            this.privacyGroupId = privacyGroupId;
             return this;
         }
 
@@ -113,6 +123,11 @@ public interface SendRequest {
                 @Override
                 public Set<MessageHash> getAffectedContractTransactions() {
                     return Set.copyOf(affectedContractTransactions);
+                }
+
+                @Override
+                public Optional<PrivacyGroup.Id> getPrivacyGroupId() {
+                    return Optional.ofNullable(privacyGroupId);
                 }
             };
         }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/SendSignedRequest.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/SendSignedRequest.java
@@ -1,13 +1,11 @@
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.data.MessageHash;
+import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 public interface SendSignedRequest {
 
@@ -20,6 +18,8 @@ public interface SendSignedRequest {
     byte[] getExecHash();
 
     Set<MessageHash> getAffectedContractTransactions();
+
+    Optional<PrivacyGroup.Id> getPrivacyGroupId();
 
     class Builder {
 
@@ -34,6 +34,8 @@ public interface SendSignedRequest {
         private byte[] execHash;
 
         private Set<MessageHash> affectedContractTransactions;
+
+        private PrivacyGroup.Id privacyGroupId;
 
         public static Builder create() {
             return new Builder() {};
@@ -66,6 +68,11 @@ public interface SendSignedRequest {
 
         public Builder withPrivacyMode(PrivacyMode privacyMode) {
             this.privacyMode = privacyMode;
+            return this;
+        }
+
+        public Builder withPrivacyGroupId(PrivacyGroup.Id privacyGroupId) {
+            this.privacyGroupId = privacyGroupId;
             return this;
         }
 
@@ -106,6 +113,11 @@ public interface SendSignedRequest {
                 @Override
                 public Set<MessageHash> getAffectedContractTransactions() {
                     return Set.copyOf(affectedContractTransactions);
+                }
+
+                @Override
+                public Optional<PrivacyGroup.Id> getPrivacyGroupId() {
+                    return Optional.ofNullable(privacyGroupId);
                 }
             };
         }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/resend/ResendManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/resend/ResendManagerImpl.java
@@ -18,7 +18,8 @@ public class ResendManagerImpl implements ResendManager {
 
     private final PayloadDigest payloadDigest;
 
-    public ResendManagerImpl(EncryptedTransactionDAO encryptedTransactionDAO, Enclave enclave, PayloadDigest payloadDigest) {
+    public ResendManagerImpl(
+            EncryptedTransactionDAO encryptedTransactionDAO, Enclave enclave, PayloadDigest payloadDigest) {
         this(encryptedTransactionDAO, PayloadEncoder.create(), enclave, payloadDigest);
     }
 
@@ -45,6 +46,7 @@ public class ResendManagerImpl implements ResendManager {
             final EncodedPayload tempPayload =
                     EncodedPayload.Builder.from(payload)
                             .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                            .withExecHash(new byte[0])
                             .withNewRecipientKeys(List.of(payload.getRecipientKeys().get(0)))
                             .withRecipientBoxes(List.of(payload.getRecipientBoxes().get(0).getData()))
                             .build();

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/EncodedPayloadManagerImplTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/EncodedPayloadManagerImplTest.java
@@ -51,25 +51,29 @@ public class EncodedPayloadManagerImplTest {
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
         final List<PublicKey> recipients = List.of(singleRecipient);
 
-        final SendRequest request = SendRequest.Builder.create()
-            .withSender(sender)
-            .withRecipients(recipients)
-            .withPayload(testPayload.getBytes())
-            .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
-            .withAffectedContractTransactions(emptySet())
-            .withExecHash(new byte[0])
-            .build();
+        final SendRequest request =
+                SendRequest.Builder.create()
+                        .withSender(sender)
+                        .withRecipients(recipients)
+                        .withPayload(testPayload.getBytes())
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptySet())
+                        .withExecHash(new byte[0])
+                        .build();
 
         final EncodedPayload sampleReturnPayload = EncodedPayload.Builder.create().build();
-        when(enclave.encryptPayload(any(), eq(sender), eq(List.of(singleRecipient, sender)), any(), any(), any())).thenReturn(sampleReturnPayload);
+        when(enclave.encryptPayload(any(), eq(sender), eq(List.of(singleRecipient, sender)), any()))
+                .thenReturn(sampleReturnPayload);
 
         final EncodedPayload encodedPayload = encodedPayloadManager.create(request);
 
         assertThat(encodedPayload).isEqualTo(sampleReturnPayload);
 
         verify(privacyHelper).findAffectedContractTransactionsFromSendRequest(emptySet());
-        verify(privacyHelper).validateSendRequest(PrivacyMode.STANDARD_PRIVATE, List.of(singleRecipient, sender), emptyList());
-        verify(enclave).encryptPayload(request.getPayload(), sender, List.of(singleRecipient, sender), PrivacyMode.STANDARD_PRIVATE, emptyList(), request.getExecHash());
+        verify(privacyHelper)
+                .validateSendRequest(PrivacyMode.STANDARD_PRIVATE, List.of(singleRecipient, sender), emptyList());
+        verify(enclave)
+                .encryptPayload(eq(request.getPayload()), eq(sender), eq(List.of(singleRecipient, sender)), any());
         verify(enclave).getForwardingKeys();
     }
 
@@ -82,27 +86,32 @@ public class EncodedPayloadManagerImplTest {
 
         final String singleRecipientBase64 = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
-        final List<PublicKey> recipients = List.of(singleRecipient, sender, singleRecipient); //list the keys multiple times
+        final List<PublicKey> recipients =
+                List.of(singleRecipient, sender, singleRecipient); // list the keys multiple times
 
-        final SendRequest request = SendRequest.Builder.create()
-            .withSender(sender)
-            .withRecipients(recipients)
-            .withPayload(testPayload.getBytes())
-            .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
-            .withAffectedContractTransactions(emptySet())
-            .withExecHash(new byte[0])
-            .build();
+        final SendRequest request =
+                SendRequest.Builder.create()
+                        .withSender(sender)
+                        .withRecipients(recipients)
+                        .withPayload(testPayload.getBytes())
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptySet())
+                        .withExecHash(new byte[0])
+                        .build();
 
         final EncodedPayload sampleReturnPayload = EncodedPayload.Builder.create().build();
-        when(enclave.encryptPayload(any(), eq(sender), eq(List.of(singleRecipient, sender)), any(), any(), any())).thenReturn(sampleReturnPayload);
+        when(enclave.encryptPayload(any(), eq(sender), eq(List.of(singleRecipient, sender)), any()))
+                .thenReturn(sampleReturnPayload);
 
         final EncodedPayload encodedPayload = encodedPayloadManager.create(request);
 
         assertThat(encodedPayload).isEqualTo(sampleReturnPayload);
 
         verify(privacyHelper).findAffectedContractTransactionsFromSendRequest(emptySet());
-        verify(privacyHelper).validateSendRequest(PrivacyMode.STANDARD_PRIVATE, List.of(singleRecipient, sender), emptyList());
-        verify(enclave).encryptPayload(request.getPayload(), sender, List.of(singleRecipient, sender), PrivacyMode.STANDARD_PRIVATE, emptyList(), request.getExecHash());
+        verify(privacyHelper)
+                .validateSendRequest(PrivacyMode.STANDARD_PRIVATE, List.of(singleRecipient, sender), emptyList());
+        verify(enclave)
+                .encryptPayload(eq(request.getPayload()), eq(sender), eq(List.of(singleRecipient, sender)), any());
         verify(enclave).getForwardingKeys();
     }
 
@@ -115,16 +124,17 @@ public class EncodedPayloadManagerImplTest {
 
         final String singleRecipientBase64 = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
-        final List<PublicKey> recipients = List.of(singleRecipient); //list the keys multiple times
+        final List<PublicKey> recipients = List.of(singleRecipient); // list the keys multiple times
 
-        final EncodedPayload samplePayload = EncodedPayload.Builder.create()
-            .withSenderKey(sender)
-            .withRecipientKeys(recipients)
-            .withCipherText(testPayload.getBytes())
-            .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
-            .withAffectedContractTransactions(emptyMap())
-            .withExecHash(new byte[0])
-            .build();
+        final EncodedPayload samplePayload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(sender)
+                        .withRecipientKeys(recipients)
+                        .withCipherText(testPayload.getBytes())
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptyMap())
+                        .withExecHash(new byte[0])
+                        .build();
 
         when(payloadDigest.digest(any())).thenReturn("test hash".getBytes());
         when(enclave.getPublicKeys()).thenReturn(Set.of(singleRecipient));
@@ -151,27 +161,27 @@ public class EncodedPayloadManagerImplTest {
 
         final String singleRecipientBase64 = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
-        final List<PublicKey> recipients = List.of(singleRecipient); //list the keys multiple times
+        final List<PublicKey> recipients = List.of(singleRecipient); // list the keys multiple times
 
-        final EncodedPayload samplePayload = EncodedPayload.Builder.create()
-            .withSenderKey(sender)
-            .withRecipientKeys(recipients)
-            .withCipherText(testPayload.getBytes())
-            .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
-            .withAffectedContractTransactions(emptyMap())
-            .withExecHash(new byte[0])
-            .build();
+        final EncodedPayload samplePayload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(sender)
+                        .withRecipientKeys(recipients)
+                        .withCipherText(testPayload.getBytes())
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptyMap())
+                        .withExecHash(new byte[0])
+                        .build();
 
         when(payloadDigest.digest(any())).thenReturn("test hash".getBytes());
         when(enclave.getPublicKeys()).thenReturn(Set.of(singleRecipient));
         when(enclave.unencryptTransaction(any(), any())).thenThrow(new EnclaveException("test exception"));
 
-        final Throwable throwable
-            = catchThrowable(() -> encodedPayloadManager.decrypt(samplePayload, null));
+        final Throwable throwable = catchThrowable(() -> encodedPayloadManager.decrypt(samplePayload, null));
 
         assertThat(throwable)
-            .isInstanceOf(RecipientKeyNotFoundException.class)
-            .hasMessage("No suitable recipient keys found to decrypt payload for dGVzdCBoYXNo");
+                .isInstanceOf(RecipientKeyNotFoundException.class)
+                .hasMessage("No suitable recipient keys found to decrypt payload for dGVzdCBoYXNo");
 
         verify(payloadDigest, times(2)).digest(any());
         verify(enclave).getPublicKeys();
@@ -187,30 +197,27 @@ public class EncodedPayloadManagerImplTest {
 
         final String singleRecipientBase64 = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
-        final List<PublicKey> recipients = List.of(singleRecipient); //list the keys multiple times
+        final List<PublicKey> recipients = List.of(singleRecipient);
 
-        final EncodedPayload samplePayload = EncodedPayload.Builder.create()
-            .withSenderKey(sender)
-            .withRecipientKeys(recipients)
-            .withCipherText(testPayload.getBytes())
-            .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
-            .withAffectedContractTransactions(emptyMap())
-            .withExecHash(new byte[0])
-            .build();
+        final EncodedPayload samplePayload =
+                EncodedPayload.Builder.create()
+                        .withSenderKey(sender)
+                        .withRecipientKeys(recipients)
+                        .withCipherText(testPayload.getBytes())
+                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withAffectedContractTransactions(emptyMap())
+                        .withExecHash(new byte[0])
+                        .build();
 
         when(payloadDigest.digest(any())).thenReturn("test hash".getBytes());
         when(enclave.getPublicKeys()).thenReturn(emptySet());
         when(enclave.unencryptTransaction(any(), any())).thenThrow(new EnclaveException("test exception"));
 
-        final Throwable throwable
-            = catchThrowable(() -> encodedPayloadManager.decrypt(samplePayload, singleRecipient));
+        final Throwable throwable = catchThrowable(() -> encodedPayloadManager.decrypt(samplePayload, singleRecipient));
 
-        assertThat(throwable)
-            .isInstanceOf(EnclaveException.class)
-            .hasMessage("test exception");
+        assertThat(throwable).isInstanceOf(EnclaveException.class).hasMessage("test exception");
 
         verify(payloadDigest).digest(any());
         verify(enclave).unencryptTransaction(samplePayload, singleRecipient);
     }
-
 }

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/EncodedPayloadManagerImplTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/EncodedPayloadManagerImplTest.java
@@ -124,7 +124,7 @@ public class EncodedPayloadManagerImplTest {
 
         final String singleRecipientBase64 = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
-        final List<PublicKey> recipients = List.of(singleRecipient); // list the keys multiple times
+        final List<PublicKey> recipients = List.of(singleRecipient);
 
         final EncodedPayload samplePayload =
                 EncodedPayload.Builder.create()
@@ -161,7 +161,7 @@ public class EncodedPayloadManagerImplTest {
 
         final String singleRecipientBase64 = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
         final PublicKey singleRecipient = PublicKey.from(Base64.getDecoder().decode(singleRecipientBase64));
-        final List<PublicKey> recipients = List.of(singleRecipient); // list the keys multiple times
+        final List<PublicKey> recipients = List.of(singleRecipient);
 
         final EncodedPayload samplePayload =
                 EncodedPayload.Builder.create()

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/ReceiveResponseTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/ReceiveResponseTest.java
@@ -1,8 +1,11 @@
 package com.quorum.tessera.transaction;
 
+import com.quorum.tessera.data.MessageHash;
+import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 import org.junit.Test;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +23,7 @@ public class ReceiveResponseTest {
 
         assertThat(result.getUnencryptedTransactionData()).containsExactly(someData);
         assertThat(result.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(result.getPrivacyGroupId()).isNotPresent();
     }
 
     @Test(expected = RuntimeException.class)
@@ -56,5 +60,27 @@ public class ReceiveResponseTest {
                 .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
                 .withUnencryptedTransactionData(someData)
                 .build();
+    }
+
+    @Test
+    public void buildWithEverything() {
+        ReceiveResponse result =
+                ReceiveResponse.Builder.create()
+                        .withUnencryptedTransactionData("data".getBytes())
+                        .withSender(PublicKey.from("sender".getBytes()))
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withAffectedTransactions(Set.of(new MessageHash("hash".getBytes())))
+                        .withExecHash("execHash".getBytes())
+                        .withManagedParties(Set.of(PublicKey.from("ownKey".getBytes())))
+                        .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
+                        .build();
+
+        assertThat(result.getPrivacyGroupId()).isPresent();
+        assertThat(result.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        assertThat(result.getAffectedTransactions()).containsExactly(new MessageHash("hash".getBytes()));
+        assertThat(result.getExecHash()).isEqualTo("execHash".getBytes());
+        assertThat(result.getPrivacyGroupId().get()).isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
+        assertThat(result.sender()).isEqualTo(PublicKey.from("sender".getBytes()));
+        assertThat(result.getManagedParties()).containsExactly(PublicKey.from("ownKey".getBytes()));
     }
 }

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/SendRequestTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/SendRequestTest.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.data.MessageHash;
+import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 import org.junit.Test;
@@ -18,6 +19,7 @@ public class SendRequestTest {
     public void buildWithEverything() {
         byte[] payload = "Payload".getBytes();
         PublicKey sender = mock(PublicKey.class);
+        PrivacyGroup.Id groupId = mock(PrivacyGroup.Id.class);
         List<PublicKey> recipients = List.of(mock(PublicKey.class));
         MessageHash affectedTransaction = mock(MessageHash.class);
         final byte[] execHash = "ExecHash".getBytes();
@@ -29,6 +31,7 @@ public class SendRequestTest {
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                         .withExecHash(execHash)
                         .withAffectedContractTransactions(Set.of(affectedTransaction))
+                        .withPrivacyGroupId(groupId)
                         .build();
 
         assertThat(sendRequest).isNotNull();
@@ -38,6 +41,8 @@ public class SendRequestTest {
         assertThat(sendRequest.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
         assertThat(sendRequest.getExecHash()).containsExactly(execHash);
         assertThat(sendRequest.getAffectedContractTransactions()).containsExactly(affectedTransaction);
+
+        assertThat(sendRequest.getPrivacyGroupId()).isPresent().get().isSameAs(groupId);
     }
 
     @Test(expected = NullPointerException.class)

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/SendSignedRequestTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/SendSignedRequestTest.java
@@ -1,6 +1,7 @@
 package com.quorum.tessera.transaction;
 
 import com.quorum.tessera.data.MessageHash;
+import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 import org.junit.Test;
@@ -21,6 +22,8 @@ public class SendSignedRequestTest {
 
         MessageHash affectedTransaction = mock(MessageHash.class);
 
+        PrivacyGroup.Id groupId = mock(PrivacyGroup.Id.class);
+
         SendSignedRequest request =
                 SendSignedRequest.Builder.create()
                         .withSender(mock(PublicKey.class))
@@ -29,6 +32,7 @@ public class SendSignedRequestTest {
                         .withRecipients(recipients)
                         .withAffectedContractTransactions(Set.of(affectedTransaction))
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withPrivacyGroupId(groupId)
                         .build();
 
         assertThat(request).isNotNull();
@@ -37,6 +41,8 @@ public class SendSignedRequestTest {
         assertThat(request.getExecHash()).containsExactly("Exehash".getBytes());
         assertThat(request.getRecipients()).hasSize(1).containsAll(recipients);
         assertThat(request.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
+
+        assertThat(request.getPrivacyGroupId()).isPresent().get().isSameAs(groupId);
     }
 
     @Test
@@ -58,6 +64,7 @@ public class SendSignedRequestTest {
         assertThat(request.getExecHash()).isEmpty();
         assertThat(request.getRecipients()).hasSize(1).containsAll(recipients);
         assertThat(request.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(request.getPrivacyGroupId()).isNotPresent();
     }
 
     @Test(expected = NullPointerException.class)

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/TransactionManagerTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/TransactionManagerTest.java
@@ -85,7 +85,7 @@ public class TransactionManagerTest {
 
         when(encodedPayload.getCipherText()).thenReturn("CIPHERTEXT".getBytes());
 
-        when(enclave.encryptPayload(any(), any(), any(), any(), any(), any())).thenReturn(encodedPayload);
+        when(enclave.encryptPayload(any(), any(), any(), any())).thenReturn(encodedPayload);
 
         PublicKey sender = PublicKey.from("SENDER".getBytes());
         PublicKey receiver = PublicKey.from("RECEIVER".getBytes());
@@ -98,6 +98,7 @@ public class TransactionManagerTest {
         when(sendRequest.getPayload()).thenReturn(payload);
         when(sendRequest.getSender()).thenReturn(sender);
         when(sendRequest.getRecipients()).thenReturn(List.of(receiver));
+        when(sendRequest.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
 
         SendResponse result = transactionManager.send(sendRequest);
 
@@ -105,11 +106,11 @@ public class TransactionManagerTest {
         assertThat(result.getTransactionHash().toString()).isEqualTo("Q0lQSEVSVEVYVA==");
         assertThat(result.getManagedParties()).containsExactly(receiver);
 
-        verify(enclave).encryptPayload(any(), any(), any(), any(), any(), any());
+        verify(enclave).encryptPayload(any(), any(), any(), any());
         verify(payloadEncoder).encode(encodedPayload);
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class), any(Callable.class));
         verify(enclave).getForwardingKeys();
-        verify(enclave, times(3)).getPublicKeys();
+        verify(enclave).getPublicKeys();
     }
 
     @Test
@@ -119,7 +120,7 @@ public class TransactionManagerTest {
 
         when(encodedPayload.getCipherText()).thenReturn("CIPHERTEXT".getBytes());
 
-        when(enclave.encryptPayload(any(), any(), any(), any(), any(), any())).thenReturn(encodedPayload);
+        when(enclave.encryptPayload(any(), any(), any(), any())).thenReturn(encodedPayload);
 
         doAnswer(
                         invocation -> {
@@ -141,6 +142,7 @@ public class TransactionManagerTest {
         when(sendRequest.getPayload()).thenReturn(payload);
         when(sendRequest.getSender()).thenReturn(sender);
         when(sendRequest.getRecipients()).thenReturn(List.of(receiver));
+        when(sendRequest.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
 
         SendResponse result = transactionManager.send(sendRequest);
 
@@ -148,11 +150,11 @@ public class TransactionManagerTest {
         assertThat(result.getTransactionHash().toString()).isEqualTo("Q0lQSEVSVEVYVA==");
         assertThat(result.getManagedParties()).isEmpty();
 
-        verify(enclave).encryptPayload(any(), any(), any(), any(), any(), any());
+        verify(enclave).encryptPayload(any(), any(), any(), any());
         verify(payloadEncoder).encode(encodedPayload);
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class), any(Callable.class));
         verify(enclave).getForwardingKeys();
-        verify(enclave, times(3)).getPublicKeys();
+        verify(enclave).getPublicKeys();
         verify(batchPayloadPublisher).publishPayload(any(), anyList());
     }
 
@@ -162,7 +164,7 @@ public class TransactionManagerTest {
 
         when(encodedPayload.getCipherText()).thenReturn("CIPHERTEXT".getBytes());
 
-        when(enclave.encryptPayload(any(), any(), any(), any(), any(), any())).thenReturn(encodedPayload);
+        when(enclave.encryptPayload(any(), any(), any(), any())).thenReturn(encodedPayload);
         when(enclave.getForwardingKeys()).thenReturn(Set.of(PublicKey.from("RECEIVER".getBytes())));
 
         PublicKey sender = PublicKey.from("SENDER".getBytes());
@@ -174,6 +176,7 @@ public class TransactionManagerTest {
         when(sendRequest.getPayload()).thenReturn(payload);
         when(sendRequest.getSender()).thenReturn(sender);
         when(sendRequest.getRecipients()).thenReturn(List.of(receiver));
+        when(sendRequest.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
 
         SendResponse result = transactionManager.send(sendRequest);
 
@@ -181,11 +184,11 @@ public class TransactionManagerTest {
         assertThat(result.getTransactionHash().toString()).isEqualTo("Q0lQSEVSVEVYVA==");
         assertThat(result.getManagedParties()).isEmpty();
 
-        verify(enclave).encryptPayload(any(), any(), any(), any(), any(), any());
+        verify(enclave).encryptPayload(any(), any(), any(), any());
         verify(payloadEncoder).encode(encodedPayload);
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class), any(Callable.class));
         verify(enclave).getForwardingKeys();
-        verify(enclave, times(3)).getPublicKeys();
+        verify(enclave).getPublicKeys();
     }
 
     @Test
@@ -206,7 +209,7 @@ public class TransactionManagerTest {
 
         when(payload.getCipherText()).thenReturn("ENCRYPTED_PAYLOAD".getBytes());
 
-        when(enclave.encryptPayload(any(RawTransaction.class), any(), any(), any(), any())).thenReturn(payload);
+        when(enclave.encryptPayload(any(RawTransaction.class), any(), any())).thenReturn(payload);
 
         PublicKey receiver = PublicKey.from("RECEIVER".getBytes());
 
@@ -215,6 +218,7 @@ public class TransactionManagerTest {
         SendSignedRequest sendSignedRequest = mock(SendSignedRequest.class);
         when(sendSignedRequest.getRecipients()).thenReturn(List.of(receiver));
         when(sendSignedRequest.getSignedData()).thenReturn("HASH".getBytes());
+        when(sendSignedRequest.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
 
         SendResponse result = transactionManager.sendSignedTransaction(sendSignedRequest);
 
@@ -222,12 +226,18 @@ public class TransactionManagerTest {
         assertThat(result.getTransactionHash()).isEqualTo(new MessageHash("HASH".getBytes()));
         assertThat(result.getManagedParties()).containsExactly(receiver);
 
-        verify(enclave).encryptPayload(any(RawTransaction.class), any(), any(), any(), any());
+        ArgumentCaptor<PrivacyMetadata> data = ArgumentCaptor.forClass(PrivacyMetadata.class);
+
+        verify(enclave).encryptPayload(any(RawTransaction.class), any(), data.capture());
         verify(payloadEncoder).encode(payload);
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class), any(Callable.class));
         verify(encryptedRawTransactionDAO).retrieveByHash(any(MessageHash.class));
         verify(enclave).getForwardingKeys();
-        verify(enclave, times(3)).getPublicKeys();
+        verify(enclave).getPublicKeys();
+
+        final PrivacyMetadata passingData = data.getValue();
+        assertThat(passingData.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(passingData.getPrivacyGroupId()).isNotPresent();
     }
 
     @Test
@@ -259,13 +269,18 @@ public class TransactionManagerTest {
 
         when(payload.getCipherText()).thenReturn("ENCRYPTED_PAYLOAD".getBytes());
 
-        when(enclave.encryptPayload(any(RawTransaction.class), any(), any(), any(), any())).thenReturn(payload);
+        when(enclave.encryptPayload(any(RawTransaction.class), any(), any())).thenReturn(payload);
 
         PublicKey receiver = PublicKey.from("RECEIVER".getBytes());
 
         SendSignedRequest sendSignedRequest = mock(SendSignedRequest.class);
         when(sendSignedRequest.getRecipients()).thenReturn(List.of(receiver));
         when(sendSignedRequest.getSignedData()).thenReturn("HASH".getBytes());
+        when(sendSignedRequest.getPrivacyMode()).thenReturn(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        when(sendSignedRequest.getAffectedContractTransactions()).thenReturn(emptySet());
+        when(sendSignedRequest.getExecHash()).thenReturn("execHash".getBytes());
+        when(sendSignedRequest.getPrivacyGroupId())
+                .thenReturn(Optional.of(PrivacyGroup.Id.fromBytes("group".getBytes())));
 
         SendResponse result = transactionManager.sendSignedTransaction(sendSignedRequest);
 
@@ -273,13 +288,24 @@ public class TransactionManagerTest {
         assertThat(result.getTransactionHash()).isEqualTo(new MessageHash("HASH".getBytes()));
         assertThat(result.getManagedParties()).isEmpty();
 
-        verify(enclave).encryptPayload(any(RawTransaction.class), any(), any(), any(), any());
+        ArgumentCaptor<PrivacyMetadata> data = ArgumentCaptor.forClass(PrivacyMetadata.class);
+
+        verify(enclave).encryptPayload(any(RawTransaction.class), any(), data.capture());
         verify(payloadEncoder).encode(payload);
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class), any(Callable.class));
         verify(encryptedRawTransactionDAO).retrieveByHash(any(MessageHash.class));
         verify(enclave).getForwardingKeys();
-        verify(enclave, times(3)).getPublicKeys();
+        verify(enclave).getPublicKeys();
         verify(batchPayloadPublisher).publishPayload(any(), anyList());
+
+        final PrivacyMetadata passingData = data.getValue();
+        assertThat(passingData.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        assertThat(passingData.getAffectedContractTransactions()).isEmpty();
+        assertThat(passingData.getExecHash()).isEqualTo("execHash".getBytes());
+        assertThat(passingData.getPrivacyGroupId())
+                .isPresent()
+                .get()
+                .isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
     }
 
     @Test
@@ -299,13 +325,14 @@ public class TransactionManagerTest {
 
         when(payload.getCipherText()).thenReturn("ENCRYPTED_PAYLOAD".getBytes());
         when(enclave.getForwardingKeys()).thenReturn(Set.of(PublicKey.from("RECEIVER".getBytes())));
-        when(enclave.encryptPayload(any(RawTransaction.class), any(), any(), any(), any())).thenReturn(payload);
+        when(enclave.encryptPayload(any(RawTransaction.class), any(), any())).thenReturn(payload);
 
         PublicKey receiver = PublicKey.from("RECEIVER".getBytes());
 
         SendSignedRequest sendSignedRequest = mock(SendSignedRequest.class);
         when(sendSignedRequest.getRecipients()).thenReturn(List.of(receiver));
         when(sendSignedRequest.getSignedData()).thenReturn("HASH".getBytes());
+        when(sendSignedRequest.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
 
         SendResponse result = transactionManager.sendSignedTransaction(sendSignedRequest);
 
@@ -313,12 +340,12 @@ public class TransactionManagerTest {
         assertThat(result.getTransactionHash()).isEqualTo(new MessageHash("HASH".getBytes()));
         assertThat(result.getManagedParties()).isEmpty();
 
-        verify(enclave).encryptPayload(any(RawTransaction.class), any(), any(), any(), any());
+        verify(enclave).encryptPayload(any(RawTransaction.class), any(), any());
         verify(payloadEncoder).encode(payload);
         verify(encryptedTransactionDAO).save(any(EncryptedTransaction.class), any(Callable.class));
         verify(encryptedRawTransactionDAO).retrieveByHash(any(MessageHash.class));
         verify(enclave).getForwardingKeys();
-        verify(enclave, times(3)).getPublicKeys();
+        verify(enclave).getPublicKeys();
     }
 
     @Test
@@ -578,7 +605,6 @@ public class TransactionManagerTest {
         when(payload.getRecipientKeys()).thenReturn(singletonList(PublicKey.from("recipient".getBytes())));
         when(payload.getPrivacyMode()).thenReturn(PrivacyMode.PARTY_PROTECTION);
         when(payload.getAffectedContractTransactions()).thenReturn(affectedTx);
-        when(payload.getExecHash()).thenReturn("execHash".getBytes());
 
         when(encryptedTransactionDAO.retrieveByHash(any(MessageHash.class))).thenReturn(Optional.empty());
 
@@ -631,6 +657,7 @@ public class TransactionManagerTest {
                 EncodedPayload.Builder.create()
                         .withCipherText("ct1".getBytes())
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .build();
         when(payloadEncoder.decode(any())).thenReturn(existingPayload);
         when(encryptedTransactionDAO.retrieveByHash(any(MessageHash.class)))
@@ -640,6 +667,7 @@ public class TransactionManagerTest {
                 EncodedPayload.Builder.create()
                         .withCipherText("ct1".getBytes())
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withRecipientKey(PublicKey.from("recipient1".getBytes()))
                         .withRecipientBox("recipient_box1".getBytes())
                         .build();
@@ -681,6 +709,7 @@ public class TransactionManagerTest {
                         .withCipherText("ct1".getBytes())
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                         .withAffectedContractTransactions(Map.of(TxHash.from(new byte[0]), new byte[0]))
+                        .withExecHash("execHash".getBytes())
                         .withRecipientKeys(List.of(recipient1, recipient2))
                         .build();
         when(payloadEncoder.decode(any())).thenReturn(existingPayload);
@@ -692,6 +721,7 @@ public class TransactionManagerTest {
                         .withCipherText("ct1".getBytes())
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                         .withAffectedContractTransactions(Map.of(TxHash.from(new byte[0]), new byte[0]))
+                        .withExecHash("execHash".getBytes())
                         .withRecipientKeys(List.of(recipient1, recipient2))
                         .withRecipientBox("recipient_box1".getBytes())
                         .build();
@@ -874,6 +904,52 @@ public class TransactionManagerTest {
         assertThat(receiveResponse).isNotNull();
         assertThat(receiveResponse.sender()).isEqualTo(sender);
         assertThat(receiveResponse.getUnencryptedTransactionData()).isEqualTo(expectedOutcome);
+        assertThat(receiveResponse.getPrivacyGroupId()).isNotPresent();
+
+        verify(payloadEncoder).decode(any(byte[].class));
+        verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));
+        verify(enclave, times(2)).unencryptTransaction(any(EncodedPayload.class), any(PublicKey.class));
+        verify(enclave).getPublicKeys();
+    }
+
+    @Test
+    public void receiveWithPrivacyGroupId() {
+        PublicKey sender = PublicKey.from("sender".getBytes());
+        byte[] randomData = Base64.getEncoder().encode("odd-data".getBytes());
+        MessageHash messageHash = new MessageHash(randomData);
+
+        ReceiveRequest receiveRequest =
+                ReceiveRequest.Builder.create()
+                        .withRecipient(mock(PublicKey.class))
+                        .withTransactionHash(messageHash)
+                        .build();
+
+        EncryptedTransaction encryptedTransaction = new EncryptedTransaction(messageHash, randomData);
+
+        EncodedPayload payload = mock(EncodedPayload.class);
+        when(payload.getExecHash()).thenReturn("execHash".getBytes());
+        when(payload.getPrivacyMode()).thenReturn(PrivacyMode.PRIVATE_STATE_VALIDATION);
+        when(payload.getSenderKey()).thenReturn(sender);
+        when(payload.getPrivacyGroupId()).thenReturn(Optional.of(PrivacyGroup.Id.fromBytes("group".getBytes())));
+        when(payloadEncoder.decode(any(byte[].class))).thenReturn(payload);
+
+        when(encryptedTransactionDAO.retrieveByHash(any(MessageHash.class)))
+                .thenReturn(Optional.of(encryptedTransaction));
+
+        byte[] expectedOutcome = "Encrypted payload".getBytes();
+
+        when(enclave.unencryptTransaction(any(EncodedPayload.class), any(PublicKey.class))).thenReturn(expectedOutcome);
+
+        PublicKey publicKey = mock(PublicKey.class);
+        when(enclave.getPublicKeys()).thenReturn(Set.of(publicKey));
+
+        ReceiveResponse receiveResponse = transactionManager.receive(receiveRequest);
+
+        assertThat(receiveResponse).isNotNull();
+        assertThat(receiveResponse.sender()).isEqualTo(sender);
+        assertThat(receiveResponse.getUnencryptedTransactionData()).isEqualTo(expectedOutcome);
+        assertThat(receiveResponse.getPrivacyGroupId()).isPresent();
+        assertThat(receiveResponse.getPrivacyGroupId().get()).isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
 
         verify(payloadEncoder).decode(any(byte[].class));
         verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));
@@ -944,7 +1020,6 @@ public class TransactionManagerTest {
 
         EncodedPayload payload = mock(EncodedPayload.class);
         when(payload.getSenderKey()).thenReturn(sender);
-        when(payload.getExecHash()).thenReturn("execHash".getBytes());
         when(payload.getPrivacyMode()).thenReturn(PrivacyMode.STANDARD_PRIVATE);
         when(payload.getRecipientBoxes()).thenReturn(List.of(RecipientBox.from("box1".getBytes())));
         when(payloadEncoder.decode(any(byte[].class))).thenReturn(payload);

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/resend/ResendManagerTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/resend/ResendManagerTest.java
@@ -6,6 +6,7 @@ import com.quorum.tessera.data.MessageHash;
 import com.quorum.tessera.enclave.*;
 import com.quorum.tessera.encryption.Nonce;
 import com.quorum.tessera.encryption.PublicKey;
+import com.quorum.tessera.enclave.PayloadDigest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class ResendManagerTest {
         this.encryptedTransactionDAO = mock(EncryptedTransactionDAO.class);
         this.payloadEncoder = mock(PayloadEncoder.class);
         this.enclave = mock(Enclave.class);
-        this.payloadDigest = cipherText -> cipherText;
+        payloadDigest = cipherText -> cipherText;
 
         this.resendManager = new ResendManagerImpl(encryptedTransactionDAO, payloadEncoder, enclave, payloadDigest);
     }
@@ -165,6 +166,7 @@ public class ResendManagerTest {
                 EncodedPayload.Builder.create()
                         .withSenderKey(senderKey)
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withCipherText("CIPHERTEXT".getBytes())
                         .withRecipientBoxes(singletonList(recipientBox2))
                         .withRecipientKeys(List.of(recipientKey2, senderKey))

--- a/tessera-data/src/test/java/com/quorum/tessera/data/staging/StagingTransactionUtilsTest.java
+++ b/tessera-data/src/test/java/com/quorum/tessera/data/staging/StagingTransactionUtilsTest.java
@@ -33,11 +33,10 @@ public class StagingTransactionUtilsTest {
                         .withRecipientKeys(Arrays.asList(recipient1))
                         .withPrivacyMode(PrivacyMode.PARTY_PROTECTION)
                         .withAffectedContractTransactions(singletonMap(affectedHash, "somesecurityHash".getBytes()))
-                        .withExecHash("execHash".getBytes())
                         .build();
 
         final String messageHash =
-            Base64.getEncoder().encodeToString(new PayloadDigest.Default().digest(encodedPayload.getCipherText()));
+                Base64.getEncoder().encodeToString(new PayloadDigest.Default().digest(encodedPayload.getCipherText()));
 
         final byte[] raw = encoder.encode(encodedPayload);
 

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/PartyInfoResource.java
@@ -2,10 +2,7 @@ package com.quorum.tessera.p2p;
 
 import com.quorum.tessera.discovery.Discovery;
 import com.quorum.tessera.discovery.NodeUri;
-import com.quorum.tessera.enclave.Enclave;
-import com.quorum.tessera.enclave.EncodedPayload;
-import com.quorum.tessera.enclave.PayloadEncoder;
-import com.quorum.tessera.enclave.PrivacyMode;
+import com.quorum.tessera.enclave.*;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.p2p.model.GetPartyInfoResponse;
 import com.quorum.tessera.p2p.partyinfo.PartyInfoParser;
@@ -104,25 +101,41 @@ public class PartyInfoResource {
      *     encoded partyinfo that contains only the local node's URL if not using remote key validation; a 500 Internal
      *     Server Error if remote key validation fails
      */
-    @Operation(summary = "/partyinfo", operationId = "broadcastPartyInfo", description = "broadcast partyinfo information to server")
-    @ApiResponse(responseCode = "200",
-        description = "server successfully updated its party info",
-        content = @Content(array = @ArraySchema(schema = @Schema(description = "empty if server is using remote key validation, else is encoded partyinfo object containing only the server's URL", type = "string", format = "byte"))))
+    @Operation(
+            summary = "/partyinfo",
+            operationId = "broadcastPartyInfo",
+            description = "broadcast partyinfo information to server")
+    @ApiResponse(
+            responseCode = "200",
+            description = "server successfully updated its party info",
+            content =
+                    @Content(
+                            array =
+                                    @ArraySchema(
+                                            schema =
+                                                    @Schema(
+                                                            description =
+                                                                    "empty if server is using remote key validation, else is encoded partyinfo object containing only the server's URL",
+                                                            type = "string",
+                                                            format = "byte"))))
     @ApiResponse(responseCode = "500", description = "Validation failed (if server is using remote key validation)")
     @POST
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     public Response partyInfo(
-        @RequestBody(required = true, description = "partyinfo object")
-        final byte[] payload,
-        @HeaderParam(Constants.API_VERSION_HEADER) @Parameter(description = "client's supported API versions", array = @ArraySchema(schema = @Schema(type = "string"))) final List<String> headers) {
+            @RequestBody(required = true, description = "partyinfo object") final byte[] payload,
+            @HeaderParam(Constants.API_VERSION_HEADER)
+                    @Parameter(
+                            description = "client's supported API versions",
+                            array = @ArraySchema(schema = @Schema(type = "string")))
+                    final List<String> headers) {
 
         final PartyInfo partyInfo = partyInfoParser.from(payload);
         final Set<String> versions =
-            Optional.ofNullable(headers).orElse(emptyList()).stream()
-                .filter(Objects::nonNull)
-                .flatMap(v -> Arrays.stream(v.split(",")))
-                .collect(Collectors.toSet());
+                Optional.ofNullable(headers).orElse(emptyList()).stream()
+                        .filter(Objects::nonNull)
+                        .flatMap(v -> Arrays.stream(v.split(",")))
+                        .collect(Collectors.toSet());
 
         final NodeInfo nodeInfo = NodeInfoUtil.from(partyInfo, versions);
 
@@ -133,10 +146,10 @@ public class PartyInfoResource {
 
             discovery.onUpdate(nodeInfo);
             partyInfo.getParties().stream()
-                .map(Party::getUrl)
-                .map(NodeUri::create)
-                .map(NodeUri::asURI)
-                .forEach(partyStore::store);
+                    .map(Party::getUrl)
+                    .map(NodeUri::create)
+                    .map(NodeUri::asURI)
+                    .forEach(partyStore::store);
 
             // create an empty party info object with our URL to send back
             // this is used by older versions (before 0.10.0), but we don't want to give any info back
@@ -148,62 +161,60 @@ public class PartyInfoResource {
         final PublicKey localPublicKey = enclave.defaultPublicKey();
 
         final Predicate<Recipient> isValidRecipient =
-            r -> {
-                try {
-                    LOGGER.debug("Validating key {} for peer {}", r.getKey(), r.getUrl());
+                r -> {
+                    try {
+                        LOGGER.debug("Validating key {} for peer {}", r.getKey(), r.getUrl());
 
-                    final String dataToEncrypt = UUID.randomUUID().toString();
-                    final EncodedPayload encodedPayload =
-                        enclave.encryptPayload(
-                            dataToEncrypt.getBytes(),
-                            localPublicKey,
-                            Arrays.asList(r.getKey()),
-                            PrivacyMode.STANDARD_PRIVATE,
-                            emptyList(),
-                            new byte[0]);
+                        final String dataToEncrypt = UUID.randomUUID().toString();
+                        final EncodedPayload encodedPayload =
+                                enclave.encryptPayload(
+                                        dataToEncrypt.getBytes(),
+                                        localPublicKey,
+                                        List.of(r.getKey()),
+                                        PrivacyMetadata.Builder.forStandardPrivate().build());
 
-                    final byte[] encodedPayloadBytes = payloadEncoder.encode(encodedPayload);
+                        final byte[] encodedPayloadBytes = payloadEncoder.encode(encodedPayload);
 
-                    try (Response response =
-                             restClient
-                                 .target(r.getUrl())
-                                 .path("partyinfo")
-                                 .path("validate")
-                                 .request()
-                                 .post(Entity.entity(encodedPayloadBytes, MediaType.APPLICATION_OCTET_STREAM))) {
+                        try (Response response =
+                                restClient
+                                        .target(r.getUrl())
+                                        .path("partyinfo")
+                                        .path("validate")
+                                        .request()
+                                        .post(Entity.entity(encodedPayloadBytes, MediaType.APPLICATION_OCTET_STREAM))) {
 
-                        LOGGER.debug("Response code {} from peer {}", response.getStatus(), r.getUrl());
+                            LOGGER.debug("Response code {} from peer {}", response.getStatus(), r.getUrl());
 
-                        final String responseData = response.readEntity(String.class);
+                            final String responseData = response.readEntity(String.class);
 
-                        final boolean isValid = Objects.equals(responseData, dataToEncrypt);
-                        if (!isValid) {
-                            LOGGER.warn(
-                                "Validation of key {} for peer {} failed.  Key and peer will not be added to local partyinfo.",
-                                r.getKey(),
-                                r.getUrl());
-                            LOGGER.debug("Response from {} was {}", r.getUrl(), responseData);
+                            final boolean isValid = Objects.equals(responseData, dataToEncrypt);
+                            if (!isValid) {
+                                LOGGER.warn(
+                                        "Validation of key {} for peer {} failed.  Key and peer will not be added to local partyinfo.",
+                                        r.getKey(),
+                                        r.getUrl());
+                                LOGGER.debug("Response from {} was {}", r.getUrl(), responseData);
+                            }
+
+                            return isValid;
                         }
-
-                        return isValid;
+                        // Assume any and all exceptions to mean invalid. enclave bubbles up nacl array out of
+                        // bounds when calculating shared key from invalid data
+                    } catch (Exception ex) {
+                        LOGGER.debug(null, ex);
+                        return false;
                     }
-                    // Assume any and all exceptions to mean invalid. enclave bubbles up nacl array out of
-                    // bounds when calculating shared key from invalid data
-                } catch (Exception ex) {
-                    LOGGER.debug(null, ex);
-                    return false;
-                }
-            };
+                };
 
         final String partyInfoSender = partyInfo.getUrl();
         final Predicate<Recipient> isSender = r -> NodeUri.create(r.getUrl()).equals(NodeUri.create(partyInfoSender));
 
         // Validate caller and treat no valid certs as security issue.
         final Set<com.quorum.tessera.partyinfo.node.Recipient> validatedSendersKeys =
-            partyInfo.getRecipients().stream()
-                .filter(isSender.and(isValidRecipient))
-                .map(r -> com.quorum.tessera.partyinfo.node.Recipient.of(r.getKey(), r.getUrl()))
-                .collect(Collectors.toSet());
+                partyInfo.getRecipients().stream()
+                        .filter(isSender.and(isValidRecipient))
+                        .map(r -> com.quorum.tessera.partyinfo.node.Recipient.of(r.getKey(), r.getUrl()))
+                        .collect(Collectors.toSet());
 
         LOGGER.debug("Validated keys for peer {}: {}", partyInfoSender, validatedSendersKeys);
         if (validatedSendersKeys.isEmpty()) {
@@ -212,25 +223,28 @@ public class PartyInfoResource {
 
         // End validation stuff
         final NodeInfo reducedNodeInfo =
-            NodeInfo.Builder.create()
-                .withUrl(partyInfoSender)
-                .withSupportedApiVersions(versions)
-                .withRecipients(validatedSendersKeys)
-                .build();
+                NodeInfo.Builder.create()
+                        .withUrl(partyInfoSender)
+                        .withSupportedApiVersions(versions)
+                        .withRecipients(validatedSendersKeys)
+                        .build();
 
         discovery.onUpdate(reducedNodeInfo);
 
         partyInfo.getParties().stream()
-            .map(Party::getUrl)
-            .map(NodeUri::create)
-            .map(NodeUri::asURI)
-            .forEach(partyStore::store);
+                .map(Party::getUrl)
+                .map(NodeUri::create)
+                .map(NodeUri::asURI)
+                .forEach(partyStore::store);
 
         return Response.ok().build();
     }
 
     @Operation(summary = "/partyinfo", description = "fetch network/peer information")
-    @ApiResponse(responseCode = "200", description = "server's partyinfo data", content = @Content(schema = @Schema(implementation = GetPartyInfoResponse.class)))
+    @ApiResponse(
+            responseCode = "200",
+            description = "server's partyinfo data",
+            content = @Content(schema = @Schema(implementation = GetPartyInfoResponse.class)))
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getPartyInfo() {
@@ -266,8 +280,14 @@ public class PartyInfoResource {
         return Response.status(Response.Status.OK).entity(output).build();
     }
 
-    @Operation(summary = "/partyinfo/validate", operationId = "validateParty", description = "decrypt a UUID payload (used to validate ownership of an asymmetric key pair)")
-    @ApiResponse(responseCode = "200", description = "successfully decrypted payload", content = @Content(schema = @Schema(description = "decrypted UUID", type = "string")))
+    @Operation(
+            summary = "/partyinfo/validate",
+            operationId = "validateParty",
+            description = "decrypt a UUID payload (used to validate ownership of an asymmetric key pair)")
+    @ApiResponse(
+            responseCode = "200",
+            description = "successfully decrypted payload",
+            content = @Content(schema = @Schema(description = "decrypted UUID", type = "string")))
     @ApiResponse(responseCode = "400", description = "decrypted payload is not a valid UUID")
     @POST
     @Path("validate")

--- a/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/PartyInfoResourceTest.java
+++ b/tessera-jaxrs/sync-jaxrs/src/test/java/com/quorum/tessera/p2p/PartyInfoResourceTest.java
@@ -4,11 +4,14 @@ import com.quorum.tessera.discovery.Discovery;
 import com.quorum.tessera.enclave.Enclave;
 import com.quorum.tessera.enclave.EncodedPayload;
 import com.quorum.tessera.enclave.PayloadEncoder;
-import com.quorum.tessera.enclave.PrivacyMode;
+import com.quorum.tessera.enclave.PrivacyMetadata;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.p2p.partyinfo.PartyInfoParser;
 import com.quorum.tessera.p2p.partyinfo.PartyStore;
-import com.quorum.tessera.partyinfo.model.*;
+import com.quorum.tessera.partyinfo.model.NodeInfoUtil;
+import com.quorum.tessera.partyinfo.model.Party;
+import com.quorum.tessera.partyinfo.model.PartyInfo;
+import com.quorum.tessera.partyinfo.model.Recipient;
 import com.quorum.tessera.partyinfo.node.NodeInfo;
 import org.junit.After;
 import org.junit.Before;
@@ -31,7 +34,8 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.*;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.*;
 
 public class PartyInfoResourceTest {
@@ -154,13 +158,7 @@ public class PartyInfoResourceTest {
                             return encodedPayload;
                         })
                 .when(enclave)
-                .encryptPayload(
-                        any(byte[].class),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any());
+                .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
 
         when(payloadEncoder.encode(encodedPayload)).thenReturn(payload);
 
@@ -183,14 +181,7 @@ public class PartyInfoResourceTest {
 
         verify(partyInfoParser).from(payload);
         verify(enclave).defaultPublicKey();
-        verify(enclave)
-                .encryptPayload(
-                        any(byte[].class),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any());
+        verify(enclave).encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
         verify(payloadEncoder).encode(encodedPayload);
         verify(restClient).target(url);
 
@@ -289,13 +280,7 @@ public class PartyInfoResourceTest {
 
         EncodedPayload encodedPayload = mock(EncodedPayload.class);
 
-        when(enclave.encryptPayload(
-                        any(byte[].class),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any()))
+        when(enclave.encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class)))
                 .thenReturn(encodedPayload);
 
         when(payloadEncoder.encode(encodedPayload)).thenReturn(payload);
@@ -320,13 +305,7 @@ public class PartyInfoResourceTest {
             verify(partyInfoParser).from(payload);
             verify(enclave).defaultPublicKey();
             verify(enclave)
-                    .encryptPayload(
-                            any(byte[].class),
-                            any(PublicKey.class),
-                            anyList(),
-                            eq(PrivacyMode.STANDARD_PRIVATE),
-                            any(),
-                            any());
+                    .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
             verify(payloadEncoder).encode(encodedPayload);
             verify(restClient).target(url);
         }
@@ -362,13 +341,7 @@ public class PartyInfoResourceTest {
 
         EncodedPayload encodedPayload = mock(EncodedPayload.class);
 
-        when(enclave.encryptPayload(
-                        any(byte[].class),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any()))
+        when(enclave.encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class)))
                 .thenReturn(encodedPayload);
 
         when(payloadEncoder.encode(encodedPayload)).thenReturn(payload);
@@ -393,13 +366,7 @@ public class PartyInfoResourceTest {
             verify(partyInfoParser).from(payload);
             verify(enclave).defaultPublicKey();
             verify(enclave)
-                    .encryptPayload(
-                            any(byte[].class),
-                            any(PublicKey.class),
-                            anyList(),
-                            eq(PrivacyMode.STANDARD_PRIVATE),
-                            any(),
-                            any());
+                    .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
             verify(payloadEncoder).encode(encodedPayload);
             verify(restClient).target(url);
         }
@@ -432,13 +399,7 @@ public class PartyInfoResourceTest {
 
         EncodedPayload encodedPayload = mock(EncodedPayload.class);
 
-        when(enclave.encryptPayload(
-                        any(byte[].class),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any()))
+        when(enclave.encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class)))
                 .thenReturn(encodedPayload);
 
         when(payloadEncoder.encode(encodedPayload)).thenReturn(payload);
@@ -459,13 +420,7 @@ public class PartyInfoResourceTest {
             verify(partyInfoParser).from(payload);
             verify(enclave).defaultPublicKey();
             verify(enclave)
-                    .encryptPayload(
-                            any(byte[].class),
-                            any(PublicKey.class),
-                            anyList(),
-                            eq(PrivacyMode.STANDARD_PRIVATE),
-                            any(),
-                            any());
+                    .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
             verify(payloadEncoder).encode(encodedPayload);
             verify(restClient).target(url);
         }
@@ -542,13 +497,7 @@ public class PartyInfoResourceTest {
                             return encodedPayload;
                         })
                 .when(enclave)
-                .encryptPayload(
-                        any(byte[].class),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any());
+                .encryptPayload(any(byte[].class), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
 
         when(payloadEncoder.encode(any(EncodedPayload.class))).thenReturn("somedata".getBytes());
 
@@ -581,13 +530,7 @@ public class PartyInfoResourceTest {
 
         ArgumentCaptor<byte[]> uuidCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(enclave, times(2))
-                .encryptPayload(
-                        uuidCaptor.capture(),
-                        any(PublicKey.class),
-                        anyList(),
-                        eq(PrivacyMode.STANDARD_PRIVATE),
-                        any(),
-                        any());
+                .encryptPayload(uuidCaptor.capture(), any(PublicKey.class), anyList(), any(PrivacyMetadata.class));
         List<byte[]> capturedUUIDs = uuidCaptor.getAllValues();
         assertThat(capturedUUIDs).hasSize(2);
         assertThat(capturedUUIDs.get(0)).isNotEqualTo(capturedUUIDs.get(1));

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/EncodedPayloadResourceTest.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/EncodedPayloadResourceTest.java
@@ -169,14 +169,14 @@ public class EncodedPayloadResourceTest {
                 List.of(decoder.decode("FNirZRc2ayMaYopCBaWQ/1I7VWFiCM0lNw533Hckzxb+qpvngdWVVzJlsE05dbxl")));
         request.setRecipientNonce(decoder.decode("p9gYDJlEoBvLdUQ+ZoONl2Jl9AirV1en"));
         request.setRecipientKeys(List.of(decoder.decode("BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=")));
-        request.setPrivacyMode(0);
+        request.setPrivacyMode(3);
         request.setAffectedContractTransactions(Map.of("dHgx", "dHgxdmFs", "dHgy", "dHgydmFs"));
         request.setExecHash("execHash".getBytes());
 
         final ReceiveResponse response =
                 ReceiveResponse.Builder.create()
                         .withUnencryptedTransactionData("decryptedData".getBytes())
-                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                         .withAffectedTransactions(
                                 Set.of(new MessageHash("tx1val".getBytes()), new MessageHash("tx2val".getBytes())))
                         .withExecHash("execHash".getBytes())
@@ -195,7 +195,7 @@ public class EncodedPayloadResourceTest {
         final com.quorum.tessera.api.ReceiveResponse payloadEncryptResponse =
                 result.readEntity(com.quorum.tessera.api.ReceiveResponse.class);
         assertThat(payloadEncryptResponse.getPayload()).isEqualTo("decryptedData".getBytes());
-        assertThat(payloadEncryptResponse.getPrivacyFlag()).isEqualTo(0);
+        assertThat(payloadEncryptResponse.getPrivacyFlag()).isEqualTo(3);
         assertThat(payloadEncryptResponse.getAffectedContractTransactions())
                 .containsExactlyInAnyOrder("dHgxdmFs", "dHgydmFs");
         assertThat(payloadEncryptResponse.getExecHash()).isEqualTo("execHash");
@@ -217,7 +217,7 @@ public class EncodedPayloadResourceTest {
                 .isEqualTo(decoder.decode("p9gYDJlEoBvLdUQ+ZoONl2Jl9AirV1en"));
         assertThat(payloadBeforeDecryption.getRecipientKeys())
                 .containsExactly(PublicKey.from(decoder.decode("BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=")));
-        assertThat(payloadBeforeDecryption.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(payloadBeforeDecryption.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
         assertThat(payloadBeforeDecryption.getAffectedContractTransactions())
                 .contains(
                         entry(TxHash.from("tx1".getBytes()), SecurityHash.from("tx1val".getBytes())),
@@ -316,14 +316,14 @@ public class EncodedPayloadResourceTest {
                 List.of(decoder.decode("FNirZRc2ayMaYopCBaWQ/1I7VWFiCM0lNw533Hckzxb+qpvngdWVVzJlsE05dbxl")));
         request.setRecipientNonce(decoder.decode("p9gYDJlEoBvLdUQ+ZoONl2Jl9AirV1en"));
         request.setRecipientKeys(List.of(decoder.decode("BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=")));
-        request.setPrivacyMode(0);
+        request.setPrivacyMode(3);
         request.setAffectedContractTransactions(Map.of("dHgx", "dHgxdmFs", "dHgy", "dHgydmFs"));
         request.setExecHash("execHash".getBytes());
 
         final ReceiveResponse response =
                 ReceiveResponse.Builder.create()
                         .withUnencryptedTransactionData("decryptedData".getBytes())
-                        .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
+                        .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
                         .withAffectedTransactions(
                                 Set.of(new MessageHash("tx1val".getBytes()), new MessageHash("tx2val".getBytes())))
                         .withExecHash("execHash".getBytes())
@@ -340,7 +340,7 @@ public class EncodedPayloadResourceTest {
         final com.quorum.tessera.api.ReceiveResponse payloadEncryptResponse =
                 result.readEntity(com.quorum.tessera.api.ReceiveResponse.class);
         assertThat(payloadEncryptResponse.getPayload()).isEqualTo("decryptedData".getBytes());
-        assertThat(payloadEncryptResponse.getPrivacyFlag()).isEqualTo(0);
+        assertThat(payloadEncryptResponse.getPrivacyFlag()).isEqualTo(3);
         assertThat(payloadEncryptResponse.getAffectedContractTransactions())
                 .containsExactlyInAnyOrder("dHgxdmFs", "dHgydmFs");
         assertThat(payloadEncryptResponse.getExecHash()).isEqualTo("execHash");
@@ -362,7 +362,7 @@ public class EncodedPayloadResourceTest {
                 .isEqualTo(decoder.decode("p9gYDJlEoBvLdUQ+ZoONl2Jl9AirV1en"));
         assertThat(payloadBeforeDecryption.getRecipientKeys())
                 .containsExactly(PublicKey.from(decoder.decode("BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=")));
-        assertThat(payloadBeforeDecryption.getPrivacyMode()).isEqualTo(PrivacyMode.STANDARD_PRIVATE);
+        assertThat(payloadBeforeDecryption.getPrivacyMode()).isEqualTo(PrivacyMode.PRIVATE_STATE_VALIDATION);
         assertThat(payloadBeforeDecryption.getAffectedContractTransactions())
                 .contains(
                         entry(TxHash.from("tx1".getBytes()), SecurityHash.from("tx1val".getBytes())),

--- a/tessera-recover/src/test/java/com/quorum/tessera/recovery/workflow/PreparePayloadForRecipientTest.java
+++ b/tessera-recover/src/test/java/com/quorum/tessera/recovery/workflow/PreparePayloadForRecipientTest.java
@@ -125,6 +125,7 @@ public class PreparePayloadForRecipientTest {
                 EncodedPayload.Builder.create()
                         .withSenderKey(targetResendKey)
                         .withPrivacyMode(PrivacyMode.PRIVATE_STATE_VALIDATION)
+                        .withExecHash("execHash".getBytes())
                         .withRecipientKeys(List.of(recipient1, recipient2))
                         .withRecipientBox("encrypteddata1".getBytes())
                         .build();

--- a/tessera-recover/src/test/java/com/quorum/tessera/recovery/workflow/StandardPrivateOnlyFilterTest.java
+++ b/tessera-recover/src/test/java/com/quorum/tessera/recovery/workflow/StandardPrivateOnlyFilterTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class StandardPrivateOnlyFilterTest {
 
-    private StandardPrivateOnlyFilter filter = new StandardPrivateOnlyFilter();
+    private final StandardPrivateOnlyFilter filter = new StandardPrivateOnlyFilter();
 
     @Test
     public void nullInputDoesntPass() {
@@ -24,21 +24,25 @@ public class StandardPrivateOnlyFilterTest {
     @Test
     public void nonStandardPrivateDoesntPass() {
         Arrays.stream(PrivacyMode.values())
-            .filter(p -> !PrivacyMode.STANDARD_PRIVATE.equals(p))
-            .forEach(p -> {
-                final EncodedPayload psvPayload = EncodedPayload.Builder.create().withPrivacyMode(p).build();
-                final BatchWorkflowContext contextPsv = new BatchWorkflowContext();
-                contextPsv.setEncodedPayload(psvPayload);
+                .filter(p -> !PrivacyMode.STANDARD_PRIVATE.equals(p))
+                .forEach(
+                        p -> {
+                            final EncodedPayload.Builder builder = EncodedPayload.Builder.create().withPrivacyMode(p);
+                            if (p == PrivacyMode.PRIVATE_STATE_VALIDATION) {
+                                builder.withExecHash("execHash".getBytes());
+                            }
+                            final EncodedPayload psvPayload = builder.build();
+                            final BatchWorkflowContext contextPsv = new BatchWorkflowContext();
+                            contextPsv.setEncodedPayload(psvPayload);
 
-                assertThat(filter.filter(contextPsv)).isFalse();
-            });
+                            assertThat(filter.filter(contextPsv)).isFalse();
+                        });
     }
 
     @Test
     public void standardPrivatePasses() {
-        final EncodedPayload payload = EncodedPayload.Builder.create()
-            .withPrivacyMode(PrivacyMode.STANDARD_PRIVATE)
-            .build();
+        final EncodedPayload payload =
+                EncodedPayload.Builder.create().withPrivacyMode(PrivacyMode.STANDARD_PRIVATE).build();
         final BatchWorkflowContext context = new BatchWorkflowContext();
         context.setEncodedPayload(payload);
 


### PR DESCRIPTION
A part of #1216.

This PR is specific to

- Include PrivacyGroupId in EncodedPayload
- Include PrivacyGroupId in send and receive domain objects
- Modify enclave encrypt signature to also include privacy group id
- Changes to the payload encoder and unit tests to ensure backward compatibility