### PR TITLE
Handle null addresses list in privacygroup request

### DIFF
--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/PrivacyGroupResource.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/PrivacyGroupResource.java
@@ -70,7 +70,8 @@ public class PrivacyGroupResource {
                         .orElseGet(privacyGroupManager::defaultPublicKey);
 
         final List<PublicKey> members =
-                Arrays.stream(request.getAddresses())
+                Stream.ofNullable(request.getAddresses())
+                        .flatMap(Arrays::stream)
                         .map(base64Codec::decode)
                         .map(PublicKey::from)
                         .collect(Collectors.toList());


### PR DESCRIPTION
Address list in the privacygroup request came from besu might be null - treat as empty list