### PR TITLE
Activate RestSuiteHttpH2EncTypeEC and RestSuiteBesu

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - run: ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC
+      - run: ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave
       - uses: actions/upload-artifact@v1
         if: failure()
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -127,7 +127,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - run: ./gradlew :tests:acceptance-test:test -PexcludeTests="RecoverIT,RestSuiteHttpH2RemoteEnclave,RunHashicorpIT,RunAzureIT,RunAwsIT"
+    - run: ./gradlew :tests:acceptance-test:test -PexcludeTests="RecoverIT,RestSuiteHttpH2RemoteEnclave,RestSuiteHttpH2RemoteEnclaveEncTypeEC,RunHashicorpIT,RunAzureIT,RunAwsIT"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - run: ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave
+      - run: ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC
       - uses: actions/upload-artifact@v1
         if: failure()
         with:

--- a/cli/config-cli/build.gradle
+++ b/cli/config-cli/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compile 'javax.ws.rs:javax.ws.rs-api'
 
   runtimeOnly project(':encryption:encryption-jnacl')
+  runtimeOnly project(':encryption:encryption-ec')
 
   testCompile project(':tests:test-util')
   testCompile 'org.hibernate:hibernate-validator'

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   compile 'org.jasypt:jasypt'
   runtimeOnly 'org.glassfish:javax.el'
   runtimeOnly project(':encryption:encryption-jnacl')
+  runtimeOnly project(':encryption:encryption-ec')
   testCompile project(':tests:test-util')
   testCompile 'org.hibernate:hibernate-validator'
   runtimeOnly 'org.eclipse.persistence:org.eclipse.persistence.moxy'

--- a/tessera-dist/build.gradle
+++ b/tessera-dist/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   compile project(':server:jersey-server')
   compile 'org.glassfish.jersey.media:jersey-media-json-processing:2.27'
   compile project(':encryption:encryption-jnacl')
-
+  compile project(':encryption:encryption-ec')
   compile "org.bouncycastle:bcpkix-jdk15on"
 }
 

--- a/tessera-dist/tessera-app/build.gradle
+++ b/tessera-dist/tessera-app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile project(':server:jersey-server')
   compile 'org.glassfish.jersey.media:jersey-media-json-processing:2.27'
   compile project(':encryption:encryption-jnacl')
-
+  compile project(':encryption:encryption-ec')
   compile "org.bouncycastle:bcpkix-jdk15on"
 }
 

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -66,6 +66,8 @@ test {
   include(
     '**/RecoverIT.class',
     '**/RestSuiteHttpH2RemoteEnclave.class',
+    '**/RestSuiteHttpH2EncTypeEC.class',
+    '**/RestSuiteBesu.class',
     '**/RestSuiteHttpHSQL.class',
     '**/RestSuiteUnixH2.class',
     '**/RestSuiteHttpSqllite.class',

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -66,6 +66,7 @@ test {
   include(
     '**/RecoverIT.class',
     '**/RestSuiteHttpH2RemoteEnclave.class',
+    '**/RestSuiteHttpH2RemoteEnclaveEncTypeEC.class',
     '**/RestSuiteHttpH2EncTypeEC.class',
     '**/RestSuiteBesu.class',
     '**/RestSuiteHttpHSQL.class',

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/DBType.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/DBType.java
@@ -6,10 +6,10 @@ import java.net.URL;
 
 public enum DBType {
   H2(
-      "jdbc:h2:./target/h2/%s%d;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE",
+      "jdbc:h2:./build/h2/%s%d;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE",
       "/ddls/h2-ddl.sql"),
   HSQL("jdbc:hsqldb:hsql://127.0.0.1:9189/%s%d", "/ddls/hsql-ddl.sql"),
-  SQLITE("jdbc:sqlite:target/sqlite-%s%d.db", "/ddls/sqlite-ddl.sql");
+  SQLITE("jdbc:sqlite:build/sqlite-%s%d.db", "/ddls/sqlite-ddl.sql");
 
   private final String urlTemplate;
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuiteHttpH2RemoteEnclaveEncTypeEC.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuiteHttpH2RemoteEnclaveEncTypeEC.java
@@ -1,0 +1,20 @@
+package com.quorum.tessera.test.rest;
+
+import com.quorum.tessera.config.CommunicationType;
+import com.quorum.tessera.config.EncryptorType;
+import com.quorum.tessera.test.DBType;
+import org.junit.runner.RunWith;
+import suite.EnclaveType;
+import suite.ProcessConfig;
+import suite.SocketType;
+import suite.TestSuite;
+
+@RunWith(TestSuite.class)
+@ProcessConfig(
+  communicationType = CommunicationType.REST,
+  dbType = DBType.H2,
+  socketType = SocketType.HTTP,
+  enclaveType = EnclaveType.REMOTE,
+  encryptorType = EncryptorType.EC)
+public class RestSuiteHttpH2RemoteEnclaveEncTypeEC extends RestSuite {
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuiteHttpH2RemoteEnclaveEncTypeEC.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuiteHttpH2RemoteEnclaveEncTypeEC.java
@@ -11,10 +11,9 @@ import suite.TestSuite;
 
 @RunWith(TestSuite.class)
 @ProcessConfig(
-  communicationType = CommunicationType.REST,
-  dbType = DBType.H2,
-  socketType = SocketType.HTTP,
-  enclaveType = EnclaveType.REMOTE,
-  encryptorType = EncryptorType.EC)
-public class RestSuiteHttpH2RemoteEnclaveEncTypeEC extends RestSuite {
-}
+    communicationType = CommunicationType.REST,
+    dbType = DBType.H2,
+    socketType = SocketType.HTTP,
+    enclaveType = EnclaveType.REMOTE,
+    encryptorType = EncryptorType.EC)
+public class RestSuiteHttpH2RemoteEnclaveEncTypeEC extends RestSuite {}

--- a/tests/acceptance-test/src/test/resources/logback-enclave.xml
+++ b/tests/acceptance-test/src/test/resources/logback-enclave.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/enclave-${node.number}.log</file>
+        <file>build/logs/enclave-${node.number}.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/tests/acceptance-test/src/test/resources/logback-node.xml
+++ b/tests/acceptance-test/src/test/resources/logback-node.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/node-${node.number}.log</file>
+        <file>build/logs/node-${node.number}.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>


### PR DESCRIPTION
Activate RestSuiteHttpH2EncTypeEC and RestSuiteBesu. 
Add EC encryptor to all modules that use JNACL (with the exception of simple dist) .
Add and active RemoteEnclave test suite that uses EC for enc type to ensure remoted enclave and client support the config.