### PR TITLE
Remove mandatoryrecipients from receive

### DIFF
--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/ReceiveResponse.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/ReceiveResponse.java
@@ -22,8 +22,6 @@ public interface ReceiveResponse {
 
   Optional<PrivacyGroup.Id> getPrivacyGroupId();
 
-  Set<PublicKey> getMandatoryRecipients();
-
   class Builder {
 
     private byte[] unencryptedTransactionData;
@@ -39,8 +37,6 @@ public interface ReceiveResponse {
     private PublicKey sender;
 
     private PrivacyGroup.Id privacyGroupId;
-
-    private Set<PublicKey> mandatoryRecipients = Collections.emptySet();
 
     private Builder() {}
 
@@ -80,11 +76,6 @@ public interface ReceiveResponse {
 
     public Builder withPrivacyGroupId(PrivacyGroup.Id privacyGroupId) {
       this.privacyGroupId = privacyGroupId;
-      return this;
-    }
-
-    public Builder withMandatoryRecipients(Set<PublicKey> mandatoryRecipients) {
-      this.mandatoryRecipients = mandatoryRecipients;
       return this;
     }
 
@@ -136,11 +127,6 @@ public interface ReceiveResponse {
         @Override
         public Optional<PrivacyGroup.Id> getPrivacyGroupId() {
           return Optional.ofNullable(privacyGroupId);
-        }
-
-        @Override
-        public Set<PublicKey> getMandatoryRecipients() {
-          return Set.copyOf(mandatoryRecipients);
         }
       };
     }

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/internal/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/internal/TransactionManagerImpl.java
@@ -460,7 +460,6 @@ public class TransactionManagerImpl implements TransactionManager {
         .withExecHash(payload.getExecHash())
         .withManagedParties(managedParties)
         .withSender(payload.getSenderKey())
-        .withMandatoryRecipients(payload.getMandatoryRecipients())
         .build();
   }
 

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/ReceiveResponseTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/ReceiveResponseTest.java
@@ -85,32 +85,4 @@ public class ReceiveResponseTest {
     assertThat(result.sender()).isEqualTo(PublicKey.from("sender".getBytes()));
     assertThat(result.getManagedParties()).containsExactly(PublicKey.from("ownKey".getBytes()));
   }
-
-  @Test
-  public void buildMandatoryRecipients() {
-    ReceiveResponse result =
-        ReceiveResponse.Builder.create()
-            .withUnencryptedTransactionData("data".getBytes())
-            .withSender(PublicKey.from("sender".getBytes()))
-            .withPrivacyMode(PrivacyMode.MANDATORY_RECIPIENTS)
-            .withAffectedTransactions(Set.of(new MessageHash("hash".getBytes())))
-            .withManagedParties(Set.of(PublicKey.from("ownKey".getBytes())))
-            .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
-            .withMandatoryRecipients(
-                Set.of(
-                    PublicKey.from("mandatory1".getBytes()),
-                    PublicKey.from("mandatory2".getBytes())))
-            .build();
-
-    assertThat(result.getPrivacyGroupId()).isPresent();
-    assertThat(result.getPrivacyMode()).isEqualTo(PrivacyMode.MANDATORY_RECIPIENTS);
-    assertThat(result.getAffectedTransactions())
-        .containsExactly(new MessageHash("hash".getBytes()));
-    assertThat(result.getPrivacyGroupId().get())
-        .isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
-    assertThat(result.sender()).isEqualTo(PublicKey.from("sender".getBytes()));
-    assertThat(result.getManagedParties()).containsExactly(PublicKey.from("ownKey".getBytes()));
-    assertThat(result.getMandatoryRecipients())
-        .contains(PublicKey.from("mandatory2".getBytes()), PublicKey.from("mandatory1".getBytes()));
-  }
 }

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/internal/TransactionManagerTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/internal/TransactionManagerTest.java
@@ -1121,7 +1121,6 @@ public class TransactionManagerTest {
     assertThat(receiveResponse.getPrivacyGroupId()).isPresent();
     assertThat(receiveResponse.getPrivacyGroupId().get())
         .isEqualTo(PrivacyGroup.Id.fromBytes("group".getBytes()));
-    assertThat(receiveResponse.getMandatoryRecipients()).contains(mandReceiver1, mandReceiver2);
 
     verify(payloadEncoder).decode(any(byte[].class));
     verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
@@ -43,9 +43,6 @@ public class ReceiveResponse {
   @Schema(description = "privacy group id of the transaction", format = "base64")
   private String privacyGroupId;
 
-  @Schema(description = "mandatory recipients of the transaction", format = "base64")
-  private String[] mandatoryRecipients;
-
   public ReceiveResponse() {}
 
   public byte[] getPayload() {
@@ -104,11 +101,4 @@ public class ReceiveResponse {
     this.privacyGroupId = privacyGroupId;
   }
 
-  public String[] getMandatoryRecipients() {
-    return mandatoryRecipients;
-  }
-
-  public void setMandatoryRecipients(String... mandatoryRecipients) {
-    this.mandatoryRecipients = mandatoryRecipients;
-  }
 }

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/ReceiveResponse.java
@@ -100,5 +100,4 @@ public class ReceiveResponse {
   public void setPrivacyGroupId(String privacyGroupId) {
     this.privacyGroupId = privacyGroupId;
   }
-
 }

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource4.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/TransactionResource4.java
@@ -2,31 +2,25 @@ package com.quorum.tessera.q2t;
 
 import static com.quorum.tessera.version.MandatoryRecipientsVersion.MIME_TYPE_JSON_4;
 
-import com.quorum.tessera.api.ReceiveResponse;
 import com.quorum.tessera.api.SendRequest;
 import com.quorum.tessera.api.SendResponse;
 import com.quorum.tessera.api.SendSignedRequest;
 import com.quorum.tessera.api.constraint.PrivacyValid;
-import com.quorum.tessera.config.constraints.ValidBase64;
 import com.quorum.tessera.data.MessageHash;
 import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.privacygroup.PrivacyGroupManager;
 import com.quorum.tessera.transaction.TransactionManager;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -151,83 +145,6 @@ public class TransactionResource4 {
             .build();
 
     return Response.created(location).entity(sendResponse).build();
-  }
-
-  @GET
-  @Path("/transaction/{hash}")
-  @Consumes({MIME_TYPE_JSON_4})
-  @Produces({MIME_TYPE_JSON_4})
-  public Response receive(
-      @Parameter(
-              description = "hash indicating encrypted payload to retrieve from database",
-              schema = @Schema(format = "base64"))
-          @Valid
-          @ValidBase64
-          @PathParam("hash")
-          final String hash,
-      @Parameter(
-              description =
-                  "(optional) public key of recipient of the encrypted payload; used in decryption; if not provided, decryption is attempted with all known recipient keys in turn",
-              schema = @Schema(format = "base64"))
-          @QueryParam("to")
-          final String toStr,
-      @Parameter(
-              description =
-                  "(optional) indicates whether the payload is raw; determines which database the payload is retrieved from; possible values\n* true - for pre-stored payloads in the \"raw\" database\n* false (default) - for already sent payloads in \"standard\" database")
-          @Valid
-          @Pattern(flags = Pattern.Flag.CASE_INSENSITIVE, regexp = "^(true|false)$")
-          @QueryParam("isRaw")
-          final String isRaw) {
-
-    final PublicKey recipient =
-        Optional.ofNullable(toStr)
-            .filter(Predicate.not(String::isEmpty))
-            .map(base64Decoder::decode)
-            .map(PublicKey::from)
-            .orElse(null);
-
-    final MessageHash transactionHash =
-        Optional.of(hash).map(base64Decoder::decode).map(MessageHash::new).get();
-
-    final com.quorum.tessera.transaction.ReceiveRequest request =
-        com.quorum.tessera.transaction.ReceiveRequest.Builder.create()
-            .withRecipient(recipient)
-            .withTransactionHash(transactionHash)
-            .withRaw(Boolean.parseBoolean(isRaw))
-            .build();
-
-    com.quorum.tessera.transaction.ReceiveResponse response = transactionManager.receive(request);
-
-    final ReceiveResponse receiveResponse = new ReceiveResponse();
-    receiveResponse.setPayload(response.getUnencryptedTransactionData());
-    receiveResponse.setSenderKey(response.sender().encodeToBase64());
-    receiveResponse.setAffectedContractTransactions(
-        response.getAffectedTransactions().stream()
-            .map(MessageHash::getHashBytes)
-            .map(base64Encoder::encodeToString)
-            .toArray(String[]::new));
-
-    Optional.ofNullable(response.getExecHash())
-        .map(String::new)
-        .ifPresent(receiveResponse::setExecHash);
-
-    receiveResponse.setPrivacyFlag(response.getPrivacyMode().getPrivacyFlag());
-    receiveResponse.setManagedParties(
-        Optional.ofNullable(response.getManagedParties()).orElse(Collections.emptySet()).stream()
-            .map(PublicKey::encodeToBase64)
-            .toArray(String[]::new));
-
-    response
-        .getPrivacyGroupId()
-        .map(PrivacyGroup.Id::getBase64)
-        .ifPresent(receiveResponse::setPrivacyGroupId);
-
-    receiveResponse.setMandatoryRecipients(
-        response.getMandatoryRecipients().stream()
-            .map(PublicKey::encodeToBase64)
-            .toArray(String[]::new));
-
-    return Response.ok(receiveResponse).build();
   }
 
   @POST

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource4Test.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource4Test.java
@@ -7,14 +7,11 @@ import com.quorum.tessera.api.SendRequest;
 import com.quorum.tessera.api.SendResponse;
 import com.quorum.tessera.api.SendSignedRequest;
 import com.quorum.tessera.data.MessageHash;
-import com.quorum.tessera.enclave.PrivacyGroup;
 import com.quorum.tessera.enclave.PrivacyMode;
 import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.privacygroup.PrivacyGroupManager;
-import com.quorum.tessera.transaction.ReceiveResponse;
 import com.quorum.tessera.transaction.TransactionManager;
 import java.util.Base64;
-import java.util.Set;
 import javax.ws.rs.core.Response;
 import org.junit.After;
 import org.junit.Before;
@@ -102,47 +99,6 @@ public class TransactionResource4Test {
     assertThat(Base64.getEncoder().encodeToString(hash.getHashBytes())).isEqualTo(base64Hash);
     assertThat(businessObject.getMandatoryRecipients().iterator().next().encodeToBase64())
         .isEqualTo(base64Key);
-  }
-
-  @Test
-  public void receiveMandatoryRecipients() {
-    final PublicKey senderPublicKey = PublicKey.from("sender".getBytes());
-    final PublicKey mandatoryKey = PublicKey.from("auditor".getBytes());
-
-    ReceiveResponse response =
-        ReceiveResponse.Builder.create()
-            .withPrivacyMode(PrivacyMode.MANDATORY_RECIPIENTS)
-            .withAffectedTransactions(Set.of())
-            .withUnencryptedTransactionData("Success".getBytes())
-            .withManagedParties(Set.of(senderPublicKey))
-            .withSender(senderPublicKey)
-            .withPrivacyGroupId(PrivacyGroup.Id.fromBytes("group".getBytes()))
-            .withMandatoryRecipients(Set.of(mandatoryKey))
-            .build();
-
-    when(transactionManager.receive(any(com.quorum.tessera.transaction.ReceiveRequest.class)))
-        .thenReturn(response);
-
-    String transactionHash = Base64.getEncoder().encodeToString("transactionHash".getBytes());
-
-    Response result = transactionResource.receive(transactionHash, null, Boolean.FALSE.toString());
-    assertThat(result.getStatus()).isEqualTo(200);
-
-    com.quorum.tessera.api.ReceiveResponse resultResponse =
-        com.quorum.tessera.api.ReceiveResponse.class.cast(result.getEntity());
-
-    assertThat(resultResponse.getPrivacyFlag())
-        .isEqualTo(PrivacyMode.MANDATORY_RECIPIENTS.getPrivacyFlag());
-    assertThat(resultResponse.getAffectedContractTransactions()).isNullOrEmpty();
-    assertThat(resultResponse.getPayload()).isEqualTo("Success".getBytes());
-    assertThat(resultResponse.getManagedParties())
-        .containsExactlyInAnyOrder(senderPublicKey.encodeToBase64());
-    assertThat(resultResponse.getSenderKey()).isEqualTo(senderPublicKey.encodeToBase64());
-    assertThat(resultResponse.getPrivacyGroupId())
-        .isEqualTo(PublicKey.from("group".getBytes()).encodeToBase64());
-    assertThat(resultResponse.getMandatoryRecipients()[0]).isEqualTo(mandatoryKey.encodeToBase64());
-
-    verify(transactionManager).receive(any(com.quorum.tessera.transaction.ReceiveRequest.class));
   }
 
   @Test

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuite.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/RestSuite.java
@@ -3,7 +3,7 @@ package com.quorum.tessera.test.rest;
 import suite.TestSuite;
 
 @TestSuite.SuiteClasses({
-  SendReceiveMandatoryRecipientsIT.class,
+  SendMandatoryRecipientsIT.class,
   SendReceivePrivacyGroupIT.class,
   PrivacyGroupIT.class,
   PrivacyIT.class,

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
@@ -95,7 +95,8 @@ public class SendMandatoryRecipientsIT {
     try (connection) {
 
       PreparedStatement preparedStatement =
-          connection.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+          connection.prepareStatement(
+              "SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
       preparedStatement.setBytes(1, hashBytes);
       try (preparedStatement) {
         ResultSet resultSet = preparedStatement.executeQuery();
@@ -109,7 +110,8 @@ public class SendMandatoryRecipientsIT {
     }
 
     EncodedPayload payload = PayloadEncoder.create().decode(receivedPayload);
-    assertThat(payload.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
+    assertThat(payload.getMandatoryRecipients())
+        .containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
 
     // validate data in Node C's DB
     Connection connectionC = c.getDatabaseConnection();
@@ -119,7 +121,8 @@ public class SendMandatoryRecipientsIT {
     try (connectionC) {
 
       PreparedStatement preparedStatement =
-        connectionC.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+          connectionC.prepareStatement(
+              "SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
       preparedStatement.setBytes(1, hashBytes);
       try (preparedStatement) {
         ResultSet resultSet = preparedStatement.executeQuery();
@@ -133,8 +136,8 @@ public class SendMandatoryRecipientsIT {
     }
 
     EncodedPayload payloadC = PayloadEncoder.create().decode(payloadOnC);
-    assertThat(payloadC.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
-
+    assertThat(payloadC.getMandatoryRecipients())
+        .containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
   }
 
   @Test
@@ -200,7 +203,8 @@ public class SendMandatoryRecipientsIT {
     try (connection) {
 
       PreparedStatement preparedStatement =
-        connection.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+          connection.prepareStatement(
+              "SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
       preparedStatement.setBytes(1, hash);
       try (preparedStatement) {
         ResultSet resultSet = preparedStatement.executeQuery();
@@ -214,7 +218,8 @@ public class SendMandatoryRecipientsIT {
     }
 
     EncodedPayload payload = PayloadEncoder.create().decode(payloadOnA);
-    assertThat(payload.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
+    assertThat(payload.getMandatoryRecipients())
+        .containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
 
     // validate data in Node C's DB
     Connection connectionC = c.getDatabaseConnection();
@@ -224,7 +229,8 @@ public class SendMandatoryRecipientsIT {
     try (connectionC) {
 
       PreparedStatement preparedStatement =
-        connectionC.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+          connectionC.prepareStatement(
+              "SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
       preparedStatement.setBytes(1, hash);
       try (preparedStatement) {
         ResultSet resultSet = preparedStatement.executeQuery();
@@ -238,6 +244,7 @@ public class SendMandatoryRecipientsIT {
     }
 
     EncodedPayload payloadC = PayloadEncoder.create().decode(payloadOnC);
-    assertThat(payloadC.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
+    assertThat(payloadC.getMandatoryRecipients())
+        .containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
   }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
@@ -1,22 +1,31 @@
 package com.quorum.tessera.test.rest;
 
 import static com.quorum.tessera.version.MandatoryRecipientsVersion.MIME_TYPE_JSON_4;
+import static com.quorum.tessera.version.MultiTenancyVersion.MIME_TYPE_JSON_2_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.quorum.tessera.api.*;
+import com.quorum.tessera.enclave.EncodedPayload;
+import com.quorum.tessera.enclave.PayloadEncoder;
+import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.test.Party;
 import com.quorum.tessera.test.PartyHelper;
+import db.UncheckedSQLException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Base64;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import org.junit.Test;
 import suite.NodeAlias;
 
-public class SendReceiveMandatoryRecipientsIT {
+public class SendMandatoryRecipientsIT {
 
   private final PartyHelper partyHelper = PartyHelper.create();
 
@@ -72,50 +81,60 @@ public class SendReceiveMandatoryRecipientsIT {
     final SendResponse result = response.readEntity(SendResponse.class);
     final String hash = result.getKey();
 
-    // Hash length should be 64 bytes
-    assertThat(Base64.getDecoder().decode(hash)).hasSize(64);
-
-    final String encodedHash = URLEncoder.encode(hash, UTF_8.toString());
     assertThat(hash).isNotNull().isNotBlank();
 
-    final Response receiveResponse =
-        a.getRestClient()
-            .target(a.getQ2TUri())
-            .path("/transaction")
-            .path(encodedHash)
-            .request()
-            .accept(MIME_TYPE_JSON_4)
-            .buildGet()
-            .invoke();
+    // Hash length should be 64 bytes
+    final byte[] hashBytes = Base64.getDecoder().decode(hash);
+    assertThat(hashBytes).hasSize(64);
 
-    // validate result
-    assertThat(receiveResponse).isNotNull();
-    assertThat(receiveResponse.getStatus()).isEqualTo(200);
+    // validate data in Node A's DB
+    Connection connection = a.getDatabaseConnection();
 
-    final ReceiveResponse receiveResult = receiveResponse.readEntity(ReceiveResponse.class);
+    byte[] receivedPayload;
 
-    assertThat(receiveResult.getPayload()).isEqualTo(transactionData);
-    assertThat(receiveResult.getManagedParties()).containsExactly(a.getPublicKey());
-    assertThat(receiveResult.getSenderKey()).isEqualTo(a.getPublicKey());
+    try (connection) {
 
-    final Response receiveResponseOnC =
-        c.getRestClient()
-            .target(c.getQ2TUri())
-            .path("/transaction")
-            .path(encodedHash)
-            .request()
-            .accept(MIME_TYPE_JSON_4)
-            .buildGet()
-            .invoke();
+      PreparedStatement preparedStatement =
+          connection.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+      preparedStatement.setBytes(1, hashBytes);
+      try (preparedStatement) {
+        ResultSet resultSet = preparedStatement.executeQuery();
+        try (resultSet) {
+          assertThat(resultSet.next()).isTrue();
+          receivedPayload = resultSet.getBytes(1);
+        }
+      }
+    } catch (SQLException ex) {
+      throw new UncheckedSQLException(ex);
+    }
 
-    // validate result
-    assertThat(receiveResponseOnC).isNotNull();
-    assertThat(receiveResponseOnC.getStatus()).isEqualTo(200);
+    EncodedPayload payload = PayloadEncoder.create().decode(receivedPayload);
+    assertThat(payload.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
 
-    final ReceiveResponse receiveResultOnC = receiveResponseOnC.readEntity(ReceiveResponse.class);
-    assertThat(receiveResultOnC.getPayload()).isEqualTo(transactionData);
-    assertThat(receiveResultOnC.getManagedParties()).containsExactly(c.getPublicKey());
-    assertThat(receiveResultOnC.getSenderKey()).isEqualTo(a.getPublicKey());
+    // validate data in Node C's DB
+    Connection connectionC = c.getDatabaseConnection();
+
+    byte[] payloadOnC;
+
+    try (connectionC) {
+
+      PreparedStatement preparedStatement =
+        connectionC.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+      preparedStatement.setBytes(1, hashBytes);
+      try (preparedStatement) {
+        ResultSet resultSet = preparedStatement.executeQuery();
+        try (resultSet) {
+          assertThat(resultSet.next()).isTrue();
+          payloadOnC = resultSet.getBytes(1);
+        }
+      }
+    } catch (SQLException ex) {
+      throw new UncheckedSQLException(ex);
+    }
+
+    EncodedPayload payloadC = PayloadEncoder.create().decode(payloadOnC);
+    assertThat(payloadC.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
+
   }
 
   @Test
@@ -151,7 +170,7 @@ public class SendReceiveMandatoryRecipientsIT {
             .path("/transaction")
             .path(encodedHash)
             .request()
-            .accept(MIME_TYPE_JSON_4)
+            .accept(MIME_TYPE_JSON_2_1)
             .buildGet()
             .invoke();
 
@@ -173,43 +192,52 @@ public class SendReceiveMandatoryRecipientsIT {
 
     assertThat(response.getStatus()).isEqualTo(201);
 
-    final Response receiveResponse =
-        a.getRestClient()
-            .target(a.getQ2TUri())
-            .path("/transaction")
-            .path(encodedHash)
-            .request()
-            .accept(MIME_TYPE_JSON_4)
-            .buildGet()
-            .invoke();
+    // validate data in Node A's DB
+    Connection connection = a.getDatabaseConnection();
 
-    // validate result
-    assertThat(receiveResponse).isNotNull();
-    assertThat(receiveResponse.getStatus()).isEqualTo(200);
+    byte[] payloadOnA;
 
-    final ReceiveResponse receiveResult = receiveResponse.readEntity(ReceiveResponse.class);
+    try (connection) {
 
-    assertThat(receiveResult.getPayload()).isEqualTo(transactionData);
-    assertThat(receiveResult.getManagedParties()).containsExactly(a.getPublicKey());
-    assertThat(receiveResult.getSenderKey()).isEqualTo(a.getPublicKey());
+      PreparedStatement preparedStatement =
+        connection.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+      preparedStatement.setBytes(1, hash);
+      try (preparedStatement) {
+        ResultSet resultSet = preparedStatement.executeQuery();
+        try (resultSet) {
+          assertThat(resultSet.next()).isTrue();
+          payloadOnA = resultSet.getBytes(1);
+        }
+      }
+    } catch (SQLException ex) {
+      throw new UncheckedSQLException(ex);
+    }
 
-    final Response receiveResponseOnC =
-        c.getRestClient()
-            .target(c.getQ2TUri())
-            .path("/transaction")
-            .path(encodedHash)
-            .request()
-            .accept(MIME_TYPE_JSON_4)
-            .buildGet()
-            .invoke();
+    EncodedPayload payload = PayloadEncoder.create().decode(payloadOnA);
+    assertThat(payload.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
 
-    // validate result
-    assertThat(receiveResponseOnC).isNotNull();
-    assertThat(receiveResponseOnC.getStatus()).isEqualTo(200);
+    // validate data in Node C's DB
+    Connection connectionC = c.getDatabaseConnection();
 
-    final ReceiveResponse receiveResultOnC = receiveResponseOnC.readEntity(ReceiveResponse.class);
-    assertThat(receiveResultOnC.getPayload()).isEqualTo(transactionData);
-    assertThat(receiveResultOnC.getManagedParties()).containsExactly(c.getPublicKey());
-    assertThat(receiveResultOnC.getSenderKey()).isEqualTo(a.getPublicKey());
+    byte[] payloadOnC;
+
+    try (connectionC) {
+
+      PreparedStatement preparedStatement =
+        connectionC.prepareStatement("SELECT ENCODED_PAYLOAD FROM ENCRYPTED_TRANSACTION et WHERE HASH = ?");
+      preparedStatement.setBytes(1, hash);
+      try (preparedStatement) {
+        ResultSet resultSet = preparedStatement.executeQuery();
+        try (resultSet) {
+          assertThat(resultSet.next()).isTrue();
+          payloadOnC = resultSet.getBytes(1);
+        }
+      }
+    } catch (SQLException ex) {
+      throw new UncheckedSQLException(ex);
+    }
+
+    EncodedPayload payloadC = PayloadEncoder.create().decode(payloadOnC);
+    assertThat(payloadC.getMandatoryRecipients()).containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
   }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendReceiveMandatoryRecipientsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendReceiveMandatoryRecipientsIT.java
@@ -116,7 +116,6 @@ public class SendReceiveMandatoryRecipientsIT {
     assertThat(receiveResultOnC.getPayload()).isEqualTo(transactionData);
     assertThat(receiveResultOnC.getManagedParties()).containsExactly(c.getPublicKey());
     assertThat(receiveResultOnC.getSenderKey()).isEqualTo(a.getPublicKey());
-
   }
 
   @Test

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendReceiveMandatoryRecipientsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendReceiveMandatoryRecipientsIT.java
@@ -97,7 +97,6 @@ public class SendReceiveMandatoryRecipientsIT {
     assertThat(receiveResult.getPayload()).isEqualTo(transactionData);
     assertThat(receiveResult.getManagedParties()).containsExactly(a.getPublicKey());
     assertThat(receiveResult.getSenderKey()).isEqualTo(a.getPublicKey());
-    assertThat(receiveResult.getMandatoryRecipients()).containsExactly(c.getPublicKey());
 
     final Response receiveResponseOnC =
         c.getRestClient()
@@ -117,7 +116,7 @@ public class SendReceiveMandatoryRecipientsIT {
     assertThat(receiveResultOnC.getPayload()).isEqualTo(transactionData);
     assertThat(receiveResultOnC.getManagedParties()).containsExactly(c.getPublicKey());
     assertThat(receiveResultOnC.getSenderKey()).isEqualTo(a.getPublicKey());
-    assertThat(receiveResultOnC.getMandatoryRecipients()).containsExactly(c.getPublicKey());
+
   }
 
   @Test
@@ -194,7 +193,6 @@ public class SendReceiveMandatoryRecipientsIT {
     assertThat(receiveResult.getPayload()).isEqualTo(transactionData);
     assertThat(receiveResult.getManagedParties()).containsExactly(a.getPublicKey());
     assertThat(receiveResult.getSenderKey()).isEqualTo(a.getPublicKey());
-    assertThat(receiveResult.getMandatoryRecipients()).containsExactly(c.getPublicKey());
 
     final Response receiveResponseOnC =
         c.getRestClient()
@@ -214,6 +212,5 @@ public class SendReceiveMandatoryRecipientsIT {
     assertThat(receiveResultOnC.getPayload()).isEqualTo(transactionData);
     assertThat(receiveResultOnC.getManagedParties()).containsExactly(c.getPublicKey());
     assertThat(receiveResultOnC.getSenderKey()).isEqualTo(a.getPublicKey());
-    assertThat(receiveResultOnC.getMandatoryRecipients()).containsExactly(c.getPublicKey());
   }
 }


### PR DESCRIPTION
MandatoryRecipients private metadata does not need to be included in the response back for `/receive` request as Quorum does not need to store it.

The participants being validated during send together with ACOTHs validation at execution (performed as part of `PartyProtection` should be deemed sufficient