### PR TITLE
upgrade hsqldb to 2.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ allprojects {
 
         implementation "com.h2database:h2:2.1.212"
         implementation "com.zaxxer:HikariCP:5.0.1"
-        implementation "org.hsqldb:hsqldb:2.5.1"
+        implementation "org.hsqldb:hsqldb:2.7.1"
         implementation "org.xerial:sqlite-jdbc:3.23.1"
 
         api 'org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2'

--- a/cvss-suppressions.xml
+++ b/cvss-suppressions.xml
@@ -32,12 +32,4 @@
         <packageUrl regex="true">^pkg:maven/org.yaml/snakeyaml@1.33</packageUrl>
         <cve>CVE-2022-38752</cve>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: hsqldb-2.5.1.jar
-   Until 2.7.1 is released
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.hsqldb/hsqldb@2.5.1</packageUrl>
-        <cve>CVE-2022-41853</cve>
-    </suppress>
 </suppressions>

--- a/tests/acceptance-test/src/test/java/db/HsqlDatabaseServer.java
+++ b/tests/acceptance-test/src/test/java/db/HsqlDatabaseServer.java
@@ -1,7 +1,7 @@
 package db;
 
 import java.io.IOException;
-import org.hsqldb.persist.HsqlProperties;
+import java.util.Properties;
 import org.hsqldb.server.Server;
 import org.hsqldb.server.ServerAcl;
 
@@ -18,7 +18,7 @@ public class HsqlDatabaseServer implements DatabaseServer {
   @Override
   public void start() {
 
-    HsqlProperties properties = new HsqlProperties();
+    Properties properties = new Properties();
     for (int i = 0; i < 4; i++) {
       String db = nodeId + (i + 1);
       properties.setProperty(

--- a/tests/acceptance-test/src/test/java/module-info.test
+++ b/tests/acceptance-test/src/test/java/module-info.test
@@ -41,7 +41,10 @@
     tessera.acceptance.tests=org.yaml.snakeyaml
 
 --add-reads
-    tessera.acceptance.tests=hsqldb
+    tessera.acceptance.tests=org.jnrproject.unixsocket
+
+--add-modules
+    org.hsqldb
 
 --add-reads
-    tessera.acceptance.tests=org.jnrproject.unixsocket
+    tessera.acceptance.tests=org.hsqldb


### PR DESCRIPTION
## PR Description

- Upgrade version of hsqldb to 2.7.1 to fix vulnerability CVE-2022-41853 (See https://nvd.nist.gov/vuln/detail/CVE-2022-41853)

## Fixed Issue(s)

The change was originally carried out by @macfarla in PR #1494. This PR added a fix to module-info.test file to make acceptance-tests build

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
