### PR TITLE
Server Metric resource not being deployed 

### DIFF
--- a/server/jersey-server/src/main/java/module-info.java
+++ b/server/jersey-server/src/main/java/module-info.java
@@ -28,7 +28,8 @@ module tessera.server.jersey {
   exports com.quorum.tessera.server.jaxrs to
       hk2.locator;
   exports com.quorum.tessera.server.monitoring to
-      hk2.locator;
+      hk2.locator,
+      jersey.server;
 
   opens com.quorum.tessera.server.jaxrs to
       hk2.utils;

--- a/server/jersey-server/src/main/java/module-info.java
+++ b/server/jersey-server/src/main/java/module-info.java
@@ -27,6 +27,8 @@ module tessera.server.jersey {
   exports com.quorum.tessera.server.http;
   exports com.quorum.tessera.server.jaxrs to
       hk2.locator;
+  exports com.quorum.tessera.server.monitoring to
+      hk2.locator;
 
   opens com.quorum.tessera.server.jaxrs to
       hk2.utils;

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.ServerConfig;
-import com.quorum.tessera.jaxrs.client.ClientFactory;
 import com.quorum.tessera.test.Party;
 import com.quorum.tessera.test.PartyHelper;
 import java.net.URI;
@@ -22,8 +21,6 @@ public class MetricsIT {
   @Test
   public void metrics() {
     final PartyHelper partyHelper = PartyHelper.create();
-
-    ClientFactory clientFactory = new ClientFactory();
 
     Set<URI> uris =
         partyHelper

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
@@ -1,20 +1,19 @@
 package com.quorum.tessera.test.rest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.jaxrs.client.ClientFactory;
 import com.quorum.tessera.test.Party;
 import com.quorum.tessera.test.PartyHelper;
-import java.net.URI;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetricsIT {
 
@@ -22,28 +21,22 @@ public class MetricsIT {
   public void metrics() {
     final PartyHelper partyHelper = PartyHelper.create();
 
-    Set<URI> uris =
+    Set<ServerConfig> serverConfigs =
         partyHelper
             .getParties()
             .map(Party::getConfig)
             .map(Config::getServerConfigs)
             .flatMap(List::stream)
-            .map(ServerConfig::getServerUri)
             .collect(Collectors.toUnmodifiableSet());
 
-    Client client = partyHelper.getParties().findAny().get().getRestClient();
-
-    Set<Response> responses =
-        uris.stream()
-            .map(client::target)
-            .map(t -> t.path("metrics"))
-            .map(WebTarget::request)
-            .map(Invocation.Builder::get)
-            .collect(Collectors.toUnmodifiableSet());
-
-    for (Response response : responses) {
+    ClientFactory clientFactory = new ClientFactory();
+    for(ServerConfig serverConfig : serverConfigs) {
+      Client c = clientFactory.buildFrom(serverConfig);
+      Response response = c.target(serverConfig.getServerUri()).path("metrics").request().get();
       assertThat(response).isNotNull();
       assertThat(response.getStatus()).isEqualTo(200);
     }
+
+
   }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
@@ -1,0 +1,52 @@
+package com.quorum.tessera.test.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ServerConfig;
+import com.quorum.tessera.jaxrs.client.ClientFactory;
+import com.quorum.tessera.test.Party;
+import com.quorum.tessera.test.PartyHelper;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
+
+public class MetricsIT {
+
+  @Test
+  public void metrics() {
+    final PartyHelper partyHelper = PartyHelper.create();
+
+    ClientFactory clientFactory = new ClientFactory();
+
+    Set<URI> uris =
+        partyHelper
+            .getParties()
+            .map(Party::getConfig)
+            .map(Config::getServerConfigs)
+            .flatMap(List::stream)
+            .map(ServerConfig::getServerUri)
+            .collect(Collectors.toUnmodifiableSet());
+
+    Client client = partyHelper.getParties().findAny().get().getRestClient();
+
+    Set<Response> responses =
+        uris.stream()
+            .map(client::target)
+            .map(t -> t.path("metrics"))
+            .map(WebTarget::request)
+            .map(Invocation.Builder::get)
+            .collect(Collectors.toUnmodifiableSet());
+
+    for (Response response : responses) {
+      assertThat(response).isNotNull();
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
+  }
+}

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/MetricsIT.java
@@ -1,19 +1,18 @@
 package com.quorum.tessera.test.rest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.ServerConfig;
 import com.quorum.tessera.jaxrs.client.ClientFactory;
 import com.quorum.tessera.test.Party;
 import com.quorum.tessera.test.PartyHelper;
-import org.junit.Test;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
 
 public class MetricsIT {
 
@@ -30,13 +29,11 @@ public class MetricsIT {
             .collect(Collectors.toUnmodifiableSet());
 
     ClientFactory clientFactory = new ClientFactory();
-    for(ServerConfig serverConfig : serverConfigs) {
+    for (ServerConfig serverConfig : serverConfigs) {
       Client c = clientFactory.buildFrom(serverConfig);
       Response response = c.target(serverConfig.getServerUri()).path("metrics").request().get();
       assertThat(response).isNotNull();
       assertThat(response.getStatus()).isEqualTo(200);
     }
-
-
   }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuite.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuite.java
@@ -20,6 +20,7 @@ import suite.TestSuite;
   TransactionForwardingIT.class,
   CustomPayloadEncryptionIT.class,
   OpenApiIT.class,
+  MetricsIT.class,
   ///
   com.quorum.tessera.test.rest.multitenancy.SendIT.class,
   com.quorum.tessera.test.rest.multitenancy.ReceiveIT.class,


### PR DESCRIPTION
Report of /metrics endpoint not working. 
1. Missing integration tests to ensure that endpoint is deployed and accessible
2. Once issue was found (package com.quorum.tessera.server.monitoring not being exports to hk2 library used internally by jersey. 

