### PR TITLE
Bump h2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ allprojects {
         implementation "org.bouncycastle:bcpkix-jdk15on:1.68"
         implementation "org.bouncycastle:bcprov-jdk15on:1.68"
 
-        implementation "com.h2database:h2:2.0.202"
+        implementation "com.h2database:h2:2.0.206"
         implementation "com.zaxxer:HikariCP:3.2.0"
         implementation "org.hsqldb:hsqldb:2.5.1"
         implementation "org.xerial:sqlite-jdbc:3.23.1"


### PR DESCRIPTION
h2 is affected by the log4shell bug (CVE-2021-42392). Tessera is not affected by this bug but a version bump will prevent future builds from failing due to CVE vulnerability checks