### PR TITLE
Update version of snakeyaml and jackson databind used by swagger plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ allprojects {
         testImplementation "nl.jqno.equalsverifier:equalsverifier:3.7.1"
         testImplementation "com.mockrunner:mockrunner-jdbc:2.0.4"
 
+        implementation "org.yaml:snakeyaml:1.31" // transitive dependency of jackson-databind:2.13.3
+
         implementation "commons-cli:commons-cli:1.5.0"
         implementation "commons-codec:commons-codec:1.15"
         implementation "commons-io:commons-io:2.11.0"

--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -7,6 +7,7 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/net\.consensys\.quorum\.tessera/partyinfo\-model@.*$</packageUrl>
         <cpe>cpe:/a:model_project:model</cpe>
+        <cve>CVE-2020-36460</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[

--- a/tessera-jaxrs/openapi/generate/build.gradle
+++ b/tessera-jaxrs/openapi/generate/build.gradle
@@ -2,6 +2,12 @@ plugins {
   id "io.swagger.core.v3.swagger-gradle-plugin"
 }
 
+configurations.all {
+  resolutionStrategy {
+    force 'org.yaml:snakeyaml:1.31', 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  }
+}
+
 dependencies {
   compileOnly project(":tessera-jaxrs:common-jaxrs")
   compileOnly project(":tessera-jaxrs:sync-jaxrs")

--- a/tessera-jaxrs/sync-jaxrs/build.gradle
+++ b/tessera-jaxrs/sync-jaxrs/build.gradle
@@ -50,7 +50,7 @@ jar {
 def generatedResources = "${project.buildDir}/generated-resources/openapi"
 
 resolve {
-  classpath = sourceSets.main.output
+  classpath = sourceSets.main.compileClasspath.plus(sourceSets.main.runtimeClasspath)
     outputDir = file(generatedResources)
   outputFileName = "openapi.p2p"
   outputFormat = "JSONANDYAML"

--- a/tessera-jaxrs/sync-jaxrs/build.gradle
+++ b/tessera-jaxrs/sync-jaxrs/build.gradle
@@ -3,6 +3,12 @@ plugins {
   id "java-library"
 }
 
+configurations.all {
+    resolutionStrategy {
+      force 'org.yaml:snakeyaml:1.31', 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    }
+}
+
 dependencies {
 
   implementation project(":tessera-jaxrs:common-jaxrs")
@@ -29,12 +35,6 @@ dependencies {
   api "jakarta.inject:jakarta.inject-api"
 
   compileOnly project(':tessera-jaxrs:openapi:common')
-
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion") {
-      because 'databind less than 2.13.2.2 has a bug'
-    }
-  }
 }
 
 jar {
@@ -50,8 +50,8 @@ jar {
 def generatedResources = "${project.buildDir}/generated-resources/openapi"
 
 resolve {
-  classpath = sourceSets.main.compileClasspath.plus(sourceSets.main.runtimeClasspath)
-  outputDir = file(generatedResources)
+  classpath = sourceSets.main.output
+    outputDir = file(generatedResources)
   outputFileName = "openapi.p2p"
   outputFormat = "JSONANDYAML"
   prettyPrint = "TRUE"

--- a/tessera-jaxrs/sync-jaxrs/build.gradle
+++ b/tessera-jaxrs/sync-jaxrs/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 configurations.all {
-    resolutionStrategy {
-      force 'org.yaml:snakeyaml:1.31', 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-    }
+  resolutionStrategy {
+    force 'org.yaml:snakeyaml:1.31', 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  }
 }
 
 dependencies {
@@ -51,7 +51,7 @@ def generatedResources = "${project.buildDir}/generated-resources/openapi"
 
 resolve {
   classpath = sourceSets.main.compileClasspath.plus(sourceSets.main.runtimeClasspath)
-    outputDir = file(generatedResources)
+  outputDir = file(generatedResources)
   outputFileName = "openapi.p2p"
   outputFormat = "JSONANDYAML"
   prettyPrint = "TRUE"

--- a/tessera-jaxrs/thirdparty-jaxrs/build.gradle
+++ b/tessera-jaxrs/thirdparty-jaxrs/build.gradle
@@ -3,6 +3,12 @@ plugins {
   id "java-library"
 }
 
+configurations.all {
+  resolutionStrategy {
+    force 'org.yaml:snakeyaml:1.31', 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  }
+}
+
 dependencies {
   api 'io.swagger.core.v3:swagger-annotations'
   api "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"

--- a/tessera-jaxrs/transaction-jaxrs/build.gradle
+++ b/tessera-jaxrs/transaction-jaxrs/build.gradle
@@ -3,6 +3,12 @@ plugins {
   id "java-library"
 }
 
+configurations.all {
+  resolutionStrategy {
+    force 'org.yaml:snakeyaml:1.31', 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+  }
+}
+
 dependencies {
   implementation project(":tessera-jaxrs:common-jaxrs")
   implementation project(":tessera-jaxrs:jaxrs-client")


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

* add cve info to suppression of party model
* force versions of snakeyaml and jackson databind since swagger plugin does not respect the constraint

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
