### PR TITLE
Add wget and netcat into base repo

### DIFF
--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -13,6 +13,11 @@ RUN mkdir /install/enclave-jaxrs && tar xvf $(find . -name enclave-jaxrs-*.tar 2
 # Create executable image
 FROM adoptopenjdk/openjdk11:alpine
 
+RUN apt-get update && apt-get install -y \
+  wget \
+  netcat \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=extractor /install/enclave-jaxrs/ /tessera
 
 ENTRYPOINT ["/tessera/bin/enclave-jaxrs"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## PR Description
Wget and netcat were available in the previous base image and commonly used for upcheck
