### PR TITLE
spotless gradle plugin v5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.time.Duration
 plugins {
   id "org.owasp.dependencycheck" version "7.1.0.1"
   id 'jacoco'
-  id 'com.diffplug.gradle.spotless' version '4.0.1'
+  id 'com.diffplug.spotless' version '5.17.1'
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
   id "org.javamodularity.moduleplugin" version "1.8.8"
   id 'org.ec4j.editorconfig' version '0.0.3'
@@ -181,7 +181,7 @@ nexusPublishing {
 subprojects {
 
   apply plugin: "java-library"
-  apply plugin: "com.diffplug.gradle.spotless"
+  apply plugin: "com.diffplug.spotless"
   apply plugin: "maven-publish"
   apply plugin: "jacoco"
   apply plugin: "org.owasp.dependencycheck"
@@ -280,7 +280,6 @@ subprojects {
         fileTree('.') {
           include "*.gradle"
         })
-        .from("$rootDir/build.gradle")
       greclipse().configFile(rootProject.file("gradle/formatter.properties"))
       endWithNewline()
     }

--- a/tests/acceptance-test/build.gradle
+++ b/tests/acceptance-test/build.gradle
@@ -113,11 +113,11 @@ test {
     )
 
   if(!file("/usr/local/lib").exists() ||  file("/usr/local/lib/").listFiles(new FilenameFilter() {
-    @Override
-    boolean accept(File dir, String name) {
-      return name.startsWith("libsodium");
-    }
-  }).length <= 0) {
+      @Override
+      boolean accept(File dir, String name) {
+        return name.startsWith("libsodium");
+      }
+    }).length <= 0) {
     exclude "**/RestSuiteHttpH2EncTypeKalium.class"
   }
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Version 5 of spotless gradle plugin
* name of plugin has changed 
* required a change to main build.gradle - removing this line `.from("$rootDir/build.gradle")` which doesn't seem to change behavior
* running spotlessApply resulted in minor formatting change to one build.gradle file

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
