### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code from SCM
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
       with:
         distribution: 'adopt'
         java-version: 17
@@ -28,33 +28,33 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build -x dependencyCheckAnalyze -x javadoc -x test --info
     - name: Upload tessera dist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       if: success()
       with:
         name: tessera-dists
         path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
     - name: Upload tessera enclave dist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
         name: enclave-dists
         path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
     - name: Upload aws key vault dist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
         name: aws-key-vault-dist
         path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
     - name: Upload azure key vault dist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
         name: azure-key-vault-dist
         path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
     - name: Upload hashicorp key vault dist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
         name: hashicorp-key-vault-dist
         path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
     - name: Upload kalium encryptor dist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
         name: kalium-dist
         path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code from SCM
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
       with:
         distribution: 'adopt'
         java-version: 17
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code from SCM
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
       with:
         distribution: 'adopt'
         java-version: 17
@@ -95,40 +95,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code from SCM
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
       with:
         distribution: 'adopt'
         java-version: 17
         check-latest: true
     - name: Download tessera dist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: tessera-dists
         path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
     - name: Download tessera enclave dist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: enclave-dists
         path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
     - name: Download aws key vault dist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: aws-key-vault-dist
         path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
     - name: Download azure key vault dist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: azure-key-vault-dist
         path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
     - name: Download hashicorp key vault dist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: hashicorp-key-vault-dist
         path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
     - name: Download kalium encryptor dist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: kalium-dist
         path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
@@ -136,13 +136,13 @@ jobs:
       run: |
         ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --fail-fast -PexcludeTests="RunHashicorpIT,AwsKeyVaultIT,RecoverIT,RunAzureIT,AzureKeyVaultIT,RestSuiteHttpH2RemoteEnclaveEncTypeEC,CucumberTestSuite" --info
     - name: Upload Junit reports
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       if: always()
       with:
        name: itest-junit-report
        path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
     - name: Upload test logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       if: always()
       with:
        name: itest-logs
@@ -154,40 +154,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
         with:
           distribution: 'adopt'
           java-version: 17
           check-latest: true
       - name: Download tessera dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-dists
           path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
       - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: enclave-dists
           path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
       - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: aws-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
       - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: azure-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
       - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: hashicorp-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
       - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: kalium-dist
           path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
@@ -195,13 +195,13 @@ jobs:
         run: |
           ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC --info
       - name: Upload junit reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: remote_enclave_itest-junit-report
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: remote_enclave_itest-logs
@@ -213,40 +213,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
         with:
           distribution: 'adopt'
           java-version: 17
           check-latest: true
       - name: Download tessera dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-dists
           path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
       - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: enclave-dists
           path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
       - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: aws-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
       - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: azure-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
       - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: hashicorp-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
       - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: kalium-dist
           path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
@@ -254,13 +254,13 @@ jobs:
         run: |
           ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests CucumberTestSuite --info
       - name: Upload junit reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: cucumber_itest-junit-report
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: cucumber_itest-logs
@@ -272,39 +272,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
         with:
           distribution: 'adopt'
           java-version: 17
           check-latest: true
       - name: Download tessera dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-dists
           path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
       - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: enclave-dists
           path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
       - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: aws-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
       - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: azure-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
       - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: hashicorp-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
       - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: kalium-dist
           path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
@@ -325,13 +325,13 @@ jobs:
           export PATH=$PATH:$PWD && popd
           ./gradlew :tests:acceptance-test:test --tests RunHashicorpIT --info
       - name: Upload junit reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: failure()
         with:
           name: vault-itest-junit-report
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: failure()
         with:
           name: vault-itest-logs
@@ -343,40 +343,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
         with:
           distribution: 'adopt'
           java-version: 17
           check-latest: true
       - name: Download tessera dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-dists
           path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
       - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: enclave-dists
           path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
       - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: aws-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
       - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: azure-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
       - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: hashicorp-key-vault-dist
           path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
       - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: kalium-dist
           path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
@@ -384,13 +384,13 @@ jobs:
         run: |
           ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests RecoverIT --info
       - name: Upload junit reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: recovery_itest-junit-report
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: recovery-itest-logs
@@ -402,19 +402,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Download tessera dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-dists
           path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       - name: Get current date-time (RFC 3339 standard)
         id: date
         run: echo "::set-output name=now::$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       - name: Build Docker image as portable tar
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           tags: ${{ env.TESSERA_DOCKER_IMAGE }}:develop
           labels: |
@@ -427,7 +427,7 @@ jobs:
           context: .
           outputs: type=docker,dest=/tmp/tessera-develop-image.tar
       - name: upload-artifact portable Docker image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
           name: tessera-develop-image
           path: /tmp/tessera-develop-image.tar
@@ -438,20 +438,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
         with:
           distribution: 'adopt'
           java-version: 14
           check-latest: true
       - name: download-artifact portable Docker image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-develop-image
           path: /tmp
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       - name: Load image
         run: |
           docker load --input /tmp/tessera-develop-image.tar
@@ -460,7 +460,7 @@ jobs:
         run:
           docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_tessera_docker_image='{name="${{ env.TESSERA_DOCKER_IMAGE }}:develop",local=true}' -e TF_VAR_quorum_docker_image='{name="${{ env.QUORUM_DOCKER_IMAGE }}:latest",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
       - name: Upload Gauge report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: always()
         with:
           name: gauge-reports
@@ -475,18 +475,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: download-artifact portable Docker image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-develop-image
           path: /tmp
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       - name: Load image
         run: |
           docker load --input /tmp/tessera-develop-image.tar
           docker image ls -a
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       full-version: ${{ steps.version.outputs.full-version }}
       minor-version: ${{ steps.version.outputs.minor-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Get release version
         id: version
         run: |
@@ -54,8 +54,8 @@ jobs:
     needs: [ check-version ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1.4.4
         with:
           java-version: 17
       - run: ./gradlew dependencyCheckAnalyze -x test
@@ -63,9 +63,9 @@ jobs:
     needs: [ check-dependencies, check-version ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1.4.4
         with:
           java-version: 17
       - name: Release
@@ -99,37 +99,37 @@ jobs:
 
           echo ::set-output name=branch-name::release-$now
       - name: Create PR to update development version
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           branch: ${{ steps.release.outputs.branch-name }}
           title: Update development version
           body: Triggered by release https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - name: Upload tessera dists
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: success()
         with:
           name: tessera-dists
           path: tessera-dist/build/distributions/
       - name: Upload enclave dists
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: success()
         with:
           name: enclave-dists
           path: enclave/enclave-jaxrs/build/distributions/
       - name: Upload azure-key-vault dists
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: success()
         with:
           name: azure-key-vault-dists
           path: key-vault/azure-key-vault/build/distributions/
       - name: Upload aws-key-vault dists
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: success()
         with:
           name: aws-key-vault-dists
           path: key-vault/aws-key-vault/build/distributions/
       - name: Upload hashicorp-key-vault dists
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         if: success()
         with:
           name: hashicorp-key-vault-dists
@@ -140,39 +140,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from SCM
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Download tessera dists
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: tessera-dists
           path: tessera-dist/build/distributions/
       - name: Download enclave dists
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: enclave-dists
           path: enclave/enclave-jaxrs/build/distributions/
       - name: Download azure-key-vault dists
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         if: success()
         with:
           name: azure-key-vault-dists
           path: key-vault/azure-key-vault/build/distributions/
       - name: Download aws-key-vault dists
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         if: success()
         with:
           name: aws-key-vault-dists
           path: key-vault/aws-key-vault/build/distributions/
       - name: Download hashicorp-key-vault dists
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         if: success()
         with:
           name: hashicorp-key-vault-dists
           path: key-vault/hashicorp-key-vault/build/distributions/
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -181,7 +181,7 @@ jobs:
         run: |
           echo "::set-output name=now::$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       - name: Build and push standalone tessera images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           tags: |
             ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:latest
@@ -196,7 +196,7 @@ jobs:
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .
       - name: Build and push tessera+azure images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           tags: |
             ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:azure-latest
@@ -211,7 +211,7 @@ jobs:
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .
       - name: Build and push tessera+aws images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           tags: |
             ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:aws-latest
@@ -226,7 +226,7 @@ jobs:
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .
       - name: Build and push tessera+hashicorp images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           tags: |
             ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:hashicorp-latest
@@ -241,7 +241,7 @@ jobs:
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .
       - name: Build and push standalone enclave images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           tags: |
             ${{ env.TESSERA_DOCKER_IMAGE_NAME }}:enclave-latest

--- a/.github/workflows/update-openapi-doc.yaml
+++ b/.github/workflows/update-openapi-doc.yaml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Checkout github pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           ref: ${{ env.GHPAGES_REF }}
           path: ${{ env.GHPAGES_DIR }}
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1.4.4
         with:
           java-version: 11
       - name: Generate OpenAPI document
@@ -54,7 +54,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Deploy changes to gh-pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # 3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ env.GHPAGES_DIR }} # The branch the action should deploy to.


### PR DESCRIPTION
## Summary

Pin every `uses:` ref in `.github/workflows/` (and any composite action
files) to a full 40-character commit SHA, with the original tag
preserved as a `# vX` comment.

## Why

Tags and branches are mutable, so a compromised action can replace what
runs in our pipelines without changing the tag we reference. Pinning to
a SHA closes that supply-chain vector. See GitHub's hardening guide:
<https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>.

## Deadline

**TechOps is enforcing SHA-pinned GitHub Actions across the org by
June 8, 2026.** Merging this PR brings the repo into compliance ahead
of the cut-over; after that date workflows that still reference
mutable tags or branches will be blocked from running.

## How

Generated mechanically with [`pinact run`](https://github.com/suzuki-shunsuke/pinact).
No version bumps were applied (strict pin); follow-up upgrades can come
from Renovate or a separate `pinact run -u` PR.

## Test plan

- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that pin action references for supply-chain hardening, with no changes to build/test/release logic itself.
> 
> **Overview**
> Pins third-party GitHub Actions across `.github/workflows/gradle.yml`, `release.yml`, and `update-openapi-doc.yaml` from mutable tags (e.g., `@v1/@v2/@v3`) to full commit SHAs, keeping the prior tag as a `# vX.Y.Z` comment for traceability.
> 
> This hardens CI/build, release (Sonatype + Docker), and OpenAPI doc publishing workflows against upstream tag hijacking without altering the intended pipeline steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f1d71ed440d7efd9fc1dbf2851b0c3bf367477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->