### PR TITLE
metrics formatting: preserve trailing whitespace

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,13 +58,13 @@ jobs:
       with:
         name: kalium-dist
         path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-    - name: Send slack notification
-      uses: homoluctus/slatify@v3.0.0
-      if: always()
-      with:
-        type: ${{job.status}}
-        job_name: Build and upload binaries
-        url: ${{ secrets.SLACK_WEBHOOK }}
+#    - name: Send slack notification
+#      uses: homoluctus/slatify@v3.0.0
+#      if: always()
+#      with:
+#        type: ${{job.status}}
+#        job_name: Build and upload binaries
+#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   checkdependencies:
     name: Check dependencies for any security advisories
@@ -80,13 +80,13 @@ jobs:
         check-latest: true
     - name: Execute gradle dependencyCheckAnalyze task
       run: ./gradlew dependencyCheckAnalyze -x test
-    - name: Send slack notification
-      uses: homoluctus/slatify@v3.0.0
-      if: always()
-      with:
-        type: ${{job.status}}
-        job_name: Check dependencies for any security advisories
-        url: ${{ secrets.SLACK_WEBHOOK }}
+#    - name: Send slack notification
+#      uses: homoluctus/slatify@v3.0.0
+#      if: always()
+#      with:
+#        type: ${{job.status}}
+#        job_name: Check dependencies for any security advisories
+#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   test:
     name: Unit tests
@@ -102,13 +102,13 @@ jobs:
         check-latest: true
     - name: Execute gradle test
       run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc -x :cli:config-cli:jacocoTestCoverageVerification --info
-    - name: Send slack notification
-      uses: homoluctus/slatify@v3.0.0
-      if: always()
-      with:
-        type: ${{job.status}}
-        job_name: Unit tests
-        url: ${{ secrets.SLACK_WEBHOOK }}
+#    - name: Send slack notification
+#      uses: homoluctus/slatify@v3.0.0
+#      if: always()
+#      with:
+#        type: ${{job.status}}
+#        job_name: Unit tests
+#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   itest:
     name: Integration tests
@@ -168,13 +168,13 @@ jobs:
       with:
        name: itest-logs
        path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-    - name: Send slack notification
-      uses: homoluctus/slatify@v3.0.0
-      if: always()
-      with:
-        type: ${{job.status}}
-        job_name: Integration tests
-        url: ${{ secrets.SLACK_WEBHOOK }}
+#    - name: Send slack notification
+#      uses: homoluctus/slatify@v3.0.0
+#      if: always()
+#      with:
+#        type: ${{job.status}}
+#        job_name: Integration tests
+#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   remote_enclave_itest:
     name: Remote enclave integration tests
@@ -234,13 +234,13 @@ jobs:
         with:
           name: remote_enclave_itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-      - name: Send slack notification
-        uses: homoluctus/slatify@v3.0.0
-        if: always()
-        with:
-          type: ${{job.status}}
-          job_name: Remote enclave integration tests
-          url: ${{ secrets.SLACK_WEBHOOK }}
+#      - name: Send slack notification
+#        uses: homoluctus/slatify@v3.0.0
+#        if: always()
+#        with:
+#          type: ${{job.status}}
+#          job_name: Remote enclave integration tests
+#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   cucumber_itest:
     name: Cucumber itests
@@ -300,13 +300,13 @@ jobs:
         with:
           name: cucumber_itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-      - name: Send slack notification
-        uses: homoluctus/slatify@v3.0.0
-        if: always()
-        with:
-          type: ${{job.status}}
-          job_name: Cucumber itests
-          url: ${{ secrets.SLACK_WEBHOOK }}
+#      - name: Send slack notification
+#        uses: homoluctus/slatify@v3.0.0
+#        if: always()
+#        with:
+#          type: ${{job.status}}
+#          job_name: Cucumber itests
+#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   vaultTests:
     name: Key vault integration tests
@@ -375,12 +375,12 @@ jobs:
         with:
           name: vault-itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-      - uses: homoluctus/slatify@v3.0.0
-        if: always()
-        with:
-          type: ${{job.status}}
-          job_name: Key vault integration tests
-          url: ${{ secrets.SLACK_WEBHOOK }}
+#      - uses: homoluctus/slatify@v3.0.0
+#        if: always()
+#        with:
+#          type: ${{job.status}}
+#          job_name: Key vault integration tests
+#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   recovery_itest:
     name: Recovery integration tests
@@ -440,13 +440,13 @@ jobs:
         with:
           name: recovery-itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-      - name: Send slack notification
-        uses: homoluctus/slatify@v3.0.0
-        if: always()
-        with:
-          type: ${{job.status}}
-          job_name: Recovery integration tests
-          url: ${{ secrets.SLACK_WEBHOOK }}
+#      - name: Send slack notification
+#        uses: homoluctus/slatify@v3.0.0
+#        if: always()
+#        with:
+#          type: ${{job.status}}
+#          job_name: Recovery integration tests
+#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   build_image:
     name: Build develop Docker image
@@ -536,13 +536,13 @@ jobs:
         with:
           name: gauge-reports
           path: /tmp/acctests/gauge
-      - name: Send slack notification
-        uses: homoluctus/slatify@v3.0.0
-        if: always()
-        with:
-          type: ${{job.status}}
-          job_name: Quorum acceptance tests
-          url: ${{ secrets.SLACK_WEBHOOK }}
+#      - name: Send slack notification
+#        uses: homoluctus/slatify@v3.0.0
+#        if: always()
+#        with:
+#          type: ${{job.status}}
+#          job_name: Quorum acceptance tests
+#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   push_docker_develop:
     name: Push develop image to DockerHub

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MetricsResource.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MetricsResource.java
@@ -39,7 +39,7 @@ public class MetricsResource {
 
     return Response.status(Response.Status.OK)
         .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .entity(formattedMetrics.toString().trim())
+        .entity(formattedMetrics.toString())
         .build();
   }
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MetricsResource.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MetricsResource.java
@@ -39,7 +39,7 @@ public class MetricsResource {
 
     return Response.status(Response.Status.OK)
         .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .entity(formattedMetrics.append("\n").toString())
+        .entity(formattedMetrics.toString())
         .build();
   }
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MetricsResource.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/MetricsResource.java
@@ -34,12 +34,12 @@ public class MetricsResource {
       List<MBeanMetric> metrics = metricsEnquirer.getMBeanMetrics(type);
       PrometheusProtocolFormatter formatter = new PrometheusProtocolFormatter();
 
-      formattedMetrics.append(formatter.format(metrics, type)).append("\n");
+      formattedMetrics.append(formatter.format(metrics, type));
     }
 
     return Response.status(Response.Status.OK)
         .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .entity(formattedMetrics.toString())
+        .entity(formattedMetrics.append("\n").toString())
         .build();
   }
 }

--- a/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/PrometheusProtocolFormatter.java
+++ b/server/jersey-server/src/main/java/com/quorum/tessera/server/monitoring/PrometheusProtocolFormatter.java
@@ -23,7 +23,7 @@ public class PrometheusProtocolFormatter {
           .append("\n");
     }
 
-    return formattedMetrics.toString().trim();
+    return formattedMetrics.toString();
   }
 
   private String sanitize(final String input) {

--- a/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/PrometheusProtocolFormatterTest.java
+++ b/server/jersey-server/src/test/java/com/quorum/tessera/server/monitoring/PrometheusProtocolFormatterTest.java
@@ -27,7 +27,7 @@ public class PrometheusProtocolFormatterTest {
 
     AppType type = AppType.P2P;
 
-    String expectedResponse = "tessera_P2P_GET_upCheck_AverageTime_ms 100";
+    String expectedResponse = "tessera_P2P_GET_upCheck_AverageTime_ms 100\n";
 
     assertThat(protocolFormatter.format(mockMetrics, type)).isEqualTo(expectedResponse);
   }
@@ -41,7 +41,7 @@ public class PrometheusProtocolFormatterTest {
     AppType type = AppType.P2P;
 
     String expectedResponse =
-        "tessera_P2P_POST_resend_ResendRequest_RequestRate_requestsPerSeconds 1.3";
+        "tessera_P2P_POST_resend_ResendRequest_RequestRate_requestsPerSeconds 1.3\n";
 
     assertThat(protocolFormatter.format(mockMetrics, type)).isEqualTo(expectedResponse);
   }
@@ -53,7 +53,7 @@ public class PrometheusProtocolFormatterTest {
 
     AppType type = AppType.P2P;
 
-    String expectedResponse = "tessera_P2P_POST_push_byte_MinTime_ms 3.4";
+    String expectedResponse = "tessera_P2P_POST_push_byte_MinTime_ms 3.4\n";
 
     assertThat(protocolFormatter.format(mockMetrics, type)).isEqualTo(expectedResponse);
   }
@@ -66,7 +66,7 @@ public class PrometheusProtocolFormatterTest {
 
     AppType type = AppType.P2P;
 
-    String expectedResponse = "tessera_P2P_GET_receiveRaw_StringString_AverageTime_ms 5.2";
+    String expectedResponse = "tessera_P2P_GET_receiveRaw_StringString_AverageTime_ms 5.2\n";
 
     assertThat(protocolFormatter.format(mockMetrics, type)).isEqualTo(expectedResponse);
   }
@@ -82,9 +82,8 @@ public class PrometheusProtocolFormatterTest {
     AppType type = AppType.P2P;
 
     String expectedResponse =
-        "tessera_P2P_GET_upCheck_AverageTime_ms 100"
-            + "\n"
-            + "tessera_P2P_POST_resend_ResendRequest_RequestRate_requestsPerSeconds 1.3";
+        "tessera_P2P_GET_upCheck_AverageTime_ms 100\n"
+            + "tessera_P2P_POST_resend_ResendRequest_RequestRate_requestsPerSeconds 1.3\n";
 
     assertThat(protocolFormatter.format(mockMetrics, type)).isEqualTo(expectedResponse);
   }


### PR DESCRIPTION
The newline character is required at the end of this string. 
Any other whitespace is ignored as per https://prometheus.io/docs/instrumenting/exposition_formats/ so no need to trim
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

I have tested this locally and get the following response from 
` curl localhost:8581/metrics`
Before ie without this change:
```

tessera_P2P_GET_getPartyInfo_MinTime_ms 0
tessera_P2P_GET_getPartyInfo_MaxTime_ms 0
...
tessera_THIRD_PARTY_GET_getVersion_RequestRate_requestsPerSeconds 0.0
tessera_THIRD_PARTY_GET_getVersion_RequestCount 0%
```
^ no new line at end of string

After ie with this change:
```
tessera_P2P_GET_getPartyInfo_MinTime_ms 0
tessera_P2P_GET_getPartyInfo_MaxTime_ms 0
...
tessera_THIRD_PARTY_GET_getVersion_RequestRate_requestsPerSeconds 0.0
tessera_THIRD_PARTY_GET_getVersion_RequestCount 0
```
so there is a newline at the end. Prometheus serves up the list of metrics. 

