### PR TITLE
Upgrade h2database version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ allprojects {
         implementation "org.bouncycastle:bcpkix-jdk15on:1.68"
         implementation "org.bouncycastle:bcprov-jdk15on:1.68"
 
-        implementation "com.h2database:h2:1.4.200"
+        implementation "com.h2database:h2:2.0.202"
         implementation "com.zaxxer:HikariCP:3.2.0"
         implementation "org.hsqldb:hsqldb:2.5.1"
         implementation "org.xerial:sqlite-jdbc:3.23.1"

--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -21,8 +21,4 @@
 <!--        <cpe>cpe:2.3:a:eclipse:jakarta_expression_language:3.0.3</cpe>-->
 <!--        <cve>CVE-2021-28170</cve>-->
 <!--    </suppress>-->
-    <suppress>
-        <cpe>cpe:2.3:a:h2database:h2:*:*:*:*:*:*:*:*</cpe>
-        <cve>CVE-2021-23463</cve>
-    </suppress>
 </suppressions>

--- a/tests/acceptance-test/src/test/java/com/quorum/tessera/test/DBType.java
+++ b/tests/acceptance-test/src/test/java/com/quorum/tessera/test/DBType.java
@@ -6,7 +6,7 @@ import java.net.URL;
 
 public enum DBType {
   H2(
-      "jdbc:h2:./build/h2/%s%d;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_RECONNECT=TRUE",
+      "jdbc:h2:./build/h2/%s%d;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_RECONNECT=TRUE",
       "/ddls/h2-ddl.sql"),
   HSQL("jdbc:hsqldb:hsql://127.0.0.1:9189/%s%d", "/ddls/hsql-ddl.sql"),
   SQLITE("jdbc:sqlite:build/sqlite-%s%d.db", "/ddls/sqlite-ddl.sql");


### PR DESCRIPTION
Addresses [CVE-2021-23463](https://nvd.nist.gov/vuln/detail/CVE-2021-23463)

P.S. This is a major upgrade from h2 and the official recommendation to carry out the upgrade is 

> to do a BACKUP of your existing database USING YOUR CURRENT VERSION OF H2.
> Then create a fresh database USING THE NEW VERSION OF H2, then perform a SCRIPT to load your data.

For more information, see https://github.com/h2database/h2database/releases/tag/version-2.0.202