### PR TITLE
Update Docker tagging

### DIFF
--- a/.github/workflows/docker-push-latest.yml
+++ b/.github/workflows/docker-push-latest.yml
@@ -16,5 +16,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ secrets.DOCKER_REPO }}
-          tags: latest
+          tags: develop
           add_git_labels: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -177,7 +177,7 @@ jobs:
       - uses: docker/build-push-action@v1
         with:
           repository: quorumengineering/tessera
-          tags: latest
+          tags: develop
           push: false
           dockerfile: .github/workflows/noBuild.Dockerfile
           build_args: JAR_FILE=tessera-dist/tessera-app/build/libs/tessera-app-*-app.jar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
       - uses: docker/build-push-action@v1
         with:
           repository: quorumengineering/tessera
-          tags: latest
+          tags: develop
           push: false
           dockerfile: .github/workflows/noBuild.Dockerfile
           build_args: JAR_FILE=tessera-dist/tessera-app/target/*-app.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ secrets.DOCKER_REPO }}
-          tags: ${{ steps.tag.outputs.full-ver }}, ${{ steps.tag.outputs.minor-ver }}
+          tags: ${{ steps.tag.outputs.full-ver }}, ${{ steps.tag.outputs.minor-ver }}, latest
           add_git_labels: true
           dockerfile: release-checkout/.github/workflows/noBuild.Dockerfile
           path: release-checkout/tessera-dist/tessera-app/target


### PR DESCRIPTION
#### Summary

This PR update Docker tagging so

|  Docker Tag |       Git Ref      |                                                                                    Comment                                                                                    |
|:-----------:|:------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
| YY.MM.Patch | tag YY.MM.Patch    | Image is created when pushing git tag YY.MM.Patch and then it is never overridden                                                                                             |
| YY.MM       | latest tag YY.MM.* | Image is created for the first time when pushing git tag YY.MM.0 then it is overridden on every new YY.MM.* git tag Once bumping to YY’.MM’.0 image is not overridden anymore |
| latest      | latest tag         | Image is built for the first time when pushing first git tag then it is overridden on every new git tag                                                                       |
| develop     | master             | Image is built for the first time when pushing to master then is overridden on every new push/merge into master                                                               |