### PR TITLE
Add dumb-init to base image to help with term signals

### DIFF
--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -15,4 +15,7 @@ FROM adoptopenjdk/openjdk11:alpine
 
 COPY --from=extractor /install/enclave-jaxrs/ /tessera
 
-ENTRYPOINT ["/tessera/bin/enclave-jaxrs"]
+RUN apk add dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/tessera/bin/tessera"]

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -18,4 +18,4 @@ COPY --from=extractor /install/enclave-jaxrs/ /tessera
 RUN apk add dumb-init
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/tessera/bin/tessera"]
+CMD ["/tessera/bin/enclave-jaxrs"]

--- a/docker/tessera.Dockerfile
+++ b/docker/tessera.Dockerfile
@@ -15,4 +15,7 @@ FROM adoptopenjdk/openjdk11:alpine
 
 COPY --from=extractor /install/tessera/ /tessera
 
-ENTRYPOINT ["/tessera/bin/tessera"]
+RUN apk add dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/tessera/bin/tessera"]

--- a/docker/tessera.aws.Dockerfile
+++ b/docker/tessera.aws.Dockerfile
@@ -20,4 +20,7 @@ FROM adoptopenjdk/openjdk11:alpine
 
 COPY --from=extractor /install/tessera-plus-vault/ /tessera
 
-ENTRYPOINT ["/tessera/bin/tessera"]
+RUN apk add dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/tessera/bin/tessera"]

--- a/docker/tessera.azure.Dockerfile
+++ b/docker/tessera.azure.Dockerfile
@@ -20,4 +20,7 @@ FROM adoptopenjdk/openjdk11:alpine
 
 COPY --from=extractor /install/tessera-plus-vault/ /tessera
 
-ENTRYPOINT ["/tessera/bin/tessera"]
+RUN apk add dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/tessera/bin/tessera"]

--- a/docker/tessera.hashicorp.Dockerfile
+++ b/docker/tessera.hashicorp.Dockerfile
@@ -20,4 +20,7 @@ FROM adoptopenjdk/openjdk11:alpine
 
 COPY --from=extractor /install/tessera-plus-vault/ /tessera
 
-ENTRYPOINT ["/tessera/bin/tessera"]
+RUN apk add dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/tessera/bin/tessera"]


### PR DESCRIPTION
This isn't directly a problem for tessera when running a container directly with something like `docker run` however it's fairly common practice to run a bunch of your own entry scripts (as we do in the dev-quickstart). I suspect a lot of people use them as a template. 

The problem with this approach is that SIGTERM signals no longer get passed along to tessera and tessera will be running on a different pid. dumb-init solves this problem.

https://github.com/Yelp/dumb-init

If there is no appetite for adding this to the base image I will update the dev-quickstarts with a custom docker image that will inherit from tessera.