### PR TITLE
CVE-2021-23463

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ allprojects {
         implementation "org.bouncycastle:bcpkix-jdk15on:1.68"
         implementation "org.bouncycastle:bcprov-jdk15on:1.68"
 
-        implementation "com.h2database:h2:1.4.200"
+        implementation "com.h2database:h2:2.0.202"
         implementation "com.zaxxer:HikariCP:3.2.0"
         implementation "org.hsqldb:hsqldb:2.5.1"
         implementation "org.xerial:sqlite-jdbc:3.23.1"

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ allprojects {
         implementation "org.bouncycastle:bcpkix-jdk15on:1.68"
         implementation "org.bouncycastle:bcprov-jdk15on:1.68"
 
-        implementation "com.h2database:h2:2.0.202"
+        implementation "com.h2database:h2:1.4.200"
         implementation "com.zaxxer:HikariCP:3.2.0"
         implementation "org.hsqldb:hsqldb:2.5.1"
         implementation "org.xerial:sqlite-jdbc:3.23.1"

--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -21,4 +21,8 @@
 <!--        <cpe>cpe:2.3:a:eclipse:jakarta_expression_language:3.0.3</cpe>-->
 <!--        <cve>CVE-2021-28170</cve>-->
 <!--    </suppress>-->
+    <suppress>
+        <cpe>cpe:2.3:a:h2database:h2:*:*:*:*:*:*:*:*</cpe>
+        <cve>CVE-2021-23463</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Temporarily suppress [CVE-2021-23463](https://nvd.nist.gov/vuln/detail/CVE-2021-23463#range-7253084) as h2database upgrade to 2.0.202 is a major upgrade that would require more testing