### PR TITLE
set SNI flags to false

### DIFF
--- a/server/server-utils/src/main/java/com/quorum/tessera/server/utils/ServerUtils.java
+++ b/server/server-utils/src/main/java/com/quorum/tessera/server/utils/ServerUtils.java
@@ -39,7 +39,13 @@ public class ServerUtils {
 
     if (serverConfig.isSsl()) {
       HttpConfiguration https = new HttpConfiguration();
-      https.addCustomizer(new SecureRequestCustomizer());
+
+      // set SNI flags to false since updating to jetty version 11.0.6 the default behaviour has
+      // changed
+      final SecureRequestCustomizer customizer = new SecureRequestCustomizer();
+      customizer.setSniRequired(false);
+      customizer.setSniHostCheck(false);
+      https.addCustomizer(customizer);
 
       SSLContext sslContext =
           ServerSSLContextFactory.create().from(uri.toString(), serverConfig.getSslConfig());


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Set SNI flags to false. Default behaviour changed in jetty upgrade so this brings back the previous behaviour

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
