### PR TITLE
Changes to upcheck api

### DIFF
--- a/tessera-data/src/main/java/com/quorum/tessera/data/EncryptedRawTransaction.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/EncryptedRawTransaction.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
       query = "delete from EncryptedRawTransaction where hash.hashBytes = :hash"),
   @NamedQuery(
       name = "EncryptedRawTransaction.Upcheck",
-      query = "select count(c) from EncryptedRawTransaction c"),
+      query = "select count(c.timestamp) from EncryptedRawTransaction c"),
   @NamedQuery(
       name = "EncryptedRawTransaction.FindAll",
       query = "select ert from EncryptedRawTransaction ert order by ert.timestamp, ert.hash"),

--- a/tessera-data/src/main/java/com/quorum/tessera/data/EncryptedTransaction.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/EncryptedTransaction.java
@@ -19,7 +19,7 @@ import javax.persistence.*;
       query = "select et from EncryptedTransaction et order by et.timestamp,et.hash"),
   @NamedQuery(
       name = "EncryptedTransaction.Upcheck",
-      query = "select count(c) from EncryptedTransaction c")
+      query = "select count(c.timestamp) from EncryptedTransaction c")
 })
 @Entity
 @Table(name = "ENCRYPTED_TRANSACTION")

--- a/tessera-dist/src/main/java/com/quorum/tessera/launcher/Main.java
+++ b/tessera-dist/src/main/java/com/quorum/tessera/launcher/Main.java
@@ -102,8 +102,15 @@ public class Main {
       LOGGER.debug("Created BatchResendManager");
 
       LOGGER.debug("Creating txn manager");
-      TransactionManager.create();
+      TransactionManager transactionManager = TransactionManager.create();
       LOGGER.debug("Created txn manager");
+
+      LOGGER.debug("Validating if transaction table exists");
+      if (!transactionManager.upcheck()) {
+        throw new RuntimeException(
+            "The database has not been setup correctly. Please ensure transaction tables "
+                + "are present and correct");
+      }
 
       LOGGER.debug("Creating ScheduledServiceFactory");
       ScheduledServiceFactory scheduledServiceFactory = ScheduledServiceFactory.fromConfig(config);

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.api.common;
 
-import com.quorum.tessera.transaction.TransactionManager;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -8,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
-import java.util.Objects;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -26,12 +24,6 @@ public class UpCheckResource {
 
   private static final String UPCHECK_RESPONSE_IS_UP = "I'm up!";
   private static final String UPCHECK_RESPONSE_DB = "Database unavailable";
-
-  private final TransactionManager transactionManager;
-
-  public UpCheckResource(final TransactionManager transactionManager) {
-    this.transactionManager = Objects.requireNonNull(transactionManager);
-  }
 
   /**
    * Called to check if the application is running and responsive. Gives no details about the health
@@ -58,11 +50,6 @@ public class UpCheckResource {
   @Produces(MediaType.TEXT_PLAIN)
   public Response upCheck() {
     LOGGER.info("GET upcheck");
-
-    if (!transactionManager.upcheck()) {
-      return Response.ok(UPCHECK_RESPONSE_DB).build();
-    }
-
     return Response.ok(UPCHECK_RESPONSE_IS_UP).build();
   }
 }

--- a/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
+++ b/tessera-jaxrs/common-jaxrs/src/main/java/com/quorum/tessera/api/common/UpCheckResource.java
@@ -23,7 +23,6 @@ public class UpCheckResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpCheckResource.class);
 
   private static final String UPCHECK_RESPONSE_IS_UP = "I'm up!";
-  private static final String UPCHECK_RESPONSE_DB = "Database unavailable";
 
   /**
    * Called to check if the application is running and responsive. Gives no details about the health
@@ -43,8 +42,7 @@ public class UpCheckResource {
               mediaType = MediaType.TEXT_PLAIN,
               schema = @Schema(type = "string"),
               examples = {
-                @ExampleObject(name = UPCHECK_RESPONSE_IS_UP, value = UPCHECK_RESPONSE_IS_UP),
-                @ExampleObject(name = UPCHECK_RESPONSE_DB, value = UPCHECK_RESPONSE_DB)
+                @ExampleObject(name = UPCHECK_RESPONSE_IS_UP, value = UPCHECK_RESPONSE_IS_UP)
               }))
   @GET
   @Produces(MediaType.TEXT_PLAIN)

--- a/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/UpCheckResourceTest.java
+++ b/tessera-jaxrs/common-jaxrs/src/test/java/com/quorum/tessera/api/common/UpCheckResourceTest.java
@@ -3,49 +3,17 @@ package com.quorum.tessera.api.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-import com.quorum.tessera.transaction.TransactionManager;
 import javax.ws.rs.core.Response;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class UpCheckResourceTest {
 
-  private UpCheckResource resource;
-
-  private TransactionManager transactionManager;
-
-  @Before
-  public void onSetup() {
-    this.transactionManager = mock(TransactionManager.class);
-
-    this.resource = new UpCheckResource(transactionManager);
-  }
-
-  @After
-  public void onTearDown() {
-    verifyNoMoreInteractions(transactionManager);
-  }
+  private UpCheckResource resource = new UpCheckResource();
 
   @Test
-  public void upcheck() {
-    when(transactionManager.upcheck()).thenReturn(true);
-
+  public void upCheck() {
     final Response response = resource.upCheck();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getEntity()).isEqualTo("I'm up!");
-
-    verify(transactionManager).upcheck();
-  }
-
-  @Test
-  public void upcheckWhenDBNotReady() {
-    when(transactionManager.upcheck()).thenReturn(false);
-
-    final Response response = resource.upCheck();
-    assertThat(response.getStatus()).isEqualTo(200);
-    assertThat(response.getEntity()).isEqualTo("Database unavailable");
-
-    verify(transactionManager).upcheck();
   }
 }

--- a/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/P2PRestApp.java
+++ b/tessera-jaxrs/sync-jaxrs/src/main/java/com/quorum/tessera/p2p/P2PRestApp.java
@@ -114,7 +114,7 @@ public class P2PRestApp extends TesseraRestApplication
         new TransactionResource(
             transactionManager, batchResendManager, payloadEncoder, legacyResendManager);
 
-    final UpCheckResource upCheckResource = new UpCheckResource(transactionManager);
+    final UpCheckResource upCheckResource = new UpCheckResource();
 
     final PrivacyGroupResource privacyGroupResource = new PrivacyGroupResource(privacyGroupManager);
 

--- a/tessera-jaxrs/thirdparty-jaxrs/src/main/java/com/quorum/tessera/thirdparty/ThirdPartyRestApp.java
+++ b/tessera-jaxrs/thirdparty-jaxrs/src/main/java/com/quorum/tessera/thirdparty/ThirdPartyRestApp.java
@@ -37,7 +37,7 @@ public class ThirdPartyRestApp extends TesseraRestApplication
         new RawTransactionResource(transactionManager);
     final PartyInfoResource partyInfoResource = new PartyInfoResource(discovery);
     final KeyResource keyResource = new KeyResource();
-    final UpCheckResource upCheckResource = new UpCheckResource(transactionManager);
+    final UpCheckResource upCheckResource = new UpCheckResource();
     return Set.of(rawTransactionResource, partyInfoResource, keyResource, upCheckResource);
   }
 

--- a/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/Q2TRestApp.java
+++ b/tessera-jaxrs/transaction-jaxrs/src/main/java/com/quorum/tessera/q2t/Q2TRestApp.java
@@ -56,7 +56,7 @@ public class Q2TRestApp extends TesseraRestApplication
     RawTransactionResource rawTransactionResource = new RawTransactionResource(transactionManager);
     EncodedPayloadResource encodedPayloadResource =
         new EncodedPayloadResource(encodedPayloadManager, transactionManager);
-    final UpCheckResource upCheckResource = new UpCheckResource(transactionManager);
+    final UpCheckResource upCheckResource = new UpCheckResource();
 
     final PrivacyGroupResource privacyGroupResource = new PrivacyGroupResource(privacyGroupManager);
 

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/ThirdPartyIT.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/rest/ThirdPartyIT.java
@@ -110,6 +110,7 @@ public class ThirdPartyIT {
             setUsername("junit");
             setPassword("junit");
             setUrl("jdbc:h2:mem:thirdpty".concat(nodeAlias.name()));
+            setAutoCreateTables(true);
           }
         });
 


### PR DESCRIPTION
- Validations to ensure two main transaction tables are present are performed at startup
- Once Tessera is up the assumption is db are setup correctly. `/upcheck` call will no longer need to perform this check.