### PR TITLE
upgrade logback version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
   swaggerVersion = "2.1.9"
   jerseyVersion = "3.0.3"
   slf4jVersion = "1.7.32"
-  logbackVersion = "1.2.6"
+  logbackVersion = "1.2.8"
   hk2Version = "3.0.2"
   jacksonVersion = "2.12.4";
 }


### PR DESCRIPTION
This PR is to update logback version to 1.2.8.

This is a precautionary measure from Tessera in light of [LOGBACK-1591](https://jira.qos.ch/browse/LOGBACK-1591).

PS: This is different to log4Shell/CVE-2021-44228 and are of different severity levels. In order to make RCE possible, a few conditions would need to be met including attackers having write access to the `logback.xml` file and having the application restarted to load poisonous config (or in case of users using customised logback config - having `scan="true"` flag set  ).

In production environment users are always recommended to have configuration files secured and read-only.