### PR TITLE
Ability to alter SNI checks default values in serverConfig

### DIFF
--- a/server/server-utils/src/main/java/com/quorum/tessera/server/utils/ServerUtils.java
+++ b/server/server-utils/src/main/java/com/quorum/tessera/server/utils/ServerUtils.java
@@ -43,12 +43,12 @@ public class ServerUtils {
       final SecureRequestCustomizer customizer = new SecureRequestCustomizer();
 
       Optional.ofNullable(serverConfig.getProperties().get("sniRequired"))
-        .map(Boolean::valueOf)
-        .ifPresent(customizer::setSniRequired);
+          .map(Boolean::valueOf)
+          .ifPresent(customizer::setSniRequired);
 
       Optional.ofNullable(serverConfig.getProperties().get("sniHostCheck"))
-        .map(Boolean::valueOf)
-        .ifPresent(customizer::setSniHostCheck);
+          .map(Boolean::valueOf)
+          .ifPresent(customizer::setSniHostCheck);
 
       https.addCustomizer(customizer);
 

--- a/server/server-utils/src/main/java/com/quorum/tessera/server/utils/ServerUtils.java
+++ b/server/server-utils/src/main/java/com/quorum/tessera/server/utils/ServerUtils.java
@@ -5,6 +5,7 @@ import com.quorum.tessera.ssl.context.ServerSSLContextFactory;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.Optional;
 import javax.net.ssl.SSLContext;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -39,7 +40,17 @@ public class ServerUtils {
 
     if (serverConfig.isSsl()) {
       HttpConfiguration https = new HttpConfiguration();
-      https.addCustomizer(new SecureRequestCustomizer());
+      final SecureRequestCustomizer customizer = new SecureRequestCustomizer();
+
+      Optional.ofNullable(serverConfig.getProperties().get("sniRequired"))
+        .map(Boolean::valueOf)
+        .ifPresent(customizer::setSniRequired);
+
+      Optional.ofNullable(serverConfig.getProperties().get("sniHostCheck"))
+        .map(Boolean::valueOf)
+        .ifPresent(customizer::setSniHostCheck);
+
+      https.addCustomizer(customizer);
 
       SSLContext sslContext =
           ServerSSLContextFactory.create().from(uri.toString(), serverConfig.getSslConfig());


### PR DESCRIPTION
Make SNI flags configurable via serverConfig properties. If none specified default values will be used
