### PR TITLE
update jetty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 ext {
-  jettyVersion = "11.0.8"
+  jettyVersion = "11.0.9"
   eclipselinkVersion = "3.0.2"
   swaggerVersion = "2.1.13"
   jerseyVersion = "3.0.4"
@@ -157,8 +157,8 @@ allprojects {
 
         implementation "net.java.dev.jna:jna:5.10.0"
 
-        testImplementation "org.apache.tuweni:tuweni-rlp:2.0.0"
-        testImplementation "org.apache.tuweni:tuweni-bytes:2.0.0"
+        testImplementation "org.apache.tuweni:tuweni-rlp:2.2.0"
+        testImplementation "org.apache.tuweni:tuweni-bytes:2.2.0"
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 ext {
-  jettyVersion = "11.0.9"
+  jettyVersion = "11.0.10"
   eclipselinkVersion = "3.0.2"
   swaggerVersion = "2.1.13"
   jerseyVersion = "3.0.4"
@@ -157,8 +157,8 @@ allprojects {
 
         implementation "net.java.dev.jna:jna:5.10.0"
 
-        testImplementation "org.apache.tuweni:tuweni-rlp:2.2.0"
-        testImplementation "org.apache.tuweni:tuweni-bytes:2.2.0"
+        testImplementation "org.apache.tuweni:tuweni-rlp:2.0.0"
+        testImplementation "org.apache.tuweni:tuweni-bytes:2.0.0"
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Update jetty to 11.0.10

From [Jetty 11.0.10](https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.10) releases notes, they added this [PR 8165 ](https://github.com/eclipse/jetty.project/pull/8165)to fix [this issue](https://github.com/eclipse/jetty.project/issues/8161).
They changed how input and output buffers are released.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
