### PR TITLE
[CI] Trigger releases from repo page, fix PR builds from forks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,6 +8,8 @@ on:
 env:
   GRADLE_CACHE_KEY: ${{ github.run_id }}-gradle-${{ github.run_number }}-${{ github.run_number }}-${{ github.sha }}
   DIST_TAR: tessera-dist/build/distributions/tessera-*.tar
+  TESSERA_DOCKER_IMAGE: quorumengineering/tessera
+  QUORUM_DOCKER_IMAGE: quorumengineering/quorum
 jobs:
   build:
     name: Build and upload binaries
@@ -463,10 +465,10 @@ jobs:
       - name: Get current date-time (RFC 3339 standard)
         id: date
         run: echo "::set-output name=now::$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      - name: Build image as portable tar
+      - name: Build Docker image as portable tar
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ secrets.DOCKER_REPO }}:develop
+          tags: ${{ env.TESSERA_DOCKER_IMAGE }}:develop
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -476,7 +478,7 @@ jobs:
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .
           outputs: type=docker,dest=/tmp/tessera-develop-image.tar
-      - name: Upload artifact
+      - name: upload-artifact portable Docker image
         uses: actions/upload-artifact@v2
         with:
           name: tessera-develop-image
@@ -495,7 +497,7 @@ jobs:
           distribution: 'adopt'
           java-version: 14
           check-latest: true
-      - name: Download image artifact
+      - name: download-artifact portable Docker image
         uses: actions/download-artifact@v2
         with:
           name: tessera-develop-image
@@ -509,19 +511,18 @@ jobs:
       - name: Get version of Quorum to use
         id: quorumver
         run: |
-          tagversion=`cat version.txt | cut -d'-' -f1`
-          echo "$tagversion" > version.txt
-          VERSION=${tagversion%.*}
-          RESP_CODE=$(docker manifest inspect quorumengineering/quorum:$VERSION> /dev/null ; echo $?)
+          # 1.2.3-SNAPSHOT --> 1.2
+          QUORUM_MINOR_VERSION=$(cat version.txt | cut -d '-' -f 1 | cut -d '.' -f 1,2) 
+          RESP_CODE=$(docker manifest inspect $QUORUM_DOCKER_IMAGE:$QUORUM_MINOR_VERSION> /dev/null ; echo $?)
           if [ ! $RESP_CODE -eq 0 ]; then
-            echo "no quorum image found for $VERSION"
+            echo "no quorum image found for $QUORUM_MINOR_VERSION"
             VERSION=latest
           fi
-          echo "using version $VERSION"
-          echo ::set-output name=version::$VERSION
+          echo "using version $QUORUM_MINOR_VERSION"
+          echo ::set-output name=version::$QUORUM_MINOR_VERSION
       - name: Execute acceptance tests
         run:
-          docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_quorum_docker_image='{name="quorumengineering/quorum:${{ steps.quorumver.outputs.version }}",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
+          docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_tessera_docker_image='{name="${{ env.TESSERA_DOCKER_IMAGE }}:develop",local=true}' -e TF_VAR_quorum_docker_image='{name="${{ env.QUORUM_DOCKER_IMAGE }}:${{ steps.quorumver.outputs.version }}",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
       - name: Upload Gauge report
         uses: actions/upload-artifact@v2
         if: always()
@@ -544,7 +545,7 @@ jobs:
     needs: [build_image, atest]
     runs-on: ubuntu-latest
     steps:
-      - name: Download image artifact
+      - name: download-artifact portable Docker image
         uses: actions/download-artifact@v2
         with:
           name: tessera-develop-image
@@ -562,4 +563,4 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Push image
         run : |
-          docker push ${{ secrets.DOCKER_REPO }}:develop
+          docker push ${TESSERA_DOCKER_IMAGE}:develop

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,13 +58,6 @@ jobs:
       with:
         name: kalium-dist
         path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Build and upload binaries
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   checkdependencies:
     name: Check dependencies for any security advisories
@@ -80,13 +73,6 @@ jobs:
         check-latest: true
     - name: Execute gradle dependencyCheckAnalyze task
       run: ./gradlew dependencyCheckAnalyze -x test
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Check dependencies for any security advisories
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   test:
     name: Unit tests
@@ -102,13 +88,6 @@ jobs:
         check-latest: true
     - name: Execute gradle test
       run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc --info
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Unit tests
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   itest:
     name: Integration tests
@@ -168,13 +147,6 @@ jobs:
       with:
        name: itest-logs
        path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Integration tests
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   remote_enclave_itest:
     name: Remote enclave integration tests
@@ -234,13 +206,6 @@ jobs:
         with:
           name: remote_enclave_itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Remote enclave integration tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   cucumber_itest:
     name: Cucumber itests
@@ -300,13 +265,6 @@ jobs:
         with:
           name: cucumber_itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Cucumber itests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   vaultTests:
     name: Key vault integration tests
@@ -375,12 +333,6 @@ jobs:
         with:
           name: vault-itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Key vault integration tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   recovery_itest:
     name: Recovery integration tests
@@ -440,13 +392,6 @@ jobs:
         with:
           name: recovery-itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Recovery integration tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   build_image:
     name: Build develop Docker image
@@ -529,13 +474,6 @@ jobs:
         with:
           name: gauge-reports
           path: /tmp/acctests/gauge
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Quorum acceptance tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   push_docker_develop:
     name: Push develop image to DockerHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Tessera Release Build
 
 on:
-  repository_dispatch:
-    types: [release]
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: "(WARNING: WILL TRIGGER A SONATYPE/DOCKER RELEASE) Release version - checked against version.txt"
+        required: true
+        type: string
 
 env:
   SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -10,9 +14,44 @@ env:
   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   GPG_EXECUTABLE: ${{ secrets.GPG_EXECUTABLE }}
   GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+  TESSERA_DOCKER_IMAGE_NAME: quorumengineering/tessera
 
 jobs:
-  checkdependencies:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      full-version: ${{ steps.version.outputs.full-version }}
+      minor-version: ${{ steps.version.outputs.minor-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get release version
+        id: version
+        run: |
+          # 1.2.3-SNAPSHOT --> 1.2.3
+          FULL_VERSION=$(cat version.txt | cut -d '-' -f 1)
+          
+          # 1.2.3 --> 1.2
+          MINOR_VERSION=$(echo $FULL_VERSION | cut -d '.' -f 1,2)
+          
+          echo "full-version=${FULL_VERSION}"
+          echo "minor-version=${MINOR_VERSION}"
+          
+          echo "::set-output name=full-version::$FULL_VERSION"
+          echo "::set-output name=minor-version::$MINOR_VERSION"
+      - name: Check release version
+        env:
+          USER_VERSION: ${{ github.event.inputs.release-version }}
+          TAG_VERSION: ${{ steps.version.outputs.full-version }}
+        run: |
+          # simple sanity check to help prevent accidentally releasing the wrong branch
+          if [ $USER_VERSION = $TAG_VERSION ]
+          then
+            exit 0
+          fi
+          echo "user-provided version ($USER_VERSION) does not match version.txt ($TAG_VERSION), exiting"
+          exit 1
+  check-dependencies:
+    needs: [ check-version ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,12 +59,9 @@ jobs:
         with:
           java-version: 11
       - run: ./gradlew dependencyCheckAnalyze -x test
-  release_sonatype:
-    needs: checkdependencies
+  release-sonatype:
+    needs: [ check-dependencies, check-version ]
     runs-on: ubuntu-latest
-    outputs:
-      full-ver: ${{ steps.release.outputs.full-ver }}
-      minor-ver: ${{ steps.release.outputs.minor-ver }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -34,29 +70,33 @@ jobs:
           java-version: 11
       - name: Release
         id: release
+        env:
+          TAG_NAME: tessera-${{ needs.check-version.outputs.full-version }}
+          FULL_VERSION: ${{ needs.check-version.outputs.full-version }}
+          MINOR_VERSION: ${{ needs.check-version.outputs.minor-version }}
         run: |
+          echo "Releasing $FULL_VERSION"
+
           git config user.name "quorumbot"
           now=`date +%Y%m%d%H%M%S`
-          tagversion=`cat version.txt | cut -d'-' -f1`
-          tagname="tessera-$tagversion"
-          echo "Releasing $tagname"
-          echo "$tagversion" > version.txt
+
+          echo "Creating tag  $TAG_NAME"
+          echo "$FULL_VERSION" > version.txt
           git add version.txt
-          git commit -m "Change to release version $tagversion"
-          git tag -a $tagname -m "Release tessera $tagversion"
+          git commit -m "Change to release version $FULL_VERSION"
+          git tag -a $TAG_NAME -m "Release tessera $FULL_VERSION"
           git push --tags
 
           echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
           echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
           pubkey=`gpg --list-keys -a info@goquorum.com|head -2|tail -1|xargs`
+          
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD -Psigning.gnupg.keyName=$pubkey --info
+
           ./gradlew incrementProjectVersion --info
           git add version.txt
           git commit -m "Change version to next development version"
 
-          minor_version=${tagversion%.*}
-          echo ::set-output name=full-ver::$tagversion
-          echo ::set-output name=minor-ver::$minor_version
           echo ::set-output name=branch-name::release-$now
       - name: Create PR to update development version
         uses: peter-evans/create-pull-request@v3
@@ -89,8 +129,8 @@ jobs:
           name: hashicorp-key-vault-dists
           path: key-vault/hashicorp-key-vault/build/distributions/
 
-  release_docker:
-    needs: release_sonatype
+  release-docker:
+    needs: [check-version, release-sonatype]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
@@ -133,9 +173,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:latest
-            ${{ secrets.DOCKER_REPO }}:${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:latest
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:${{ needs.check-version.outputs.minor-version }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:${{ needs.check-version.outputs.full-version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -148,9 +188,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:azure-latest
-            ${{ secrets.DOCKER_REPO }}:azure-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:azure-${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:azure-latest
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:azure-${{ needs.check-version.outputs.minor-version }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:azure-${{ needs.check-version.outputs.full-version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -163,9 +203,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:aws-latest
-            ${{ secrets.DOCKER_REPO }}:aws-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:aws-${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:aws-latest
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:aws-${{ needs.check-version.outputs.minor-version }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:aws-${{ needs.check-version.outputs.full-version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -178,9 +218,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:hashicorp-latest
-            ${{ secrets.DOCKER_REPO }}:hashicorp-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:hashicorp-${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:hashicorp-latest
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:hashicorp-${{ needs.check-version.outputs.minor-version }}
+            ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:hashicorp-${{ needs.check-version.outputs.full-version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.time.Duration
 
 plugins {
-  id "org.owasp.dependencycheck" version "6.3.1"
+  id "org.owasp.dependencycheck" version "6.5.3"
   id 'jacoco'
   id 'com.diffplug.gradle.spotless' version '3.25.0'
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"


### PR DESCRIPTION
1. Fix PR builds from forks 
    * Don't use secret for image name 
    * Fork PRs don't have access to secrets so the builds for these PRs was failing when trying to create a local image for use in the atests.  The image name is publicly known so does not need to be stored as a secret.

1. Set up workflow_dispatch for releases which can be triggered from github.com
    * workflow_dispatch allows the workflow to be run from branches other than master - making future patch releases much simpler.  
    * To prevent accidental release of the wrong branch, require users to provide the version number which is checked against version.txt.

1. Upgrade dependencycheck gradle plugin

1. Cleanup unused slack notification steps  