### PR TITLE
Ignore CVE-2021-28170 for el 3.0.3

### DIFF
--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -16,4 +16,9 @@
         <cpe>cpe:/a:org.jacoco:org.jacoco.report</cpe>
         <cve>CVE-2021-21275</cve>
     </suppress>
+
+    <suppress>
+        <cpe>cpe:2.3:a:eclipse:jakarta_expression_language:3.0.3</cpe>
+        <cve>CVE-2021-28170</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Ignore CVE-2021-28170 for el 3.0.3 as addressing this means a larger change upgrading hibernate validator to 7 and the el dependencies to 3. Peg supression to 3.0.3