### PR TITLE
Make docker entrypoint consistent with previous images

### DIFF
--- a/.github/workflows/noBuild.Dockerfile
+++ b/.github/workflows/noBuild.Dockerfile
@@ -8,6 +8,6 @@ RUN mkdir /tessera/distributions/extracted && tar xvf /tessera/distributions/tes
 # Create executable image
 FROM adoptopenjdk/openjdk11:alpine
 
-COPY --from=extractor /tessera/distributions/extracted /home/tessera-extracted/
+COPY --from=extractor /tessera/distributions/extracted /tessera
 
-ENTRYPOINT ["/home/tessera-extracted/bin/tessera"]
+ENTRYPOINT ["/tessera/bin/tessera"]


### PR DESCRIPTION
Previous images built off of the .jar distributions used entrypoint `/tessera/tessera-app.jar`.  Keeping closer consistency should make scripting etc. easier for users. 

**Note: The acceptance test check will fail as it currently depends on the old entrypoint.  [Acceptance Test PR 118](https://github.com/ConsenSys/quorum-acceptance-tests/pull/118) has been raised to update the entrypoint.**

**Note: [Quorum Examples PR 262](https://github.com/ConsenSys/quorum-examples/pull/262) assumes this PR has been accepted and merged.**