### PR TITLE
debianslim for remaining images

### DIFF
--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /install
 RUN mkdir /install/enclave-jaxrs && tar xvf $(find . -name enclave-jaxrs-*.tar 2>/dev/null) -C /install/enclave-jaxrs --strip-components 1
 
 # Create executable image
-FROM adoptopenjdk/openjdk11:alpine
+FROM adoptopenjdk/openjdk11:debianslim
 
 RUN apt-get update && apt-get install -y \
   wget \

--- a/docker/tessera.aws.Dockerfile
+++ b/docker/tessera.aws.Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir /install/aws-key-vault && tar xvf $(find . -name aws-key-vault-*.tar 2
 RUN mkdir /install/tessera-plus-vault && cp -a /install/aws-key-vault/. /install/tessera-plus-vault/ && cp -a /install/tessera/. /install/tessera-plus-vault/
 
 # Create executable image
-FROM adoptopenjdk/openjdk11:alpine
+FROM adoptopenjdk/openjdk11:debianslim
 
 RUN apt-get update && apt-get install -y \
   wget \

--- a/docker/tessera.azure.Dockerfile
+++ b/docker/tessera.azure.Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir /install/azure-key-vault && tar xvf $(find . -name azure-key-vault-*.t
 RUN mkdir /install/tessera-plus-vault && cp -a /install/azure-key-vault/. /install/tessera-plus-vault/ && cp -a /install/tessera/. /install/tessera-plus-vault/
 
 # Create executable image
-FROM adoptopenjdk/openjdk11:alpine
+FROM adoptopenjdk/openjdk11:debianslim
 
 RUN apt-get update && apt-get install -y \
   wget \

--- a/docker/tessera.hashicorp.Dockerfile
+++ b/docker/tessera.hashicorp.Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir /install/hashicorp-key-vault && tar xvf $(find . -name hashicorp-key-v
 RUN mkdir /install/tessera-plus-vault && cp -a /install/hashicorp-key-vault/. /install/tessera-plus-vault/ && cp -a /install/tessera/. /install/tessera-plus-vault/
 
 # Create executable image
-FROM adoptopenjdk/openjdk11:alpine
+FROM adoptopenjdk/openjdk11:debianslim
 
 RUN apt-get update && apt-get install -y \
   wget \


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

For consistency, use debianslim for all docker images

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
