### PR TITLE
Get mandatory api

### DIFF
--- a/security/src/main/java/module-info.java
+++ b/security/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module tessera.security {
   // requires java.base;
   requires java.xml.bind;
-  //  requires cryptacular;
+  requires cryptacular;
   requires org.slf4j;
   requires tessera.config;
   requires tessera.shared;

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManager.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/TransactionManager.java
@@ -6,6 +6,7 @@ import com.quorum.tessera.enclave.EncodedPayload;
 import com.quorum.tessera.encryption.PublicKey;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
 
 public interface TransactionManager {
 
@@ -26,6 +27,8 @@ public interface TransactionManager {
   boolean isSender(MessageHash transactionHash);
 
   List<PublicKey> getParticipants(MessageHash transactionHash);
+
+  Set<PublicKey> getMandatoryRecipients(MessageHash transactionHash);
 
   /**
    * @see Enclave#defaultPublicKey()

--- a/tessera-core/src/main/java/com/quorum/tessera/transaction/internal/TransactionManagerImpl.java
+++ b/tessera-core/src/main/java/com/quorum/tessera/transaction/internal/TransactionManagerImpl.java
@@ -514,6 +514,12 @@ public class TransactionManagerImpl implements TransactionManager {
   }
 
   @Override
+  public Set<PublicKey> getMandatoryRecipients(MessageHash transactionHash) {
+    final EncodedPayload payload = this.fetchPayload(transactionHash);
+    return payload.getMandatoryRecipients();
+  }
+
+  @Override
   public PublicKey defaultPublicKey() {
     return enclave.defaultPublicKey();
   }

--- a/tessera-core/src/test/java/com/quorum/tessera/transaction/internal/TransactionManagerTest.java
+++ b/tessera-core/src/test/java/com/quorum/tessera/transaction/internal/TransactionManagerTest.java
@@ -1718,6 +1718,35 @@ public class TransactionManagerTest {
   }
 
   @Test
+  public void getMandatoryRecipients() {
+
+    MessageHash transactionHash = mock(MessageHash.class);
+    when(transactionHash.getHashBytes()).thenReturn("DUMMY_TRANSACTION".getBytes());
+
+    final PublicKey senderKey = mock(PublicKey.class);
+    final PublicKey recipientKey = mock(PublicKey.class);
+
+    final byte[] input = "SOMEDATA".getBytes();
+    final EncryptedTransaction encryptedTransaction = mock(EncryptedTransaction.class);
+    final EncodedPayload encodedPayload = mock(EncodedPayload.class);
+    when(encodedPayload.getRecipientKeys()).thenReturn(List.of(senderKey, recipientKey));
+    when(encodedPayload.getMandatoryRecipients()).thenReturn(Set.of(recipientKey));
+    when(encryptedTransaction.getEncodedPayload()).thenReturn(input);
+
+    when(encryptedTransactionDAO.retrieveByHash(transactionHash))
+        .thenReturn(Optional.of(encryptedTransaction));
+
+    when(payloadEncoder.decode(input)).thenReturn(encodedPayload);
+
+    final Set<PublicKey> participants = transactionManager.getMandatoryRecipients(transactionHash);
+
+    assertThat(participants).containsExactly(recipientKey);
+
+    verify(payloadEncoder).decode(input);
+    verify(encryptedTransactionDAO).retrieveByHash(any(MessageHash.class));
+  }
+
+  @Test
   public void defaultPublicKey() {
     transactionManager.defaultPublicKey();
     verify(enclave).defaultPublicKey();

--- a/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource4Test.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/test/java/com/quorum/tessera/q2t/TransactionResource4Test.java
@@ -12,6 +12,7 @@ import com.quorum.tessera.encryption.PublicKey;
 import com.quorum.tessera.privacygroup.PrivacyGroupManager;
 import com.quorum.tessera.transaction.TransactionManager;
 import java.util.Base64;
+import java.util.Set;
 import javax.ws.rs.core.Response;
 import org.junit.After;
 import org.junit.Before;
@@ -159,5 +160,24 @@ public class TransactionResource4Test {
         .hasSize(2)
         .containsExactlyInAnyOrder(base64AffectedHash1, base64AffectedHash2);
     assertThat(obj.getMandatoryRecipients()).hasSize(1);
+  }
+
+  @Test
+  public void getMandatoryRecipients() {
+    byte[] data = "DUMMY_HASH".getBytes();
+
+    final String dummyPtmHash = Base64.getEncoder().encodeToString(data);
+
+    PublicKey recipient = mock(PublicKey.class);
+    when(recipient.encodeToBase64()).thenReturn("BASE64ENCODEDKEY");
+
+    when(transactionManager.getMandatoryRecipients(any(MessageHash.class)))
+        .thenReturn(Set.of(recipient));
+
+    Response response = transactionResource.getMandatoryRecipients(dummyPtmHash);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getEntity()).isEqualTo("BASE64ENCODEDKEY");
+    verify(transactionManager).getMandatoryRecipients(any(MessageHash.class));
   }
 }

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
@@ -138,6 +138,22 @@ public class SendMandatoryRecipientsIT {
     EncodedPayload payloadC = PayloadEncoder.create().decode(payloadOnC);
     assertThat(payloadC.getMandatoryRecipients())
         .containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
+
+    // Validate recipients data in Node C using /mandatory call
+    final Response getMandatoryResponse =
+        c.getRestClient()
+            .target(c.getQ2TUri())
+            .path("/transaction")
+            .path(hash)
+            .path("/mandatory")
+            .request()
+            .buildGet()
+            .invoke();
+
+    assertThat(getMandatoryResponse).isNotNull();
+    assertThat(getMandatoryResponse.getStatus()).isEqualTo(200);
+    String mandatoryList = getMandatoryResponse.readEntity(String.class);
+    assertThat(mandatoryList).isEqualTo(c.getPublicKey());
   }
 
   @Test

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/SendMandatoryRecipientsIT.java
@@ -140,11 +140,14 @@ public class SendMandatoryRecipientsIT {
         .containsExactly(PublicKey.from(Base64.getDecoder().decode(c.getPublicKey())));
 
     // Validate recipients data in Node C using /mandatory call
+
+    final String encodedHash = URLEncoder.encode(hash, UTF_8.toString());
+
     final Response getMandatoryResponse =
         c.getRestClient()
             .target(c.getQ2TUri())
             .path("/transaction")
-            .path(hash)
+            .path(encodedHash)
             .path("/mandatory")
             .request()
             .buildGet()


### PR DESCRIPTION
Add GET `/transaction/{hash}/mandatory` to retrieve the list of mandatory recipients for a given transaction hash.

This is to support contract extension operation