### PR TITLE
Convert Orion keys to Tessera keys during migration

### DIFF
--- a/migration/orion-to-tessera/src/test/java/net/consensys/tessera/migration/OrionKeyHelperTest.java
+++ b/migration/orion-to-tessera/src/test/java/net/consensys/tessera/migration/OrionKeyHelperTest.java
@@ -1,0 +1,26 @@
+package net.consensys.tessera.migration;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrionKeyHelperTest {
+
+    @Test
+    public void migrateTesseraKeysCorrectly() throws IOException {
+
+        Path orionConfigFilePath = Paths.get("").resolve("orion.conf").toAbsolutePath();
+
+        OrionKeyHelper.from(orionConfigFilePath);
+
+        Path expectedKeyPath = Paths.get("./nodeKey.key.tessera");
+        assertThat(expectedKeyPath).exists();
+
+        Files.delete(expectedKeyPath);
+    }
+}


### PR DESCRIPTION
Add migration of Orion keys to tessera keys, storing in a new file.
Show how Tessera can be used to unlock Orion private keys.