### PR TITLE
update jetty to 11.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 ext {
-  jettyVersion = "11.0.10"
+  jettyVersion = "11.0.11"
   eclipselinkVersion = "3.0.2"
   swaggerVersion = "2.1.13"
   jerseyVersion = "3.0.4"


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

The fix for “Improve SSLConnection buffers handling” (https://github.com/eclipse/jetty.project/issues/8161) is only in jetty v11.0.11. 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
